### PR TITLE
Add Windows x86_64 release packaging script

### DIFF
--- a/scripts/package-windows-x86_64.ps1
+++ b/scripts/package-windows-x86_64.ps1
@@ -1,0 +1,92 @@
+# package-windows-x86_64.ps1 — stage and verify the Windows x86_64 release binary.
+#
+# Twin of scripts/package-linux-x86_64.sh and scripts/package-darwin-aarch64.sh,
+# written in PowerShell to match the repo's Windows-tooling convention
+# (tools/build-static-llvm.ps1 is the Windows counterpart of its .sh twin, and
+# docs/with-bootstrap-runbook.md runs Windows release work "from Developer
+# PowerShell"). Run from the x64 Developer PowerShell for VS so that dumpbin.exe
+# is on PATH for the dependency gate.
+#
+# Not yet run end-to-end: the Windows build system / stage chain are still in
+# progress, so no native release with.exe exists at out\bin\with.exe yet. Written
+# against docs/with-bootstrap-runbook.md (Failure Policy, Release Handoff).
+#
+# Windows specifics vs the Unix scripts:
+#   - Dependency gate uses `dumpbin /DEPENDENTS` (the project's documented Windows
+#     "zero dynamic deps" check) in place of ldd / otool -L.
+#   - The release asset is `with-windows-x86_64` (extensionless, matching
+#     build.w release_asset_for_host() and the Linux/Darwin assets). Windows can't
+#     execute an extensionless file, so the binary is staged as .exe to run the
+#     version gate, then renamed to the asset name.
+#   - The Unix `nm -g | clang_createIndex` positive symbol gate is not ported:
+#     link.exe/lld-link don't emit a COFF symbol table for internal statics into
+#     the final .exe, so llvm-nm can't see clang_createIndex there. The negative
+#     dependency gate below is the load-bearing static-linking check; positive
+#     proof lives in the CI build/fixpoint/test the Release Handoff mandates.
+
+$ErrorActionPreference = "Stop"
+
+$asset = "with-windows-x86_64"
+# Default assumes the normal `with build` release output; override if it differs.
+$compiler = if ($env:WITH_RELEASE_COMPILER) { $env:WITH_RELEASE_COMPILER } else { "out\bin\with.exe" }
+$releaseDir = if ($env:WITH_RELEASE_DIR) { $env:WITH_RELEASE_DIR } else { "out\release" }
+
+$version = $env:WITH_VERSION
+if (-not $version) {
+    throw "set WITH_VERSION, for example WITH_VERSION=v0.14.3"
+}
+
+$onWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+    [System.Runtime.InteropServices.OSPlatform]::Windows)
+$arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+if (-not $onWindows -or $arch -ne [System.Runtime.InteropServices.Architecture]::X64) {
+    throw "this package script creates only Windows x86_64 artifacts"
+}
+
+function Require-Tool($name) {
+    if (-not (Get-Command $name -ErrorAction SilentlyContinue)) {
+        throw "missing required tool: $name"
+    }
+}
+
+Require-Tool "dumpbin.exe"
+
+if (-not (Test-Path -PathType Leaf $compiler)) {
+    throw "missing compiler: $compiler"
+}
+
+New-Item -ItemType Directory -Force -Path $releaseDir | Out-Null
+$output = Join-Path $releaseDir $asset
+# Windows cannot execute an extensionless file, so stage as .exe to run the
+# version gate, then rename to the (extensionless) asset name below.
+$staged = "$output.exe"
+Copy-Item -Path $compiler -Destination $staged -Force
+
+$versionOutput = (& $staged version | Out-String).Trim()
+if ($versionOutput -ne "with $version") {
+    throw "release binary reported '$versionOutput', expected 'with $version'"
+}
+
+# Negative static-linking gate: the release binary must import no LLVM, Clang, or
+# toolchain support DLL. The pattern is the DLL-name equivalent of the Unix list
+# (clang/LLVM/libz/libxml2/zstd/libstdc++/libgcc_s). A correct static-CRT (/MT)
+# build imports only OS DLLs (kernel32, ntdll, advapi32, ...), none of which match.
+$dependents = & dumpbin.exe /nologo /DEPENDENTS $staged
+if ($LASTEXITCODE -ne 0) {
+    throw "dumpbin failed to read $staged"
+}
+if ($dependents | Select-String -Pattern 'clang|LLVM|zlib|libxml2|zstd|MSVCP|VCRUNTIME') {
+    $dependents | ForEach-Object { Write-Host $_ }
+    throw "release binary has forbidden dynamic compiler/support dependency"
+}
+
+# The Unix scripts copy scripts/install.sh into the release dir here. install.sh
+# selects an asset by `uname` and has no Windows arm, so shipping it unmodified
+# would fail for Windows users. A Windows installer is a separate follow-up.
+
+# Name the asset per build.w release_asset_for_host() (extensionless, like the
+# Linux/Darwin assets); the installer/seed downloader adds .exe on the target.
+Move-Item -Path $staged -Destination $output -Force
+
+$hash = (Get-FileHash -Algorithm SHA256 $output).Hash.ToLowerInvariant()
+Write-Output "$hash  $output"


### PR DESCRIPTION
Adds `scripts/package-windows-x86_64.ps1`, the Windows counterpart to `scripts/package-linux-x86_64.sh` and `scripts/package-darwin-aarch64.sh`, rounding out the platform packaging scripts as the Windows port comes together.

It mirrors the Linux script and applies the same release gates, adapted to Windows/PE:

- requires `WITH_VERSION` and guards host = Windows x86_64
- stages the compiler and verifies `with version` equals `with $WITH_VERSION`
- dependency gate: `dumpbin /DEPENDENTS` must show no clang/LLVM/zlib/libxml2/zstd/MSVCP/VCRUNTIME DLL
- emits the asset `with-windows-x86_64` (extensionless, matching `release_asset_for_host()`) and prints its SHA-256

**Why PowerShell:** it matches the repo's Windows-tooling convention. `tools/build-static-llvm.ps1` is the Windows counterpart of its `.sh` twin, and `docs/with-bootstrap-runbook.md` runs Windows release work "from Developer PowerShell." It reuses that script's idioms (`Require-Tool`, `Get-FileHash`).

**Windows specifics:**

- `dumpbin /DEPENDENTS` replaces `ldd` / `otool -L` for the dependency gate.
- The asset is extensionless like the Unix assets. Since Windows cannot execute an extensionless file, the binary is staged as `.exe` to run the version gate, then renamed.
- The Unix `nm -g | clang_createIndex` positive symbol gate is not ported. `link.exe` / `lld-link` do not write a COFF symbol table for internal statics into the final `.exe`, so the negative dependency gate is the static-linking check here. Positive proof lives in the CI build/fixpoint/test that Release Handoff mandates.

**Validation status (honest):** this has not been run end to end, because the Windows build and stage chain are still in progress and no native release `with.exe` exists yet. It is written against `docs/with-bootstrap-runbook.md` (Failure Policy, Release Handoff). Verified so far: the script parses cleanly, and the host-detection and dependency-gate logic were checked on Windows PowerShell 5.1.

**A few questions for you:**

1. Keep the asset extensionless, or add `.exe`?
2. Is `out\bin\with.exe` the right release-compiler path?
3. Windows installer (`install.ps1` plus a Windows arm in `install.sh`) here, or as a follow-up?
