### PR TITLE
Cross-compilation: --target x86_64-linux-gnu (#425 step 4) — darwin-arm64 host builds a working linux ELF compiler

### DIFF
--- a/build.w
+++ b/build.w
@@ -66,40 +66,157 @@ fn run_cross_unsupported_action(ctx: ActionCtx) -> i32:
         ctx.diagnostics().error("cross: cross-target compilation for '" ++ target ++ "' is not implemented yet")
     1
 
-// ── Cross-target (linux_x86_64) helpers ─────────────────────────────
+// ── Cross-target (linux) helpers ────────────────────────────────────
+// Two supported cross tags: "linux_x86_64" and "linux_aarch64". Each
+// gets a full runtime/bridge/embed/rsp target set under
+// out/lib/cross/<tag>/ and a group (":cross-rt" / ":cross-rt-arm").
 
-fn cross_linux_dir() -> str:
-    "out/lib/cross/linux_x86_64"
+fn cross_dir(tag: str) -> str:
+    "out/lib/cross/" ++ tag
 
-fn cross_linux_triple() -> str:
+fn cross_triple(tag: str) -> str:
+    if tag == "linux_aarch64":
+        return "aarch64-unknown-linux-gnu"
     "x86_64-unknown-linux-gnu"
 
-fn cross_linux_llvm_prefix() -> str:
-    ".deps/llvm-" ++ compiler_llvm_version() ++ "-linux-x86_64"
+fn cross_platform_source(tag: str) -> str:
+    if tag == "linux_aarch64":
+        return "rt/linux_aarch64.w"
+    "rt/linux_x86_64.w"
 
-// A runtime/bridge object compiled FOR linux_x86_64 by the freshly
-// built native compiler (dep "build"), landing in cross_linux_dir().
-fn cross_object_target_named(name: str, source: str, obj_name: str, opt: str) -> Target:
-    var target = with_object_target(name, release_compiler_bin("with"), source, cross_linux_dir() ++ "/" ++ obj_name, opt, "build")
-    target = target.arg("--target=" ++ cross_linux_triple())
+fn cross_platform_obj(tag: str) -> str:
+    if tag == "linux_aarch64":
+        return "rt_linux_aarch64.o"
+    "rt_linux_x86_64.o"
+
+fn cross_platform_symbol(tag: str) -> str:
+    if tag == "linux_aarch64":
+        return "rt_linux_aarch64_o"
+    "rt_linux_x86_64_o"
+
+fn cross_llvm_prefix(tag: str) -> str:
+    let arch_tag = if tag == "linux_aarch64": "linux-aarch64" else: "linux-x86_64"
+    ".deps/llvm-" ++ compiler_llvm_version() ++ "-" ++ arch_tag
+
+// A runtime/bridge object compiled FOR the cross tag by the freshly
+// built native compiler (dep "build"), landing in cross_dir(tag).
+fn cross_object_target_named(tag: str, name: str, source: str, obj_name: str, opt: str) -> Target:
+    var target = with_object_target(name, release_compiler_bin("with"), source, cross_dir(tag) ++ "/" ++ obj_name, opt, "build")
+    target = target.arg("--target=" ++ cross_triple(tag))
     target
 
-fn cross_object_target(name: str, source: str, opt: str) -> Target:
+fn cross_object_target(tag: str, name: str, source: str, opt: str) -> Target:
     let base = comp_path_basename(source)
     let stem = if base.ends_with(".w"): base.slice(0, base.len() - 2) else: base
-    cross_object_target_named(name, source, stem ++ ".o", opt)
+    cross_object_target_named(tag, name, source, stem ++ ".o", opt)
 
-// Generate cross/linux_x86_64/llvm_ld.rsp: the linux LLVM SDK's static
+fn cross_fiber_asm_source(tag: str) -> str:
+    if tag == "linux_aarch64":
+        return "runtime/fiber_asm_aarch64.s"
+    "runtime/fiber_asm_linux_x86_64.s"
+
+// Register the full cross runtime/bridge/embed/rsp target set for one
+// cross tag under name prefix `p`, grouped as `group_name`.
+fn add_cross_rt_targets(out0: Build, tag: str, p: str, group_name: str) -> Build:
+    var out = out0
+    let dir = cross_dir(tag)
+    let triple = cross_triple(tag)
+    out = out.add_target(cross_object_target(tag, p ++ "rt-core-object", "rt/rt_core.w", "-O2"))
+    out = out.add_target(cross_object_target_named(tag, p ++ "rt-platform-object", cross_platform_source(tag), cross_platform_obj(tag), "-O2"))
+    out = out.add_target(cross_object_target(tag, p ++ "cimport-stubs-object", "rt/cimport_stubs.w", "-O1"))
+    var cross_compat = cross_object_target_named(tag, p ++ "compat-runtime-object", "out/gen/compat_runtime.w", "compat_runtime.o", "-O1")
+    cross_compat = cross_compat.dep("compat-runtime-source")
+    out = out.add_target(cross_compat)
+    out = out.add_target(cross_object_target(tag, p ++ "panic-runtime-object", "rt/panic_runtime.w", "-O1"))
+    out = out.add_target(cross_object_target(tag, p ++ "fiber-stubs-object", "rt/fiber_stubs.w", "-O1"))
+    out = out.add_target(cross_object_target(tag, p ++ "channel-runtime-object", "rt/channel_runtime.w", "-O1"))
+    out = out.add_target(cross_object_target(tag, p ++ "fiber-runtime-object", "rt/fiber_runtime.w", "-O1"))
+    out = out.add_target(cross_object_target_named(tag, p ++ "fiber-core-object", "rt/fiber_core_darwin.w", "fiber.o", "-O1"))
+    out = out.add_target(cross_object_target_named(tag, p ++ "llvm-bridge-object", "src/compiler/LlvmBridge.w", "llvm_bridge.o", "-O1"))
+    out = out.add_target(cross_object_target_named(tag, p ++ "clang-bridge-object", "src/compiler/ClangBridge.w", "clang_bridge.o", "-O1"))
+
+    // regex: whole-module IR (like the native regex-runtime-ir path) so
+    // the migrated pcre2 modules land in one object; the IR carries the
+    // target triple and CompileLlvmIrObject compiles it as written.
+    var cross_regex_ir = with_ir_target_overflow(p ++ "regex-runtime-ir", release_compiler_bin("with"), "rt/regex_runtime.w", "out/tmp/" ++ tag ++ "_regex_runtime.ll", "build", "wrap")
+    cross_regex_ir = cross_regex_ir.arg("--target=" ++ triple)
+    out = out.add_target(cross_regex_ir)
+    var cross_regex = target_new(.CompileLlvmIrObject, p ++ "regex-runtime-object", "out/tmp/" ++ tag ++ "_regex_runtime.ll").output(dir ++ "/regex_runtime.o")
+    cross_regex = cross_regex.dep(p ++ "regex-runtime-ir")
+    out = out.add_target(cross_regex)
+
+    var cross_fiber_asm = target_new(.CompileAsmObject, p ++ "fiber-asm-object", cross_fiber_asm_source(tag)).output(dir ++ "/fiber_asm.o")
+    cross_fiber_asm = cross_fiber_asm.arg("triple=" ++ triple)
+    out = out.add_target(cross_fiber_asm)
+
+    var cross_embedded = target_new(.EmbedObjectFiles, p ++ "embedded-objects-asm", tag).output(dir ++ "/embedded_objects.s")
+    cross_embedded = cross_embedded.input(dir ++ "/cimport_stubs.o")
+    cross_embedded = cross_embedded.arg("cimport_stubs_o")
+    cross_embedded = cross_embedded.input(dir ++ "/compat_runtime.o")
+    cross_embedded = cross_embedded.arg("compat_runtime_o")
+    cross_embedded = cross_embedded.input(dir ++ "/panic_runtime.o")
+    cross_embedded = cross_embedded.arg("panic_runtime_o")
+    cross_embedded = cross_embedded.input(dir ++ "/regex_runtime.o")
+    cross_embedded = cross_embedded.arg("regex_runtime_o")
+    cross_embedded = cross_embedded.input(dir ++ "/fiber_stubs.o")
+    cross_embedded = cross_embedded.arg("fiber_stubs_o")
+    cross_embedded = cross_embedded.input(dir ++ "/channel_runtime.o")
+    cross_embedded = cross_embedded.arg("channel_runtime_o")
+    cross_embedded = cross_embedded.input(dir ++ "/fiber_runtime.o")
+    cross_embedded = cross_embedded.arg("fiber_runtime_o")
+    cross_embedded = cross_embedded.input(dir ++ "/fiber.o")
+    cross_embedded = cross_embedded.arg("fiber_o")
+    cross_embedded = cross_embedded.input(dir ++ "/fiber_asm.o")
+    cross_embedded = cross_embedded.arg("fiber_asm_o")
+    cross_embedded = cross_embedded.input(dir ++ "/rt_core.o")
+    cross_embedded = cross_embedded.arg("rt_core_o")
+    cross_embedded = cross_embedded.input(dir ++ "/" ++ cross_platform_obj(tag))
+    cross_embedded = cross_embedded.arg(cross_platform_symbol(tag))
+    cross_embedded = cross_embedded.dep(p ++ "cimport-stubs-object")
+    cross_embedded = cross_embedded.dep(p ++ "compat-runtime-object")
+    cross_embedded = cross_embedded.dep(p ++ "panic-runtime-object")
+    cross_embedded = cross_embedded.dep(p ++ "regex-runtime-object")
+    cross_embedded = cross_embedded.dep(p ++ "fiber-stubs-object")
+    cross_embedded = cross_embedded.dep(p ++ "channel-runtime-object")
+    cross_embedded = cross_embedded.dep(p ++ "fiber-runtime-object")
+    cross_embedded = cross_embedded.dep(p ++ "fiber-core-object")
+    cross_embedded = cross_embedded.dep(p ++ "fiber-asm-object")
+    cross_embedded = cross_embedded.dep(p ++ "rt-core-object")
+    cross_embedded = cross_embedded.dep(p ++ "rt-platform-object")
+    out = out.add_target(cross_embedded)
+
+    var cross_embedded_obj = target_new(.CompileAsmObject, p ++ "embedded-objects-object", dir ++ "/embedded_objects.s").output(dir ++ "/embedded_objects.o")
+    cross_embedded_obj = cross_embedded_obj.arg("triple=" ++ triple)
+    cross_embedded_obj = cross_embedded_obj.dep(p ++ "embedded-objects-asm")
+    out = out.add_target(cross_embedded_obj)
+
+    var cross_ld_rsp = target_new(.Action, p ++ "llvm-link-metadata", "").output(dir ++ "/llvm_ld.rsp")
+    cross_ld_rsp.action = run_cross_linux_llvm_link_metadata_action
+    cross_ld_rsp = cross_ld_rsp.arg(tag)
+    cross_ld_rsp = cross_ld_rsp.write_scope(dir)
+    cross_ld_rsp = cross_ld_rsp.write_scope("out/command/" ++ p ++ "llvm-link-metadata")
+    out = out.add_target(cross_ld_rsp)
+
+    var cross_rt = target_new(.Group, group_name, "")
+    cross_rt = cross_rt.dep(p ++ "embedded-objects-object")
+    cross_rt = cross_rt.dep(p ++ "llvm-bridge-object")
+    cross_rt = cross_rt.dep(p ++ "clang-bridge-object")
+    cross_rt = cross_rt.dep(p ++ "llvm-link-metadata")
+    out.add_target(cross_rt)
+
+// Generate cross/<tag>/llvm_ld.rsp: the tag's linux LLVM SDK static
 // clang+LLVM archives plus the linux system libraries, mirroring what
 // the native linux ld_rsp branch of run_generate_llvm_link_metadata_action
-// writes. Fails loudly when the linux SDK is not in .deps.
+// writes. Fails loudly when that SDK is not in .deps.
 fn run_cross_linux_llvm_link_metadata_action(ctx: ActionCtx) -> i32:
     let fs = ctx.fs()
+    let args = ctx.args()
+    let tag = if args.len() > 0: args.get(0) else: "linux_x86_64"
     let output_path = ctx.output()
-    let lib_dir = cross_linux_llvm_prefix() ++ "/lib"
+    let lib_dir = cross_llvm_prefix(tag) ++ "/lib"
     let libclang = lib_dir ++ "/libclang.a"
     if not fs.host_exists(libclang):
-        ctx.diagnostics().error("cross-llvm-link-metadata: missing " ++ libclang ++ "; extract the with-llvm-sdk-" ++ compiler_llvm_version() ++ "-linux-x86_64 release asset into .deps/")
+        ctx.diagnostics().error("cross-llvm-link-metadata: missing " ++ libclang ++ "; extract or build the " ++ cross_llvm_prefix(tag) ++ " LLVM SDK first")
         return 1
     let lib_files = fs.host_list_files(lib_dir)
     if lib_files.len() == 0:
@@ -1559,92 +1676,16 @@ pub fn build(ctx: BuildCtx) -> Build:
     runtime = runtime.dep("empty-second-opposite-runtime-blob")
     out = out.add_target(runtime)
 
-    // ── Cross-target runtime (linux_x86_64) ─────────────────────────
-    // `with build :cross-rt` builds the full linux_x86_64 runtime +
-    // compiler link inputs into out/lib/cross/linux_x86_64/ using the
-    // freshly built native compiler's --target support. The link stage
-    // resolves cross links exclusively from that directory (§18.5).
-    out = out.add_target(cross_object_target("cross-rt-core-object", "rt/rt_core.w", "-O2"))
-    out = out.add_target(cross_object_target("cross-rt-platform-object", "rt/linux_x86_64.w", "-O2"))
-    out = out.add_target(cross_object_target("cross-cimport-stubs-object", "rt/cimport_stubs.w", "-O1"))
-    var cross_compat = cross_object_target_named("cross-compat-runtime-object", "out/gen/compat_runtime.w", "compat_runtime.o", "-O1")
-    cross_compat = cross_compat.dep("compat-runtime-source")
-    out = out.add_target(cross_compat)
-    out = out.add_target(cross_object_target("cross-panic-runtime-object", "rt/panic_runtime.w", "-O1"))
-    out = out.add_target(cross_object_target("cross-fiber-stubs-object", "rt/fiber_stubs.w", "-O1"))
-    out = out.add_target(cross_object_target("cross-channel-runtime-object", "rt/channel_runtime.w", "-O1"))
-    out = out.add_target(cross_object_target("cross-fiber-runtime-object", "rt/fiber_runtime.w", "-O1"))
-    out = out.add_target(cross_object_target_named("cross-fiber-core-object", "rt/fiber_core_darwin.w", "fiber.o", "-O1"))
-    out = out.add_target(cross_object_target_named("cross-llvm-bridge-object", "src/compiler/LlvmBridge.w", "llvm_bridge.o", "-O1"))
-    out = out.add_target(cross_object_target_named("cross-clang-bridge-object", "src/compiler/ClangBridge.w", "clang_bridge.o", "-O1"))
-
-    // regex: whole-module IR (like the native regex-runtime-ir path) so
-    // the migrated pcre2 modules land in one object; the IR carries the
-    // linux triple and CompileLlvmIrObject compiles it as written.
-    var cross_regex_ir = with_ir_target_overflow("cross-regex-runtime-ir", release_compiler_bin("with"), "rt/regex_runtime.w", "out/tmp/cross_regex_runtime.ll", "build", "wrap")
-    cross_regex_ir = cross_regex_ir.arg("--target=" ++ cross_linux_triple())
-    out = out.add_target(cross_regex_ir)
-    var cross_regex = target_new(.CompileLlvmIrObject, "cross-regex-runtime-object", "out/tmp/cross_regex_runtime.ll").output(cross_linux_dir() ++ "/regex_runtime.o")
-    cross_regex = cross_regex.dep("cross-regex-runtime-ir")
-    out = out.add_target(cross_regex)
-
-    var cross_fiber_asm = target_new(.CompileAsmObject, "cross-fiber-asm-object", "runtime/fiber_asm_linux_x86_64.s").output(cross_linux_dir() ++ "/fiber_asm.o")
-    cross_fiber_asm = cross_fiber_asm.arg("triple=" ++ cross_linux_triple())
-    out = out.add_target(cross_fiber_asm)
-
-    var cross_embedded = target_new(.EmbedObjectFiles, "cross-embedded-objects-asm", "linux_x86_64").output(cross_linux_dir() ++ "/embedded_objects.s")
-    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/cimport_stubs.o")
-    cross_embedded = cross_embedded.arg("cimport_stubs_o")
-    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/compat_runtime.o")
-    cross_embedded = cross_embedded.arg("compat_runtime_o")
-    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/panic_runtime.o")
-    cross_embedded = cross_embedded.arg("panic_runtime_o")
-    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/regex_runtime.o")
-    cross_embedded = cross_embedded.arg("regex_runtime_o")
-    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/fiber_stubs.o")
-    cross_embedded = cross_embedded.arg("fiber_stubs_o")
-    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/channel_runtime.o")
-    cross_embedded = cross_embedded.arg("channel_runtime_o")
-    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/fiber_runtime.o")
-    cross_embedded = cross_embedded.arg("fiber_runtime_o")
-    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/fiber.o")
-    cross_embedded = cross_embedded.arg("fiber_o")
-    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/fiber_asm.o")
-    cross_embedded = cross_embedded.arg("fiber_asm_o")
-    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/rt_core.o")
-    cross_embedded = cross_embedded.arg("rt_core_o")
-    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/rt_linux_x86_64.o")
-    cross_embedded = cross_embedded.arg("rt_linux_x86_64_o")
-    cross_embedded = cross_embedded.dep("cross-cimport-stubs-object")
-    cross_embedded = cross_embedded.dep("cross-compat-runtime-object")
-    cross_embedded = cross_embedded.dep("cross-panic-runtime-object")
-    cross_embedded = cross_embedded.dep("cross-regex-runtime-object")
-    cross_embedded = cross_embedded.dep("cross-fiber-stubs-object")
-    cross_embedded = cross_embedded.dep("cross-channel-runtime-object")
-    cross_embedded = cross_embedded.dep("cross-fiber-runtime-object")
-    cross_embedded = cross_embedded.dep("cross-fiber-core-object")
-    cross_embedded = cross_embedded.dep("cross-fiber-asm-object")
-    cross_embedded = cross_embedded.dep("cross-rt-core-object")
-    cross_embedded = cross_embedded.dep("cross-rt-platform-object")
-    out = out.add_target(cross_embedded)
-
-    var cross_embedded_obj = target_new(.CompileAsmObject, "cross-embedded-objects-object", cross_linux_dir() ++ "/embedded_objects.s").output(cross_linux_dir() ++ "/embedded_objects.o")
-    cross_embedded_obj = cross_embedded_obj.arg("triple=" ++ cross_linux_triple())
-    cross_embedded_obj = cross_embedded_obj.dep("cross-embedded-objects-asm")
-    out = out.add_target(cross_embedded_obj)
-
-    var cross_ld_rsp = target_new(.Action, "cross-llvm-link-metadata", "").output(cross_linux_dir() ++ "/llvm_ld.rsp")
-    cross_ld_rsp.action = run_cross_linux_llvm_link_metadata_action
-    cross_ld_rsp = cross_ld_rsp.write_scope(cross_linux_dir())
-    cross_ld_rsp = cross_ld_rsp.write_scope("out/command/cross-llvm-link-metadata")
-    out = out.add_target(cross_ld_rsp)
-
-    var cross_rt = target_new(.Group, "cross-rt", "")
-    cross_rt = cross_rt.dep("cross-embedded-objects-object")
-    cross_rt = cross_rt.dep("cross-llvm-bridge-object")
-    cross_rt = cross_rt.dep("cross-clang-bridge-object")
-    cross_rt = cross_rt.dep("cross-llvm-link-metadata")
-    out = out.add_target(cross_rt)
+    // ── Cross-target runtime (linux) ────────────────────────────────
+    // `with build :cross-rt` (linux_x86_64) / `:cross-rt-arm`
+    // (linux_aarch64) build the full cross runtime + compiler link
+    // inputs into out/lib/cross/<tag>/ using the freshly built native
+    // compiler's --target support. The link stage resolves cross links
+    // exclusively from that directory (§18.5). Note: these graph
+    // actions must be driven by a --target-capable compiler
+    // (WITH=out/release/bin/with) until the seed is updated.
+    out = add_cross_rt_targets(move out, "linux_x86_64", "cross-", "cross-rt")
+    out = add_cross_rt_targets(move out, "linux_aarch64", "cross-arm-", "cross-rt-arm")
 
     // The compiler links to an UNSTAMPED intermediate whose inputs (out/gen/main.w
     // + src) are commit-independent, so it caches across commits (#650). A cheap

--- a/build.w
+++ b/build.w
@@ -395,6 +395,23 @@ fn release_uat_platform_asset_dep(t: Target) -> Target:
     t
 
 fn host_runtime_spec() -> HostRuntimeSpec:
+    if os() == "Linux" and (arch() == "armv8" or arch() == "aarch64"):
+        return HostRuntimeSpec {
+            platform_source: "rt/linux_aarch64.w",
+            compat_source: "rt/compat_runtime.w",
+            bootstrap_platform_object: "out/bootstrap-lib/rt_linux_aarch64.o",
+            platform_object: "out/lib/rt_linux_aarch64.o",
+            platform_install_object: "rt_linux_aarch64.o",
+            platform_symbol: "rt_linux_aarch64_o",
+            opposite_bootstrap_platform_blob: "out/bootstrap-lib/empty_rt_darwin_aarch64.bin",
+            opposite_platform_blob: "out/lib/empty_rt_darwin_aarch64.bin",
+            opposite_platform_symbol: "rt_darwin_aarch64_o",
+            second_opposite_bootstrap_platform_blob: "out/bootstrap-lib/empty_rt_linux_x86_64.bin",
+            second_opposite_platform_blob: "out/lib/empty_rt_linux_x86_64.bin",
+            second_opposite_platform_symbol: "rt_linux_x86_64_o",
+            fiber_core_source: "rt/fiber_core_darwin.w",
+            fiber_asm_source: "runtime/fiber_asm_linux_aarch64.s",
+        }
     if os() == "Linux" and arch() == "x86_64":
         return HostRuntimeSpec {
             platform_source: "rt/linux_x86_64.w",

--- a/build.w
+++ b/build.w
@@ -112,7 +112,7 @@ fn cross_object_target(tag: str, name: str, source: str, opt: str) -> Target:
 
 fn cross_fiber_asm_source(tag: str) -> str:
     if tag == "linux_aarch64":
-        return "runtime/fiber_asm_aarch64.s"
+        return "runtime/fiber_asm_linux_aarch64.s"
     "runtime/fiber_asm_linux_x86_64.s"
 
 // Register the full cross runtime/bridge/embed/rsp target set for one

--- a/build.w
+++ b/build.w
@@ -66,6 +66,69 @@ fn run_cross_unsupported_action(ctx: ActionCtx) -> i32:
         ctx.diagnostics().error("cross: cross-target compilation for '" ++ target ++ "' is not implemented yet")
     1
 
+// ── Cross-target (linux_x86_64) helpers ─────────────────────────────
+
+fn cross_linux_dir() -> str:
+    "out/lib/cross/linux_x86_64"
+
+fn cross_linux_triple() -> str:
+    "x86_64-unknown-linux-gnu"
+
+fn cross_linux_llvm_prefix() -> str:
+    ".deps/llvm-" ++ compiler_llvm_version() ++ "-linux-x86_64"
+
+// A runtime/bridge object compiled FOR linux_x86_64 by the freshly
+// built native compiler (dep "build"), landing in cross_linux_dir().
+fn cross_object_target_named(name: str, source: str, obj_name: str, opt: str) -> Target:
+    var target = with_object_target(name, release_compiler_bin("with"), source, cross_linux_dir() ++ "/" ++ obj_name, opt, "build")
+    target = target.arg("--target=" ++ cross_linux_triple())
+    target
+
+fn cross_object_target(name: str, source: str, opt: str) -> Target:
+    let base = comp_path_basename(source)
+    let stem = if base.ends_with(".w"): base.slice(0, base.len() - 2) else: base
+    cross_object_target_named(name, source, stem ++ ".o", opt)
+
+// Generate cross/linux_x86_64/llvm_ld.rsp: the linux LLVM SDK's static
+// clang+LLVM archives plus the linux system libraries, mirroring what
+// the native linux ld_rsp branch of run_generate_llvm_link_metadata_action
+// writes. Fails loudly when the linux SDK is not in .deps.
+fn run_cross_linux_llvm_link_metadata_action(ctx: ActionCtx) -> i32:
+    let fs = ctx.fs()
+    let output_path = ctx.output()
+    let lib_dir = cross_linux_llvm_prefix() ++ "/lib"
+    let libclang = lib_dir ++ "/libclang.a"
+    if not fs.host_exists(libclang):
+        ctx.diagnostics().error("cross-llvm-link-metadata: missing " ++ libclang ++ "; extract the with-llvm-sdk-" ++ compiler_llvm_version() ++ "-linux-x86_64 release asset into .deps/")
+        return 1
+    let lib_files = fs.host_list_files(lib_dir)
+    if lib_files.len() == 0:
+        ctx.diagnostics().error("cross-llvm-link-metadata: could not list: " ++ lib_dir)
+        return 1
+    var clang_archives: Vec[str] = Vec.new()
+    var llvm_archives: Vec[str] = Vec.new()
+    for i in 0..lib_files.len() as i32:
+        let path = lib_files.get(i as i64)
+        let name = comp_path_basename(path)
+        if name.ends_with(".a"):
+            if name.starts_with("libclang") and path != libclang:
+                clang_archives.push(path)
+            else:
+                if name.starts_with("libLLVM"):
+                    llvm_archives.push(path)
+    var ld_rsp = comp_rsp_path(libclang) ++ "\n"
+    let sorted_clang = comp_sort_strings(clang_archives)
+    for i in 0..sorted_clang.len() as i32:
+        ld_rsp = ld_rsp ++ comp_rsp_path(sorted_clang.get(i as i64)) ++ "\n"
+    let sorted_llvm = comp_sort_strings(llvm_archives)
+    for i in 0..sorted_llvm.len() as i32:
+        ld_rsp = ld_rsp ++ comp_rsp_path(sorted_llvm.get(i as i64)) ++ "\n"
+    ld_rsp = ld_rsp ++ "-Bstatic\n-lstdc++\n-lgcc\n-lgcc_eh\n-Bdynamic\n-lpthread\n-ldl\n-lm\n-lz\n-lzstd\n-lxml2\n"
+    if fs.write_text(output_path, ld_rsp) != 0:
+        ctx.diagnostics().error("cross-llvm-link-metadata: could not write: " ++ output_path)
+        return 1
+    0
+
 fn empty_file_target(name: str, output: str) -> Target:
     var target = target_new(.Action, name, "").output(output)
     target.action = run_write_empty_file_action
@@ -1495,6 +1558,93 @@ pub fn build(ctx: BuildCtx) -> Build:
     runtime = runtime.dep("empty-opposite-runtime-blob")
     runtime = runtime.dep("empty-second-opposite-runtime-blob")
     out = out.add_target(runtime)
+
+    // ── Cross-target runtime (linux_x86_64) ─────────────────────────
+    // `with build :cross-rt` builds the full linux_x86_64 runtime +
+    // compiler link inputs into out/lib/cross/linux_x86_64/ using the
+    // freshly built native compiler's --target support. The link stage
+    // resolves cross links exclusively from that directory (§18.5).
+    out = out.add_target(cross_object_target("cross-rt-core-object", "rt/rt_core.w", "-O2"))
+    out = out.add_target(cross_object_target("cross-rt-platform-object", "rt/linux_x86_64.w", "-O2"))
+    out = out.add_target(cross_object_target("cross-cimport-stubs-object", "rt/cimport_stubs.w", "-O1"))
+    var cross_compat = cross_object_target_named("cross-compat-runtime-object", "out/gen/compat_runtime.w", "compat_runtime.o", "-O1")
+    cross_compat = cross_compat.dep("compat-runtime-source")
+    out = out.add_target(cross_compat)
+    out = out.add_target(cross_object_target("cross-panic-runtime-object", "rt/panic_runtime.w", "-O1"))
+    out = out.add_target(cross_object_target("cross-fiber-stubs-object", "rt/fiber_stubs.w", "-O1"))
+    out = out.add_target(cross_object_target("cross-channel-runtime-object", "rt/channel_runtime.w", "-O1"))
+    out = out.add_target(cross_object_target("cross-fiber-runtime-object", "rt/fiber_runtime.w", "-O1"))
+    out = out.add_target(cross_object_target_named("cross-fiber-core-object", "rt/fiber_core_darwin.w", "fiber.o", "-O1"))
+    out = out.add_target(cross_object_target_named("cross-llvm-bridge-object", "src/compiler/LlvmBridge.w", "llvm_bridge.o", "-O1"))
+    out = out.add_target(cross_object_target_named("cross-clang-bridge-object", "src/compiler/ClangBridge.w", "clang_bridge.o", "-O1"))
+
+    // regex: whole-module IR (like the native regex-runtime-ir path) so
+    // the migrated pcre2 modules land in one object; the IR carries the
+    // linux triple and CompileLlvmIrObject compiles it as written.
+    var cross_regex_ir = with_ir_target_overflow("cross-regex-runtime-ir", release_compiler_bin("with"), "rt/regex_runtime.w", "out/tmp/cross_regex_runtime.ll", "build", "wrap")
+    cross_regex_ir = cross_regex_ir.arg("--target=" ++ cross_linux_triple())
+    out = out.add_target(cross_regex_ir)
+    var cross_regex = target_new(.CompileLlvmIrObject, "cross-regex-runtime-object", "out/tmp/cross_regex_runtime.ll").output(cross_linux_dir() ++ "/regex_runtime.o")
+    cross_regex = cross_regex.dep("cross-regex-runtime-ir")
+    out = out.add_target(cross_regex)
+
+    var cross_fiber_asm = target_new(.CompileAsmObject, "cross-fiber-asm-object", "runtime/fiber_asm_linux_x86_64.s").output(cross_linux_dir() ++ "/fiber_asm.o")
+    cross_fiber_asm = cross_fiber_asm.arg("triple=" ++ cross_linux_triple())
+    out = out.add_target(cross_fiber_asm)
+
+    var cross_embedded = target_new(.EmbedObjectFiles, "cross-embedded-objects-asm", "linux_x86_64").output(cross_linux_dir() ++ "/embedded_objects.s")
+    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/cimport_stubs.o")
+    cross_embedded = cross_embedded.arg("cimport_stubs_o")
+    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/compat_runtime.o")
+    cross_embedded = cross_embedded.arg("compat_runtime_o")
+    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/panic_runtime.o")
+    cross_embedded = cross_embedded.arg("panic_runtime_o")
+    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/regex_runtime.o")
+    cross_embedded = cross_embedded.arg("regex_runtime_o")
+    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/fiber_stubs.o")
+    cross_embedded = cross_embedded.arg("fiber_stubs_o")
+    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/channel_runtime.o")
+    cross_embedded = cross_embedded.arg("channel_runtime_o")
+    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/fiber_runtime.o")
+    cross_embedded = cross_embedded.arg("fiber_runtime_o")
+    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/fiber.o")
+    cross_embedded = cross_embedded.arg("fiber_o")
+    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/fiber_asm.o")
+    cross_embedded = cross_embedded.arg("fiber_asm_o")
+    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/rt_core.o")
+    cross_embedded = cross_embedded.arg("rt_core_o")
+    cross_embedded = cross_embedded.input(cross_linux_dir() ++ "/rt_linux_x86_64.o")
+    cross_embedded = cross_embedded.arg("rt_linux_x86_64_o")
+    cross_embedded = cross_embedded.dep("cross-cimport-stubs-object")
+    cross_embedded = cross_embedded.dep("cross-compat-runtime-object")
+    cross_embedded = cross_embedded.dep("cross-panic-runtime-object")
+    cross_embedded = cross_embedded.dep("cross-regex-runtime-object")
+    cross_embedded = cross_embedded.dep("cross-fiber-stubs-object")
+    cross_embedded = cross_embedded.dep("cross-channel-runtime-object")
+    cross_embedded = cross_embedded.dep("cross-fiber-runtime-object")
+    cross_embedded = cross_embedded.dep("cross-fiber-core-object")
+    cross_embedded = cross_embedded.dep("cross-fiber-asm-object")
+    cross_embedded = cross_embedded.dep("cross-rt-core-object")
+    cross_embedded = cross_embedded.dep("cross-rt-platform-object")
+    out = out.add_target(cross_embedded)
+
+    var cross_embedded_obj = target_new(.CompileAsmObject, "cross-embedded-objects-object", cross_linux_dir() ++ "/embedded_objects.s").output(cross_linux_dir() ++ "/embedded_objects.o")
+    cross_embedded_obj = cross_embedded_obj.arg("triple=" ++ cross_linux_triple())
+    cross_embedded_obj = cross_embedded_obj.dep("cross-embedded-objects-asm")
+    out = out.add_target(cross_embedded_obj)
+
+    var cross_ld_rsp = target_new(.Action, "cross-llvm-link-metadata", "").output(cross_linux_dir() ++ "/llvm_ld.rsp")
+    cross_ld_rsp.action = run_cross_linux_llvm_link_metadata_action
+    cross_ld_rsp = cross_ld_rsp.write_scope(cross_linux_dir())
+    cross_ld_rsp = cross_ld_rsp.write_scope("out/command/cross-llvm-link-metadata")
+    out = out.add_target(cross_ld_rsp)
+
+    var cross_rt = target_new(.Group, "cross-rt", "")
+    cross_rt = cross_rt.dep("cross-embedded-objects-object")
+    cross_rt = cross_rt.dep("cross-llvm-bridge-object")
+    cross_rt = cross_rt.dep("cross-clang-bridge-object")
+    cross_rt = cross_rt.dep("cross-llvm-link-metadata")
+    out = out.add_target(cross_rt)
 
     // The compiler links to an UNSTAMPED intermediate whose inputs (out/gen/main.w
     // + src) are commit-independent, so it caches across commits (#650). A cheap

--- a/build/compiler.w
+++ b/build/compiler.w
@@ -212,6 +212,8 @@ fn comp_default_llvm_prefix() -> str:
         return ".deps/llvm-" ++ COMPILER_LLVM_VERSION ++ "-darwin-arm64"
     if host_os == "Linux" and host_arch == "x86_64":
         return ".deps/llvm-" ++ COMPILER_LLVM_VERSION ++ "-linux-x86_64"
+    if host_os == "Linux" and (host_arch == "armv8" or host_arch == "aarch64"):
+        return ".deps/llvm-" ++ COMPILER_LLVM_VERSION ++ "-linux-aarch64"
     if host_os == "Windows" and host_arch == "x86_64":
         return ".deps/llvm-" ++ COMPILER_LLVM_VERSION ++ "-windows-x86_64-msvc"
     COMPILER_FALLBACK_LLVM_PREFIX
@@ -302,6 +304,22 @@ fn comp_arg_value(args: &Vec[str], prefix: str) -> str:
 
 fn comp_arg_allowed_for_compiler(arg: str) -> bool:
     not arg.starts_with("compiler=") and not arg.starts_with("overflow=")
+
+// Wall-clock budget for one compiler build/ir step. The 10-minute
+// default fits native hosts; emulated hosts (e.g. an x86_64 bootstrap
+// under qemu-user) override via WITH_BUILD_STEP_TIMEOUT_MS.
+fn comp_step_timeout_ms() -> i32:
+    let raw = env("WITH_BUILD_STEP_TIMEOUT_MS")
+    var parsed = 0
+    for i in 0..raw.len() as i32:
+        let ch = raw.byte_at(i as i64)
+        if ch < 48 or ch > 57:
+            parsed = 0
+            break
+        parsed = parsed * 10 + (ch - 48)
+    if parsed > 0:
+        return parsed
+    600000
 
 fn comp_host_exe_suffix() -> str:
     if os() == "Windows":
@@ -1647,7 +1665,7 @@ pub fn run_with_compiler_build_action(ctx: ActionCtx) -> i32:
             return seed_rc
     let stdout_path = comp_join(capture_dir, "stdout.txt")
     let stderr_path = comp_join(capture_dir, "stderr.txt")
-    let rc = comp_run_compiler_capture(ctx, "build", argv, stdout_path, stderr_path, 600000)
+    let rc = comp_run_compiler_capture(ctx, "build", argv, stdout_path, stderr_path, comp_step_timeout_ms())
     if rc != 0:
         let _cleanup_tmp_bin = comp_remove_file_if_exists(fs, tmp_output)
         let _cleanup_tmp_obj = comp_remove_file_if_exists(fs, tmp_output ++ ".o")
@@ -1698,7 +1716,7 @@ pub fn run_with_compiler_ir_action(ctx: ActionCtx) -> i32:
     let _remove_tmp = comp_remove_file_if_exists(fs, tmp_output)
     let _remove_stderr = comp_remove_file_if_exists(fs, stderr_path)
     let argv = comp_compile_args(ctx, "ir", compiler_path, source_path)
-    let rc = comp_run_compiler_capture(ctx, "ir", argv, tmp_output, stderr_path, 600000)
+    let rc = comp_run_compiler_capture(ctx, "ir", argv, tmp_output, stderr_path, comp_step_timeout_ms())
     if rc != 0:
         return rc
     if not fs.exists(tmp_output):

--- a/build/compiler.w
+++ b/build/compiler.w
@@ -69,7 +69,7 @@ fn comp_dirname(path: str) -> str:
         return "/"
     path.slice(0, last_slash as i64)
 
-fn comp_path_basename(path: str) -> str:
+pub fn comp_path_basename(path: str) -> str:
     var last_slash: i64 = -1
     for i in 0..path.len() as i32:
         let ch = path.byte_at(i as i64)
@@ -79,7 +79,7 @@ fn comp_path_basename(path: str) -> str:
         return path.slice(last_slash + 1, path.len())
     path
 
-fn comp_rsp_path(path: str) -> str:
+pub fn comp_rsp_path(path: str) -> str:
     let normalized = comp_replace_all(path, "\\", "/")
     if comp_index_of(normalized, " ") >= 0:
         return "\"" ++ normalized ++ "\""
@@ -1805,7 +1805,7 @@ fn comp_str_compare(a: str, b: str) -> i32:
         return -1
     1
 
-fn comp_sort_strings(items: Vec[str]) -> Vec[str]:
+pub fn comp_sort_strings(items: Vec[str]) -> Vec[str]:
     var sorted: Vec[str] = Vec.new()
     for i in 0..items.len() as i32:
         let item = items.get(i as i64)

--- a/rt/linux_aarch64.w
+++ b/rt/linux_aarch64.w
@@ -1,0 +1,1169 @@
+// rt/linux_aarch64.w -- Linux aarch64 runtime backend.
+//
+// Implements the rt_* platform boundary through stable libc/POSIX ABI symbols.
+// Error convention: negative return = negated errno.
+
+extern fn write(fd: i32, buf: *const u8, len: u64) -> i64
+extern fn read(fd: i32, buf: *mut u8, len: u64) -> i64
+extern fn open(path: *const u8, flags: i32, mode: i32) -> i32
+extern fn close(fd: i32) -> i32
+extern fn lseek(fd: i32, offset: i64, whence: i32) -> i64
+extern fn getcwd(buf: *mut u8, size: u64) -> *mut u8
+extern fn mmap(addr: *mut u8, len: u64, prot: i32, flags: i32, fd: i32, offset: i64) -> *mut u8
+extern fn munmap(addr: *mut u8, len: u64) -> i32
+extern fn getenv(name: *const u8) -> *const u8
+extern fn stat(path: *const u8, buf: *mut u8) -> i32
+extern fn chmod(path: *const u8, mode: i32) -> i32
+extern fn _exit(code: i32) -> Unit
+extern fn __errno_location() -> *mut i32
+extern fn getrandom(buf: *mut u8, len: u64, flags: u32) -> i64
+extern fn sysconf(name: i32) -> i64
+extern fn sigaltstack(ss: *const u8, old_ss: *mut u8) -> i32
+extern fn sigaction(sig: i32, act: *const u8, old_act: *mut u8) -> i32
+extern var stdin: *mut u8
+extern var stdout: *mut u8
+extern var stderr: *mut u8
+
+fn get_errno() -> i32:
+    let p = __errno_location()
+    unsafe *p
+
+pub fn __error() -> *mut i32:
+    __errno_location()
+
+type RtStatBuf:
+    size: i64
+    is_dir: i32
+    is_file: i32
+    modified_ns: i64
+
+var rt_argc: i32 = 0
+var rt_argv_raw: i64 = 0
+
+pub fn rt_store_args(argc_val: i32, argv_val: *const *const u8) -> Unit:
+    rt_argc = argc_val
+    rt_argv_raw = argv_val as i64
+
+fn rt_random_fail():
+    let msg = "fatal: could not read OS randomness\n" as *const u8
+    let _ = write(2, msg, 36)
+    _exit(1)
+
+pub fn rt_fill_random(buf: *mut u8, len: u64) -> Unit:
+    var off: u64 = 0
+    while off < len:
+        let p = (buf as i64 + off as i64) as *mut u8
+        let n = getrandom(p, len - off, 0 as u32)
+        if n > 0:
+            off = off + n as u64
+        else:
+            if get_errno() == 4:
+                continue
+            break
+    if off < len:
+        let fd = open("/dev/urandom" as *const u8, 0, 0)
+        if fd < 0:
+            rt_random_fail()
+        while off < len:
+            let p = (buf as i64 + off as i64) as *mut u8
+            let n = rt_read(fd, p, len - off)
+            if n <= 0:
+                let _close = rt_close(fd)
+                rt_random_fail()
+            off = off + n as u64
+        let _close = rt_close(fd)
+
+pub fn rt_libc_stdin() -> *mut u8:
+    stdin
+
+pub fn rt_libc_stdout() -> *mut u8:
+    stdout
+
+pub fn rt_libc_stderr() -> *mut u8:
+    stderr
+
+pub fn rt_fiber_page_size() -> i64:
+    let page_size = sysconf(30)
+    if page_size > 0:
+        return page_size
+    4096
+
+pub fn rt_fiber_mmap_flags() -> i32:
+    // Linux: MAP_PRIVATE | MAP_ANONYMOUS.
+    0x22
+
+pub fn rt_fiber_fault_addr(info: *const u8) -> i64:
+    if info as i64 == 0:
+        return 0
+    unsafe:
+        *((info as i64 + 16) as *const i64)
+
+fn linux_store_i64(base: i64, offset: i64, value: i64):
+    unsafe:
+        *((base + offset) as *mut i64) = value
+
+fn linux_store_i32(base: i64, offset: i64, value: i32):
+    unsafe:
+        *((base + offset) as *mut i32) = value
+
+fn linux_zero_sigaction(sig: i32):
+    var sa: [152]u8 = [0 as u8; 152]
+    let sa_base = (&raw mut sa) as *mut [152]u8 as i64
+    let _ = sigaction(sig, sa_base as *const u8, 0 as *mut u8)
+
+pub fn rt_fiber_reset_signal_handler(sig: i32) -> Unit:
+    linux_zero_sigaction(sig)
+
+pub fn rt_fiber_install_signal_handlers(alt_stack: *mut u8, alt_stack_size: i64, handler: i64) -> Unit:
+    var ss: [24]u8 = [0 as u8; 24]
+    let ss_base = (&raw mut ss) as *mut [24]u8 as i64
+    linux_store_i64(ss_base, 0, alt_stack as i64)
+    linux_store_i32(ss_base, 8, 0)
+    linux_store_i64(ss_base, 16, alt_stack_size)
+    let _ = sigaltstack(ss_base as *const u8, 0 as *mut u8)
+
+    var sa: [152]u8 = [0 as u8; 152]
+    let sa_base = (&raw mut sa) as *mut [152]u8 as i64
+    linux_store_i64(sa_base, 0, handler)
+    linux_store_i32(sa_base, 136, 134217728 | 4)
+    let _ = sigaction(11, sa_base as *const u8, 0 as *mut u8)
+    let _ = sigaction(7, sa_base as *const u8, 0 as *mut u8)
+
+pub fn __open(path: *const u8, flags: i32, mode: i32) -> i32:
+    var native = flags & 3
+    if (flags & 0x0008) != 0: native = native | 0x400
+    if (flags & 0x0200) != 0: native = native | 0x40
+    if (flags & 0x0400) != 0: native = native | 0x200
+    if (flags & 0x0800) != 0: native = native | 0x80
+    var r: i32 = 0
+    loop:
+        r = open(path, native, mode)
+        if r >= 0 or get_errno() != 4:
+            break
+    r
+
+pub fn rt_write(fd: i32, buf: *const u8, len: i64) -> i64:
+    var r: i64 = 0
+    loop:
+        r = write(fd, buf, len as u64)
+        if r >= 0 or get_errno() != 4:
+            break
+    if r < 0:
+        return -(get_errno() as i64)
+    r
+
+pub fn rt_read(fd: i32, buf: *mut u8, len: i64) -> i64:
+    var r: i64 = 0
+    loop:
+        r = read(fd, buf, len as u64)
+        if r >= 0 or get_errno() != 4:
+            break
+    if r < 0:
+        return -(get_errno() as i64)
+    r
+
+pub fn rt_open(path: *const u8, flags: i32, mode: i32) -> i32:
+    // Canonical: O_RDONLY=0, O_WRONLY=1, O_RDWR=2, O_CREAT=0x200,
+    // O_TRUNC=0x400, O_APPEND=0x800.
+    // Linux: O_CREAT=0x40, O_EXCL=0x80, O_TRUNC=0x200, O_APPEND=0x400.
+    var native = flags & 3
+    if (flags & 0x200) != 0: native = native | 0x40
+    if (flags & 0x400) != 0: native = native | 0x200
+    if (flags & 0x800) != 0: native = native | 0x400
+    var r: i32 = 0
+    loop:
+        r = open(path, native, mode)
+        if r >= 0 or get_errno() != 4:
+            break
+    if r < 0:
+        return -get_errno()
+    r
+
+pub fn rt_close(fd: i32) -> i32:
+    var r: i32 = 0
+    loop:
+        r = close(fd)
+        if r >= 0 or get_errno() != 4:
+            break
+    if r < 0:
+        return -get_errno()
+    0
+
+pub fn rt_seek(fd: i32, offset: i64, whence: i32) -> i64:
+    let r = lseek(fd, offset, whence)
+    if r < 0:
+        return -(get_errno() as i64)
+    r
+
+let S_IFMT: i32 = 61440
+let S_IFDIR: i32 = 16384
+let S_IFREG: i32 = 32768
+let LINUX_STAT_SIZE: i64 = 144
+// aarch64 glibc struct stat puts st_mode at 16 (u32, with st_nlink at
+// 20) — unlike x86_64's st_nlink@16/st_mode@24. The size and mtime
+// offsets coincide on both.
+let LINUX_STAT_MODE_OFFSET: i64 = 16
+let LINUX_STAT_SIZE_OFFSET: i64 = 48
+let LINUX_STAT_MTIME_SEC_OFFSET: i64 = 88
+let LINUX_STAT_MTIME_NSEC_OFFSET: i64 = 96
+
+pub fn rt_stat(path: *const u8, out: *mut RtStatBuf) -> i32:
+    var native_buf: [144]u8 = [0 as u8; 144]
+    let r = stat(path, &native_buf as *mut [144]u8 as *mut u8)
+    if r < 0:
+        return -get_errno()
+    let base = &native_buf as i64
+    let size = unsafe *((base + LINUX_STAT_SIZE_OFFSET) as *const i64)
+    let mode = unsafe *((base + LINUX_STAT_MODE_OFFSET) as *const i32)
+    let mtime_sec = unsafe *((base + LINUX_STAT_MTIME_SEC_OFFSET) as *const i64)
+    let mtime_nsec = unsafe *((base + LINUX_STAT_MTIME_NSEC_OFFSET) as *const i64)
+    (unsafe *out).size = size
+    (unsafe *out).is_dir = if (mode & S_IFMT) == S_IFDIR: 1 else: 0
+    (unsafe *out).is_file = if (mode & S_IFMT) == S_IFREG: 1 else: 0
+    (unsafe *out).modified_ns = mtime_sec * 1000000000 + mtime_nsec
+    0
+
+pub fn rt_chmod(path: *const u8, mode: i32) -> i32:
+    let r = chmod(path, mode)
+    if r < 0:
+        return -get_errno()
+    0
+
+pub fn rt_getcwd(buf: *mut u8, size: i64) -> i32:
+    let r = getcwd(buf, size as u64)
+    if r as i64 == 0:
+        return -get_errno()
+    0
+
+pub fn rt_mmap(size: i64) -> *mut u8:
+    let p = mmap(0 as *mut u8, size as u64, 3, 0x22, -1, 0)
+    if p as i64 == -1:
+        return 0 as *mut u8
+    p
+
+pub fn rt_munmap(ptr: *mut u8, size: i64) -> Unit:
+    let _ = munmap(ptr, size as u64)
+
+pub fn rt_exit(code: i32) -> Unit:
+    _exit(code)
+
+pub fn rt_args() -> (*const *const u8, i32):
+    (rt_argv_raw as *const *const u8, rt_argc)
+
+type Timespec:
+    tv_sec: i64
+    tv_nsec: i64
+
+extern fn clock_gettime(clk_id: i32, tp: *mut Timespec) -> i32
+extern fn nanosleep(req: *const Timespec, rem: *mut Timespec) -> i32
+
+pub fn rt_clock_ns() -> i64:
+    var ts = Timespec { tv_sec: 0, tv_nsec: 0 }
+    if clock_gettime(1, &raw mut ts) != 0:
+        return 0
+    ts.tv_sec * 1000000000 + ts.tv_nsec
+
+pub fn rt_wall_clock_sec() -> i64:
+    // CLOCK_REALTIME
+    var ts = Timespec { tv_sec: 0, tv_nsec: 0 }
+    if clock_gettime(0, &raw mut ts) != 0:
+        return 0
+    ts.tv_sec
+
+pub fn rt_nanosleep(ns: i64) -> i32:
+    var req = Timespec { tv_sec: ns / 1000000000, tv_nsec: ns % 1000000000 }
+    var rem = Timespec { tv_sec: 0, tv_nsec: 0 }
+    var r: i32 = 0
+    loop:
+        r = nanosleep(&req, &raw mut rem)
+        if r >= 0 or get_errno() != 4:
+            break
+        req = rem
+    if r < 0:
+        return -get_errno()
+    0
+
+extern fn getpid() -> i32
+extern fn raise(sig: i32) -> i32
+extern fn kill(pid: i32, sig: i32) -> i32
+extern fn pthread_create(thread: *mut i64, attr: *const u8, start_routine: *mut u8, arg: *mut u8) -> i32
+extern fn pthread_join(thread: i64, retval: *mut *mut u8) -> i32
+
+pub fn rt_getpid() -> i32:
+    getpid()
+
+pub fn rt_kill(pid: i32, sig: i32) -> i32:
+    let r = kill(pid, sig)
+    if r < 0:
+        return -get_errno()
+    0
+
+pub fn rt_raise(sig: i32) -> i32:
+    let r = raise(sig)
+    if r < 0:
+        return -get_errno()
+    0
+
+pub fn rt_thread_spawn(start_routine: *mut u8, arg: *mut u8) -> i64:
+    var handle: i64 = 0
+    let rc = pthread_create(&raw mut handle, 0 as *const u8, start_routine, arg)
+    if rc != 0:
+        return -(rc as i64)
+    handle
+
+pub fn rt_thread_join(handle: i64) -> i32:
+    var retval: *mut u8 = 0 as *mut u8
+    let rc = pthread_join(handle, &raw mut retval)
+    if rc != 0:
+        return -rc
+    0
+
+extern fn mkdir(path: *const u8, mode: i32) -> i32
+extern fn unlink(path: *const u8) -> i32
+extern fn rmdir(path: *const u8) -> i32
+extern fn rename(old_path: *const u8, new_path: *const u8) -> i32
+extern fn symlink(target: *const u8, link_path: *const u8) -> i32
+extern fn access(path: *const u8, mode: i32) -> i32
+extern fn lstat(path: *const u8, st: *mut u8) -> i32
+extern fn readlink(path: *const u8, buf: *mut u8, bufsize: u64) -> i64
+extern fn opendir(path: *const u8) -> *mut u8
+extern fn readdir(dirp: *mut u8) -> *mut u8
+extern fn closedir(dirp: *mut u8) -> i32
+extern fn with_str_from_cstr(s: *const u8) -> str
+extern fn with_str_concat(a: str, b: str) -> str
+
+let LINUX_DIRENT_NAME_OFFSET: i64 = 19
+let RT_PATH_MAX: i64 = 4096
+
+fn rt_cstr_len(s: *const u8) -> i64:
+    if s as i64 == 0:
+        return 0
+    var len: i64 = 0
+    while unsafe *((s as i64 + len) as *const u8) != 0:
+        len = len + 1
+    len
+
+fn rt_dirent_name(ent: *mut u8) -> *const u8:
+    (ent as i64 + LINUX_DIRENT_NAME_OFFSET) as *const u8
+
+fn rt_dirent_is_dot_or_dotdot(name: *const u8) -> bool:
+    let first = unsafe *name
+    if first != 46:
+        return false
+    let second = unsafe *((name as i64 + 1) as *const u8)
+    if second == 0:
+        return true
+    if second != 46:
+        return false
+    (unsafe *((name as i64 + 2) as *const u8)) == 0
+
+fn rt_path_join(parent: *const u8, name: *const u8, out: *mut u8, cap: i64) -> i32:
+    let parent_len = rt_cstr_len(parent)
+    let name_len = rt_cstr_len(name)
+    var need_slash = true
+    if parent_len > 0 and unsafe *((parent as i64 + parent_len - 1) as *const u8) == 47:
+        need_slash = false
+    let slash_len: i64 = if need_slash: 1 else: 0
+    if parent_len + slash_len + name_len + 1 > cap:
+        return -36
+    var i: i64 = 0
+    while i < parent_len:
+        unsafe *((out as i64 + i) as *mut u8) = unsafe *((parent as i64 + i) as *const u8)
+        i = i + 1
+    if need_slash:
+        unsafe *((out as i64 + i) as *mut u8) = 47
+        i = i + 1
+    var j: i64 = 0
+    while j < name_len:
+        unsafe *((out as i64 + i + j) as *mut u8) = unsafe *((name as i64 + j) as *const u8)
+        j = j + 1
+    unsafe *((out as i64 + i + j) as *mut u8) = 0
+    0
+
+fn rt_lstat_mode(path: *const u8, mode_out: *mut i32) -> i32:
+    var st: [144]u8 = [0 as u8; 144]
+    let r = lstat(path, &st as *mut [144]u8 as *mut u8)
+    if r < 0:
+        return -get_errno()
+    unsafe *mode_out = unsafe *((&st as i64 + LINUX_STAT_MODE_OFFSET) as *const i32)
+    0
+
+fn rt_lstat_is_dir(path: *const u8) -> bool:
+    var mode: i32 = 0
+    if rt_lstat_mode(path, &mode as *mut i32) != 0:
+        return false
+    (mode & S_IFMT) == S_IFDIR
+
+pub fn rt_file_mode(path: *const u8) -> i32:
+    var mode: i32 = 0
+    let rc = rt_lstat_mode(path, &mode as *mut i32)
+    if rc != 0:
+        return rc
+    mode
+
+pub fn rt_mkdir(path: *const u8, mode: i32) -> i32:
+    var r: i32 = 0
+    loop:
+        r = mkdir(path, mode)
+        if r >= 0 or get_errno() != 4:
+            break
+    if r < 0:
+        return -get_errno()
+    0
+
+pub fn rt_unlink(path: *const u8) -> i32:
+    let r = unlink(path)
+    if r < 0:
+        return -get_errno()
+    0
+
+pub fn rt_rmdir(path: *const u8) -> i32:
+    let r = rmdir(path)
+    if r < 0:
+        return -get_errno()
+    0
+
+pub fn rt_rename(old_path: *const u8, new_path: *const u8) -> i32:
+    let r = rename(old_path, new_path)
+    if r < 0:
+        return -get_errno()
+    0
+
+pub fn rt_remove_tree(path: *const u8) -> i32:
+    var mode: i32 = 0
+    let stat_rc = rt_lstat_mode(path, &mode as *mut i32)
+    if stat_rc != 0:
+        return stat_rc
+    if (mode & S_IFMT) != S_IFDIR:
+        return rt_unlink(path)
+
+    let dir = opendir(path)
+    if dir as i64 == 0:
+        return -get_errno()
+    while true:
+        let ent = readdir(dir)
+        if ent as i64 == 0:
+            break
+        let name = rt_dirent_name(ent)
+        if rt_dirent_is_dot_or_dotdot(name):
+            continue
+        var child: [4096]u8 = [0 as u8; 4096]
+        let join_rc = rt_path_join(path, name, &child as *mut [4096]u8 as *mut u8, RT_PATH_MAX)
+        if join_rc != 0:
+            let _close_on_join = closedir(dir)
+            return join_rc
+        let child_rc = rt_remove_tree(&child as *const [4096]u8 as *const u8)
+        if child_rc != 0:
+            let _close_on_child = closedir(dir)
+            return child_rc
+    let close_rc = closedir(dir)
+    if close_rc < 0:
+        return -get_errno()
+    rt_rmdir(path)
+
+fn rt_copy_file(src: *const u8, dst: *const u8, mode: i32) -> i32:
+    let in_fd = rt_open(src, 0, 0)
+    if in_fd < 0:
+        return in_fd
+    let out_fd = rt_open(dst, 1 | 0x200 | 0x400, mode & 0o777)
+    if out_fd < 0:
+        let _close_in_on_open = rt_close(in_fd)
+        return out_fd
+    let buf = with_alloc(65536)
+    if buf as i64 == 0:
+        let _close_in_on_alloc = rt_close(in_fd)
+        let _close_out_on_alloc = rt_close(out_fd)
+        return -12
+    while true:
+        let read_count = rt_read(in_fd, buf, 65536)
+        if read_count < 0:
+            with_free(buf)
+            let _close_in_on_read = rt_close(in_fd)
+            let _close_out_on_read = rt_close(out_fd)
+            return read_count as i32
+        if read_count == 0:
+            break
+        var written: i64 = 0
+        while written < read_count:
+            let write_count = rt_write(out_fd, (buf as i64 + written) as *const u8, read_count - written)
+            if write_count < 0:
+                with_free(buf)
+                let _close_in_on_write = rt_close(in_fd)
+                let _close_out_on_write = rt_close(out_fd)
+                return write_count as i32
+            if write_count == 0:
+                with_free(buf)
+                let _close_in_on_zero = rt_close(in_fd)
+                let _close_out_on_zero = rt_close(out_fd)
+                return -5
+            written = written + write_count
+    with_free(buf)
+    let close_in = rt_close(in_fd)
+    let close_out = rt_close(out_fd)
+    if close_in != 0:
+        return close_in
+    if close_out != 0:
+        return close_out
+    rt_chmod(dst, mode & 0o777)
+
+pub fn rt_copy_tree(src: *const u8, dst: *const u8) -> i32:
+    var mode: i32 = 0
+    let stat_rc = rt_lstat_mode(src, &mode as *mut i32)
+    if stat_rc != 0:
+        return stat_rc
+    if (mode & S_IFMT) != S_IFDIR:
+        return rt_copy_file(src, dst, mode)
+
+    let mkdir_rc = rt_mkdir(dst, mode & 0o777)
+    if mkdir_rc != 0 and not rt_lstat_is_dir(dst):
+        return mkdir_rc
+
+    let dir = opendir(src)
+    if dir as i64 == 0:
+        return -get_errno()
+    while true:
+        let ent = readdir(dir)
+        if ent as i64 == 0:
+            break
+        let name = rt_dirent_name(ent)
+        if rt_dirent_is_dot_or_dotdot(name):
+            continue
+        var child_src: [4096]u8 = [0 as u8; 4096]
+        let src_join_rc = rt_path_join(src, name, &child_src as *mut [4096]u8 as *mut u8, RT_PATH_MAX)
+        if src_join_rc != 0:
+            let _close_on_src_join = closedir(dir)
+            return src_join_rc
+        var child_dst: [4096]u8 = [0 as u8; 4096]
+        let dst_join_rc = rt_path_join(dst, name, &child_dst as *mut [4096]u8 as *mut u8, RT_PATH_MAX)
+        if dst_join_rc != 0:
+            let _close_on_dst_join = closedir(dir)
+            return dst_join_rc
+        let child_rc = rt_copy_tree(&child_src as *const [4096]u8 as *const u8, &child_dst as *const [4096]u8 as *const u8)
+        if child_rc != 0:
+            let _close_on_child = closedir(dir)
+            return child_rc
+    let close_rc = closedir(dir)
+    if close_rc < 0:
+        return -get_errno()
+    rt_chmod(dst, mode & 0o777)
+
+pub fn rt_symlink(target: *const u8, link_path: *const u8) -> i32:
+    let r = symlink(target, link_path)
+    if r < 0:
+        return -get_errno()
+    0
+
+pub fn rt_readlink(path: *const u8) -> str:
+    var buf: [4096]u8 = [0 as u8; 4096]
+    let n = readlink(path, &buf as *mut [4096]u8 as *mut u8, 4095 as u64)
+    if n < 0:
+        return rt_empty_str()
+    unsafe *((&buf as i64 + n) as *mut u8) = 0
+    with_str_from_cstr(&buf as *const [4096]u8 as *const u8)
+
+fn rt_empty_str() -> str:
+    var empty: [1]u8 = [0 as u8; 1]
+    with_str_from_cstr(&empty as *const [1]u8 as *const u8)
+
+fn rt_newline_str() -> str:
+    var newline: [2]u8 = [10 as u8, 0 as u8]
+    with_str_from_cstr(&newline as *const [2]u8 as *const u8)
+
+fn rt_list_files_append_line(out: str, path: *const u8) -> str:
+    with_str_concat(with_str_concat(out, with_str_from_cstr(path)), rt_newline_str())
+
+fn rt_list_files_walk(path: *const u8, out: str) -> str:
+    var mode: i32 = 0
+    let stat_rc = rt_lstat_mode(path, &mode as *mut i32)
+    if stat_rc != 0:
+        return out
+    if (mode & S_IFMT) != S_IFDIR:
+        return rt_list_files_append_line(out, path)
+
+    let dir = opendir(path)
+    if dir as i64 == 0:
+        return out
+    var result = out
+    while true:
+        let ent = readdir(dir)
+        if ent as i64 == 0:
+            break
+        let name = rt_dirent_name(ent)
+        if rt_dirent_is_dot_or_dotdot(name):
+            continue
+        var child: [4096]u8 = [0 as u8; 4096]
+        let join_rc = rt_path_join(path, name, &child as *mut [4096]u8 as *mut u8, RT_PATH_MAX)
+        if join_rc != 0:
+            continue
+        result = rt_list_files_walk(&child as *const [4096]u8 as *const u8, result)
+    let _close = closedir(dir)
+    result
+
+pub fn rt_list_files(path: *const u8) -> str:
+    rt_list_files_walk(path, rt_empty_str())
+
+pub fn rt_access(path: *const u8, mode: i32) -> i32:
+    let r = access(path, mode)
+    if r < 0:
+        return -get_errno()
+    0
+
+extern fn socket(domain: i32, ty: i32, protocol: i32) -> i32
+extern fn connect(fd: i32, addr: *const u8, addrlen: u32) -> i32
+extern fn bind(fd: i32, addr: *const u8, addrlen: u32) -> i32
+extern fn listen(fd: i32, backlog: i32) -> i32
+extern fn accept(fd: i32, addr: *mut u8, addrlen: *mut u32) -> i32
+extern fn setsockopt(fd: i32, level: i32, optname: i32, optval: *const u8, optlen: u32) -> i32
+extern fn getsockname(fd: i32, addr: *mut u8, addrlen: *mut u32) -> i32
+extern fn send(fd: i32, buf: *const u8, len: u64, flags: i32) -> i64
+extern fn recv(fd: i32, buf: *mut u8, len: u64, flags: i32) -> i64
+extern fn getaddrinfo(node: *const u8, service: *const u8, hints: *const LinuxAddrInfo, res: *mut *mut LinuxAddrInfo) -> i32
+extern fn freeaddrinfo(res: *mut LinuxAddrInfo) -> Unit
+extern fn with_str_from_bytes(s: *const u8, len: i64) -> str
+extern fn with_free(ptr: *mut u8) -> Unit
+
+type LinuxAddrInfo:
+    ai_flags: i32
+    ai_family: i32
+    ai_socktype: i32
+    ai_protocol: i32
+    ai_addrlen: u32
+    ai_addr: *mut u8
+    ai_canonname: *mut u8
+    ai_next: *mut LinuxAddrInfo
+
+fn rt_str_data(s: str) -> *const u8:
+    let p = &s as *const *const u8
+    unsafe *p
+
+fn rt_net_copy_str_to_c_buf(s: str, out: *mut u8, cap: i64) -> i32:
+    if s.len() + 1 > cap:
+        return -1
+    var i: i64 = 0
+    while i < s.len():
+        unsafe *((out as i64 + i) as *mut u8) = s.byte_at(i) as u8
+        i = i + 1
+    unsafe *((out as i64 + i) as *mut u8) = 0
+    0
+
+fn rt_net_write_port_to_c_buf(port: i32, out: *mut u8, cap: i64) -> i32:
+    if port < 0 or port > 65535 or cap < 2:
+        return -1
+    var rev: [6]u8 = [0 as u8; 6]
+    var n = port
+    var len: i64 = 0
+    if n == 0:
+        rev[0] = 48 as u8
+        len = 1
+    else:
+        while n > 0:
+            rev[len] = (48 + (n % 10)) as u8
+            len = len + 1
+            n = n / 10
+    if len + 1 > cap:
+        return -1
+    var i: i64 = 0
+    while i < len:
+        unsafe *((out as i64 + i) as *mut u8) = rev[len - i - 1]
+        i = i + 1
+    unsafe *((out as i64 + len) as *mut u8) = 0
+    0
+
+fn rt_net_empty_str() -> str:
+    with_str_from_bytes("" as *const u8, 0)
+
+fn rt_net_connect_any(host: str, port: i32, socktype: i32, protocol: i32) -> i32:
+    var host_buf: [256]u8 = [0 as u8; 256]
+    var port_buf: [16]u8 = [0 as u8; 16]
+    if rt_net_copy_str_to_c_buf(host, &raw mut host_buf as *mut [256]u8 as *mut u8, 256) != 0:
+        return -1
+    if rt_net_write_port_to_c_buf(port, &raw mut port_buf as *mut [16]u8 as *mut u8, 16) != 0:
+        return -1
+    var hints = LinuxAddrInfo {
+        ai_flags: 0,
+        ai_family: 0,
+        ai_socktype: socktype,
+        ai_protocol: protocol,
+        ai_addrlen: 0 as u32,
+        ai_addr: 0 as *mut u8,
+        ai_canonname: 0 as *mut u8,
+        ai_next: 0 as *mut LinuxAddrInfo,
+    }
+    var res: *mut LinuxAddrInfo = 0 as *mut LinuxAddrInfo
+    let gai = getaddrinfo(&host_buf as *const [256]u8 as *const u8, &port_buf as *const [16]u8 as *const u8, &hints as *const LinuxAddrInfo, &raw mut res as *mut *mut LinuxAddrInfo)
+    if gai != 0 or res as i64 == 0:
+        return -1
+    var p = res
+    while p as i64 != 0:
+        let fd = socket((unsafe *p).ai_family, (unsafe *p).ai_socktype, (unsafe *p).ai_protocol)
+        if fd >= 0:
+            let rc = connect(fd, (unsafe *p).ai_addr as *const u8, (unsafe *p).ai_addrlen)
+            if rc == 0:
+                freeaddrinfo(res)
+                return fd
+            let _close_failed = rt_close(fd)
+        p = (unsafe *p).ai_next
+    freeaddrinfo(res)
+    -1
+
+pub fn with_net_tcp_connect(host: str, port: i32) -> i32:
+    rt_net_connect_any(host, port, 1, 6)
+
+pub fn with_net_udp_connect(host: str, port: i32) -> i32:
+    rt_net_connect_any(host, port, 2, 17)
+
+fn rt_net_bind_inaddr_any(fd: i32, port: i32) -> i32:
+    // Linux sockaddr_in: sin_family (u16 LE), sin_port (BE), sin_addr, pad.
+    var sa: [16]u8 = [0 as u8; 16]
+    sa[0] = 2 as u8
+    sa[2] = ((port >> 8) & 255) as u8
+    sa[3] = (port & 255) as u8
+    bind(fd, &sa as *const [16]u8 as *const u8, 16 as u32)
+
+pub fn with_net_tcp_listen(port: i32, backlog: i32) -> i32:
+    if port < 0 or port > 65535:
+        return -22
+    let fd = socket(2, 1, 6)
+    if fd < 0:
+        return -get_errno()
+    var one: i32 = 1
+    // SOL_SOCKET / SO_REUSEADDR (Linux values)
+    let _ = setsockopt(fd, 1, 2, &one as *const i32 as *const u8, 4 as u32)
+    if rt_net_bind_inaddr_any(fd, port) < 0:
+        let bind_err = get_errno()
+        let _ = rt_close(fd)
+        return -bind_err
+    if listen(fd, backlog) < 0:
+        let listen_err = get_errno()
+        let _ = rt_close(fd)
+        return -listen_err
+    fd
+
+pub fn with_net_tcp_accept(sock: i32) -> i32:
+    loop:
+        let fd = accept(sock, 0 as *mut u8, 0 as *mut u32)
+        if fd >= 0:
+            return fd
+        if get_errno() != 4:
+            return -get_errno()
+
+pub fn with_net_udp_bind(port: i32) -> i32:
+    if port < 0 or port > 65535:
+        return -22
+    let fd = socket(2, 2, 17)
+    if fd < 0:
+        return -get_errno()
+    if rt_net_bind_inaddr_any(fd, port) < 0:
+        let bind_err = get_errno()
+        let _ = rt_close(fd)
+        return -bind_err
+    fd
+
+pub fn with_net_sock_port(sock: i32) -> i32:
+    var sa: [16]u8 = [0 as u8; 16]
+    var sl: u32 = 16 as u32
+    if getsockname(sock, &raw mut sa as *mut [16]u8 as *mut u8, &raw mut sl) < 0:
+        return -get_errno()
+    ((sa[2] as i32) << 8) | (sa[3] as i32)
+
+pub fn with_net_send(sock: i32, data: str) -> i64:
+    let ptr = rt_str_data(data)
+    let len = data.len()
+    var written: i64 = 0
+    while written < len:
+        var r: i64 = 0
+        loop:
+            r = send(sock, (ptr as i64 + written) as *const u8, (len - written) as u64, 0)
+            if r >= 0 or get_errno() != 4:
+                break
+        if r < 0:
+            return if written > 0: written else: -(get_errno() as i64)
+        if r == 0:
+            return written
+        written = written + r
+    written
+
+pub fn with_net_recv(sock: i32, max_len: i64) -> str:
+    if max_len <= 0:
+        return rt_net_empty_str()
+    let buf = with_alloc(max_len)
+    if buf as i64 == 0:
+        return rt_net_empty_str()
+    var r: i64 = 0
+    loop:
+        r = recv(sock, buf, max_len as u64, 0)
+        if r >= 0 or get_errno() != 4:
+            break
+    if r <= 0:
+        with_free(buf)
+        return rt_net_empty_str()
+    let out = with_str_from_bytes(buf as *const u8, r)
+    with_free(buf)
+    out
+
+pub fn with_net_close(sock: i32) -> i32:
+    rt_close(sock)
+
+type RtSysInfo:
+    cpu_cores: i32
+    memory_total: i64
+    page_size: i64
+
+pub fn rt_sysinfo(out: *mut RtSysInfo) -> i32:
+    let page_size = sysconf(30)
+    let pages = sysconf(85)
+    let cores = sysconf(84)
+    (unsafe *out).cpu_cores = if cores > 0: cores as i32 else: 1
+    (unsafe *out).page_size = if page_size > 0: page_size else: 4096
+    (unsafe *out).memory_total = if pages > 0 and page_size > 0: pages * page_size else: 0
+    0
+
+pub fn rt_sysinfo_os() -> str:
+    with_str_from_cstr(c"Linux".ptr)
+
+pub fn rt_sysinfo_arch() -> str:
+    with_str_from_cstr(c"aarch64".ptr)
+
+pub fn rt_getenv(name: *const u8) -> *const u8:
+    getenv(name)
+
+// ---- Compiler compatibility process/env adapter ----
+
+extern fn with_alloc(size: i64) -> *mut u8
+extern fn with_free(ptr: *mut u8) -> Unit
+extern fn with_memcpy(dst: *mut u8, src: *const u8, len: i64) -> Unit
+extern fn with_memset(dst: *mut u8, val: i32, len: i64) -> Unit
+extern fn setenv(name: *const u8, value: *const u8, overwrite: i32) -> i32
+extern fn sigprocmask(how: i32, set: *const u32, old: *mut u32) -> i32
+extern fn fork() -> i32
+extern fn setpgid(pid: i32, pgid: i32) -> i32
+extern fn execv(path: *const u8, argv: *const *const u8) -> i32
+extern fn execvp(file: *const u8, argv: *const *const u8) -> i32
+extern fn waitpid(pid: i32, status: *mut i32, options: i32) -> i32
+extern fn chdir(path: *const u8) -> i32
+extern fn dup2(oldfd: i32, newfd: i32) -> i32
+extern fn getrlimit(resource: i32, lim: *mut u8) -> i32
+extern fn setrlimit(resource: i32, lim: *const u8) -> i32
+extern fn with_clock_nanos() -> i64
+extern fn with_usleep(usecs: i32) -> i32
+
+let POSIX_SIGINT: i32 = 2
+let POSIX_SIGQUIT: i32 = 3
+let POSIX_SIGTERM: i32 = 15
+let POSIX_SIGHUP: i32 = 1
+let POSIX_SIG_BLOCK: i32 = 1
+let POSIX_SIG_SETMASK: i32 = 3
+let POSIX_RLIMIT_STACK: i32 = 3
+let POSIX_RLIMIT_AS: i32 = 9
+let POSIX_RLIM_INFINITY: u64 = 9223372036854775807 as u64
+let POSIX_EINTR: i32 = 4
+let POSIX_SIGACTION_SIZE: i64 = 16
+let POSIX_RLIMIT_SIZE: i64 = 16
+let POSIX_WNOHANG: i32 = 1
+let POSIX_CAPTURE_TIMEOUT_RC: i32 = 124
+
+var posix_interrupt_flag: i32 = 0
+var posix_active_child_pgid: i32 = 0
+
+fn posix_store_i64(base: i64, offset: i64, value: i64):
+    unsafe *((base + offset) as *mut i64) = value
+
+fn posix_load_u64(base: i64, offset: i64) -> u64:
+    unsafe *((base + offset) as *const u64)
+
+fn posix_signal_bit(signo: i32) -> u32:
+    if signo <= 0:
+        return 0 as u32
+    (1 as u32) << ((signo - 1) as u32)
+
+fn posix_str_to_c_buf(s: str) -> *mut u8:
+    let out = with_alloc(s.len() + 1)
+    if out as i64 == 0:
+        return 0 as *mut u8
+    if s.len() > 0:
+        let sp = &s as *const *const u8
+        with_memcpy(out, unsafe *sp, s.len())
+    unsafe *((out as i64 + s.len()) as *mut u8) = 0
+    out
+
+fn posix_restore_default_signal_handler(signo: i32):
+    var sa: [16]u8 = [0 as u8; 16]
+    let sa_base = (&raw mut sa) as *mut [16]u8 as i64
+    with_memset(sa_base as *mut u8, 0, POSIX_SIGACTION_SIZE)
+    let _ = sigaction(signo, sa_base as *const u8, 0 as *mut u8)
+
+fn posix_block_interrupt_signals(prev_mask: *mut u32) -> i32:
+    var blocked: u32 = 0 as u32
+    blocked = blocked | posix_signal_bit(POSIX_SIGINT)
+    blocked = blocked | posix_signal_bit(POSIX_SIGTERM)
+    blocked = blocked | posix_signal_bit(POSIX_SIGHUP)
+    sigprocmask(POSIX_SIG_BLOCK, &blocked as *const u32, prev_mask)
+
+fn posix_restore_signal_mask(prev_mask: *const u32):
+    if prev_mask as i64 != 0:
+        let _ = sigprocmask(POSIX_SIG_SETMASK, prev_mask, 0 as *mut u32)
+
+fn posix_wait_child(pid: i32, timeout_ms: i32) -> i32:
+    var status: i32 = -1
+    let start_ns = with_clock_nanos()
+    let timeout_ns = timeout_ms as i64 * 1000000
+    while true:
+        let waited = if timeout_ms > 0: waitpid(pid, &raw mut status, POSIX_WNOHANG) else: waitpid(pid, &raw mut status, 0)
+        if waited == pid:
+            let termsig = status & 0x7f
+            if termsig == 0:
+                return (status >> 8) & 0xff
+            if termsig != 0x7f:
+                return 128 + termsig
+            return status
+        if waited < 0:
+            if get_errno() == POSIX_EINTR:
+                continue
+            return -1
+        if timeout_ms > 0 and with_clock_nanos() - start_ns >= timeout_ns:
+            let _term = kill(-pid, POSIX_SIGTERM)
+            let _sleep = with_usleep(10000)
+            let waited_after_term = waitpid(pid, &raw mut status, POSIX_WNOHANG)
+            if waited_after_term != pid:
+                let _kill = kill(-pid, 9)
+                let _wait = waitpid(pid, &raw mut status, 0)
+            return POSIX_CAPTURE_TIMEOUT_RC
+        if timeout_ms > 0:
+            let _sleep_poll = with_usleep(10000)
+
+fn posix_argv_blob_count(blob: *const u8, len: i64) -> i32:
+    if len <= 0:
+        return 0
+    var count = 0
+    var offset: i64 = 0
+    while offset < len:
+        count += 1
+        while offset < len and (unsafe *((blob as i64 + offset) as *const u8)) != 0:
+            offset += 1
+        offset += 1
+    count
+
+fn posix_fill_argv(blob: *const u8, len: i64, argv: *mut *const u8) -> i32:
+    var argi = 0
+    var offset: i64 = 0
+    while offset < len and argi < 255:
+        unsafe *((argv as i64 + argi as i64 * 8) as *mut *const u8) = (blob as i64 + offset) as *const u8
+        argi += 1
+        while offset < len and (unsafe *((blob as i64 + offset) as *const u8)) != 0:
+            offset += 1
+        offset += 1
+    unsafe *((argv as i64 + argi as i64 * 8) as *mut *const u8) = 0 as *const u8
+    argi
+
+fn posix_redirect_fd_to_path(path: *const u8, fd: i32) -> i32:
+    let out_fd = rt_open(path, 1 | 0x200 | 0x400, 0o644)
+    if out_fd < 0:
+        return -1
+    if dup2(out_fd, fd) < 0:
+        let _ = rt_close(out_fd)
+        return -1
+    let _ = rt_close(out_fd)
+    0
+
+fn posix_redirect_fd_from_path(path: *const u8, fd: i32) -> i32:
+    let in_fd = rt_open(path, 0, 0)
+    if in_fd < 0:
+        return -1
+    if dup2(in_fd, fd) < 0:
+        let _ = rt_close(in_fd)
+        return -1
+    let _ = rt_close(in_fd)
+    0
+
+fn posix_child_common(mask_rc: i32, prev_mask: *const u32):
+    if mask_rc == 0:
+        posix_restore_signal_mask(prev_mask)
+    let _ = setpgid(0, 0)
+    posix_restore_default_signal_handler(POSIX_SIGINT)
+    posix_restore_default_signal_handler(POSIX_SIGTERM)
+    posix_restore_default_signal_handler(POSIX_SIGHUP)
+    posix_restore_default_signal_handler(POSIX_SIGQUIT)
+
+fn posix_run_argv(blob: *const u8, len: i64, stdout_path: *const u8, stderr_path: *const u8, stdin_path: *const u8, cwd: *const u8, timeout_ms: i32, wait: bool) -> i32:
+    let argc = posix_argv_blob_count(blob, len)
+    if argc <= 0 or argc >= 256:
+        return -1
+    var prev_mask: u32 = 0 as u32
+    let mask_rc = posix_block_interrupt_signals(&raw mut prev_mask)
+    let pid = fork()
+    if pid == 0:
+        posix_child_common(mask_rc, &prev_mask as *const u32)
+        if stdin_path as i64 != 0 and posix_redirect_fd_from_path(stdin_path, 0) != 0:
+            _exit(127)
+        if stdout_path as i64 != 0 and posix_redirect_fd_to_path(stdout_path, 1) != 0:
+            _exit(127)
+        if stderr_path as i64 != 0 and posix_redirect_fd_to_path(stderr_path, 2) != 0:
+            _exit(127)
+        if cwd as i64 != 0:
+            if chdir(cwd) != 0:
+                _exit(127)
+            let _ = setenv(c"PWD".ptr, cwd, 1)
+        var argv: [256]*const u8 = [0 as *const u8; 256]
+        let _argc2 = posix_fill_argv(blob, len, (&raw mut argv) as *mut [256]*const u8 as *mut *const u8)
+        let _ = execvp(argv[0], (&argv) as *const [256]*const u8 as *const *const u8)
+        _exit(127)
+    if pid < 0:
+        if mask_rc == 0:
+            posix_restore_signal_mask(&prev_mask as *const u32)
+        return -1
+    let _ = setpgid(pid, pid)
+    if mask_rc == 0:
+        posix_restore_signal_mask(&prev_mask as *const u32)
+    if not wait:
+        return pid
+    posix_active_child_pgid = pid
+    let rc = posix_wait_child(pid, timeout_ms)
+    posix_active_child_pgid = 0
+    rc
+
+fn posix_interrupt_signal_handler(signo: i32):
+    posix_interrupt_flag = 1
+    if posix_active_child_pgid > 0:
+        let _ = kill(-posix_active_child_pgid, signo)
+    _exit(128 + signo)
+
+fn posix_interrupted() -> bool:
+    posix_interrupt_flag != 0
+
+pub fn rt_compat_setenv_str(name: str, value: str) -> i32:
+    let name_buf = posix_str_to_c_buf(name)
+    if name_buf as i64 == 0:
+        return -1
+    let value_buf = posix_str_to_c_buf(value)
+    if value_buf as i64 == 0:
+        with_free(name_buf)
+        return -1
+    let rc = setenv(name_buf as *const u8, value_buf as *const u8, 1)
+    with_free(name_buf)
+    with_free(value_buf)
+    rc
+
+pub fn rt_compat_install_interrupt_handlers() -> Unit:
+    var sa: [16]u8 = [0 as u8; 16]
+    let sa_base = (&raw mut sa) as *mut [16]u8 as i64
+    with_memset(sa_base as *mut u8, 0, POSIX_SIGACTION_SIZE)
+    posix_store_i64(sa_base, 0, posix_interrupt_signal_handler as i64)
+    let _ = sigaction(POSIX_SIGINT, sa_base as *const u8, 0 as *mut u8)
+    let _ = sigaction(POSIX_SIGTERM, sa_base as *const u8, 0 as *mut u8)
+    let _ = sigaction(POSIX_SIGHUP, sa_base as *const u8, 0 as *mut u8)
+
+pub fn rt_compat_raise_stack_limit() -> Unit:
+    var lim: [16]u8 = [0 as u8; 16]
+    let lim_base = (&raw mut lim) as *mut [16]u8 as i64
+    if getrlimit(POSIX_RLIMIT_STACK, lim_base as *mut u8) != 0:
+        return
+    var want: u64 = (8 * 1024 * 1024) as u64
+    let lim_max = posix_load_u64(lim_base, 8)
+    if lim_max != POSIX_RLIM_INFINITY and want > lim_max:
+        want = lim_max
+    let lim_cur = posix_load_u64(lim_base, 0)
+    if want > lim_cur:
+        posix_store_i64(lim_base, 0, want as i64)
+        let _ = setrlimit(POSIX_RLIMIT_STACK, lim_base as *const u8)
+
+pub fn rt_set_process_memory_limit_bytes(limit: i64) -> i32:
+    if limit <= 0:
+        return 0
+    var lim: [16]u8 = [0 as u8; 16]
+    let lim_base = (&raw mut lim) as *mut [16]u8 as i64
+    if getrlimit(POSIX_RLIMIT_AS, lim_base as *mut u8) != 0:
+        return -1
+    var want = limit as u64
+    let lim_max = posix_load_u64(lim_base, 8)
+    if lim_max != POSIX_RLIM_INFINITY and want > lim_max:
+        want = lim_max
+    let lim_cur = posix_load_u64(lim_base, 0)
+    if lim_cur != POSIX_RLIM_INFINITY and lim_cur <= want:
+        return 0
+    posix_store_i64(lim_base, 0, want as i64)
+    setrlimit(POSIX_RLIMIT_AS, lim_base as *const u8)
+
+pub fn rt_compat_interrupt_requested() -> i32:
+    posix_interrupt_flag
+
+pub fn rt_compat_exec_binary(path: str) -> i32:
+    let buf = posix_str_to_c_buf(path)
+    if buf as i64 == 0:
+        return -1
+    if posix_interrupted():
+        with_free(buf)
+        return -1
+    var argv_blob = path
+    let rc = posix_run_argv(buf as *const u8, argv_blob.len(), 0 as *const u8, 0 as *const u8, 0 as *const u8, 0 as *const u8, 0, true)
+    with_free(buf)
+    rc
+
+pub fn rt_compat_exec_argv(args: str) -> i32:
+    let buf = posix_str_to_c_buf(args)
+    if buf as i64 == 0:
+        return -1
+    let rc = if posix_interrupted(): -1 else: posix_run_argv(buf as *const u8, args.len(), 0 as *const u8, 0 as *const u8, 0 as *const u8, 0 as *const u8, 0, true)
+    with_free(buf)
+    rc
+
+pub fn rt_compat_exec_argv_cwd(args: str, cwd: str) -> i32:
+    let arg_buf = posix_str_to_c_buf(args)
+    let cwd_buf = posix_str_to_c_buf(cwd)
+    if arg_buf as i64 == 0 or cwd_buf as i64 == 0:
+        return -1
+    let rc = if posix_interrupted(): -1 else: posix_run_argv(arg_buf as *const u8, args.len(), 0 as *const u8, 0 as *const u8, 0 as *const u8, cwd_buf as *const u8, 0, true)
+    with_free(arg_buf)
+    with_free(cwd_buf)
+    rc
+
+pub fn rt_compat_exec_argv_capture(args: str, stdout_path: str, stderr_path: str, timeout_ms: i32) -> i32:
+    rt_compat_exec_argv_capture_cwd(args, stdout_path, stderr_path, timeout_ms, "")
+
+pub fn rt_compat_exec_argv_capture_input(args: str, stdout_path: str, stderr_path: str, timeout_ms: i32, stdin_path: str) -> i32:
+    let arg_buf = posix_str_to_c_buf(args)
+    let out_buf = posix_str_to_c_buf(stdout_path)
+    let err_buf = posix_str_to_c_buf(stderr_path)
+    let in_buf = posix_str_to_c_buf(stdin_path)
+    if arg_buf as i64 == 0 or out_buf as i64 == 0 or err_buf as i64 == 0 or in_buf as i64 == 0:
+        return -1
+    let rc = if posix_interrupted(): -1 else: posix_run_argv(arg_buf as *const u8, args.len(), out_buf as *const u8, err_buf as *const u8, in_buf as *const u8, 0 as *const u8, timeout_ms, true)
+    with_free(arg_buf)
+    with_free(out_buf)
+    with_free(err_buf)
+    with_free(in_buf)
+    rc
+
+pub fn rt_compat_exec_argv_capture_cwd(args: str, stdout_path: str, stderr_path: str, timeout_ms: i32, cwd: str) -> i32:
+    let arg_buf = posix_str_to_c_buf(args)
+    let out_buf = posix_str_to_c_buf(stdout_path)
+    let err_buf = posix_str_to_c_buf(stderr_path)
+    let cwd_buf = if cwd.len() > 0: posix_str_to_c_buf(cwd) else: 0 as *mut u8
+    if arg_buf as i64 == 0 or out_buf as i64 == 0 or err_buf as i64 == 0:
+        return -1
+    let rc = if posix_interrupted(): -1 else: posix_run_argv(arg_buf as *const u8, args.len(), out_buf as *const u8, err_buf as *const u8, 0 as *const u8, cwd_buf as *const u8, timeout_ms, true)
+    with_free(arg_buf)
+    with_free(out_buf)
+    with_free(err_buf)
+    if cwd_buf as i64 != 0:
+        with_free(cwd_buf)
+    rc
+
+pub fn rt_compat_exec_argv_capture_spawn(args: str, stdout_path: str, stderr_path: str) -> i32:
+    let arg_buf = posix_str_to_c_buf(args)
+    let out_buf = posix_str_to_c_buf(stdout_path)
+    let err_buf = posix_str_to_c_buf(stderr_path)
+    if arg_buf as i64 == 0 or out_buf as i64 == 0 or err_buf as i64 == 0:
+        return -1
+    let rc = if posix_interrupted(): -1 else: posix_run_argv(arg_buf as *const u8, args.len(), out_buf as *const u8, err_buf as *const u8, 0 as *const u8, 0 as *const u8, 0, false)
+    with_free(arg_buf)
+    with_free(out_buf)
+    with_free(err_buf)
+    rc
+
+pub fn rt_compat_exec_wait(pid: i32, timeout_ms: i32) -> i32:
+    if pid <= 0:
+        return -1
+    posix_active_child_pgid = pid
+    let rc = posix_wait_child(pid, timeout_ms)
+    posix_active_child_pgid = 0
+    rc

--- a/runtime/fiber_asm_linux_aarch64.s
+++ b/runtime/fiber_asm_linux_aarch64.s
@@ -1,0 +1,97 @@
+// Fiber context switch for aarch64 (Linux ELF)
+// Context layout (saved registers):
+//   [0]  x19
+//   [1]  x20
+//   [2]  x21
+//   [3]  x22
+//   [4]  x23
+//   [5]  x24
+//   [6]  x25
+//   [7]  x26
+//   [8]  x27
+//   [9]  x28
+//   [10] x29 (fp)
+//   [11] x30 (lr)
+//   [12] sp
+//   [13] d8
+//   [14] d9
+//   [15] d10
+//   [16] d11
+//   [17] d12
+//   [18] d13
+//   [19] d14
+//   [20] d15
+
+.globl _with_fiber_switch
+.globl with_fiber_switch
+.globl _with_fiber_prepare_initial_context
+.globl with_fiber_prepare_initial_context
+.p2align 2
+_with_fiber_switch:
+with_fiber_switch:
+    // x0 = pointer to current fiber context (save here)
+    // x1 = pointer to target fiber context (restore from here)
+
+    // Save callee-saved registers to current context
+    stp x19, x20, [x0, #0]
+    stp x21, x22, [x0, #16]
+    stp x23, x24, [x0, #32]
+    stp x25, x26, [x0, #48]
+    stp x27, x28, [x0, #64]
+    stp x29, x30, [x0, #80]
+    mov x2, sp
+    str x2, [x0, #96]
+
+    // Save callee-saved FP registers
+    stp d8, d9, [x0, #104]
+    stp d10, d11, [x0, #120]
+    stp d12, d13, [x0, #136]
+    stp d14, d15, [x0, #152]
+
+    // Restore callee-saved registers from target context
+    ldp x19, x20, [x1, #0]
+    ldp x21, x22, [x1, #16]
+    ldp x23, x24, [x1, #32]
+    ldp x25, x26, [x1, #48]
+    ldp x27, x28, [x1, #64]
+    ldp x29, x30, [x1, #80]
+    ldr x2, [x1, #96]
+    mov sp, x2
+
+    // Restore callee-saved FP registers
+    ldp d8, d9, [x1, #104]
+    ldp d10, d11, [x1, #120]
+    ldp d12, d13, [x1, #136]
+    ldp d14, d15, [x1, #152]
+
+    ret
+
+.p2align 2
+_with_fiber_prepare_initial_context:
+with_fiber_prepare_initial_context:
+    // x0 = context pointer
+    // x1 = usable stack base
+    // x2 = usable stack size
+    add x3, x1, x2
+    and x3, x3, #-16
+    str x3, [x0, #96]              // sp
+    str x3, [x0, #80]              // x29/fp
+    adrp x4, with_fiber_start
+    add  x4, x4, :lo12:with_fiber_start
+    str x4, [x0, #88]              // x30/lr
+    ret
+
+.globl with_fiber_start
+.p2align 2
+with_fiber_start:
+    sub sp, sp, #32
+    mov x0, sp
+    add x1, sp, #8
+    add x2, sp, #16
+    bl with_fiber_bootstrap_load
+    ldr x9, [sp]
+    ldr x0, [sp, #8]
+    ldr x1, [sp, #16]
+    blr x9
+    bl with_fiber_bootstrap_finish
+    brk #0

--- a/src/BuildGraphOps.w
+++ b/src/BuildGraphOps.w
@@ -157,7 +157,17 @@ pub fn build_graph_assemble_to_object(root: str, target: &BuildGraphTarget) -> i
     if build_graph_rt_mkdir_p(output_dir) != 0:
         build_graph_rt_eprint("error: could not create object output directory for target '" ++ target.name ++ "': " ++ output_dir)
         return 1
-    let rc = build_graph_rt_assemble_to_object(source_path, output_path)
+    // An optional `triple=<llvm-triple>` arg assembles for that target
+    // instead of the host (cross-target runtime objects).
+    var asm_triple = ""
+    if target.args.len() > 0:
+        let arg0 = target.args.get(0)
+        if arg0.starts_with("triple="):
+            asm_triple = arg0.slice(7, arg0.len())
+    let rc = if asm_triple.len() > 0:
+        build_graph_rt_assemble_to_object_for_triple(source_path, output_path, asm_triple)
+    else:
+        build_graph_rt_assemble_to_object(source_path, output_path)
     if rc != 0:
         build_graph_rt_eprint("error: compile_asm_object target '" ++ target.name ++ "' failed")
     rc
@@ -287,7 +297,12 @@ pub fn build_graph_embed_object_files(root: str, target: &BuildGraphTarget) -> i
     var has_darwin_runtime = false
     var has_linux_runtime = false
     var has_windows_runtime = false
-    if build_graph_host_target_kind() == 3 or build_graph_host_target_kind() == 4:
+    // The embed target's entry names the PLATFORM the assembly is for
+    // (e.g. "linux_x86_64" for a cross-built compiler); empty = host.
+    var macho_sections = build_graph_host_target_kind() == 3 or build_graph_host_target_kind() == 4
+    if target.entry.len() > 0:
+        macho_sections = target.entry.starts_with("darwin")
+    if macho_sections:
         asm_text = asm_text ++ ".section __TEXT,__const\n.subsections_via_symbols\n\n"
     else:
         asm_text = asm_text ++ ".section .rodata\n\n"

--- a/src/BuildGraphRuntime.w
+++ b/src/BuildGraphRuntime.w
@@ -27,6 +27,7 @@ extern fn with_clock_nanos() -> i64
 extern fn with_write(s: str) -> Unit
 extern fn with_eprint(s: str) -> Unit
 extern fn wl_assemble_to_object(source_path: str, output_path: str) -> i32
+extern fn wl_assemble_to_object_for_triple(source_path: str, output_path: str, triple: str) -> i32
 extern fn wl_compile_ir_to_object(source_path: str, output_path: str) -> i32
 
 pub fn build_graph_rt_exec_argv(args: str) -> i32:
@@ -94,6 +95,9 @@ pub fn build_graph_rt_write_file(path: str, data: str) -> i32:
 
 pub fn build_graph_rt_assemble_to_object(source_path: str, output_path: str) -> i32:
     wl_assemble_to_object(source_path, output_path)
+
+pub fn build_graph_rt_assemble_to_object_for_triple(source_path: str, output_path: str, triple: str) -> i32:
+    wl_assemble_to_object_for_triple(source_path, output_path, triple)
 
 pub fn build_graph_rt_compile_ir_to_object(source_path: str, output_path: str) -> i32:
     wl_compile_ir_to_object(source_path, output_path)

--- a/src/CImport.w
+++ b/src/CImport.w
@@ -10,6 +10,7 @@ use CiMigrate
 use std.cfg.stackify
 use compiler.ClangBridge.*
 use compiler.EmbeddedClangResource
+use TargetSpec
 
 extern fn with_parse_float(s: str) -> f64
 
@@ -576,6 +577,12 @@ fn process_c_import_with_defines(header_spec: str, defines: Vec[str]) -> str:
     c_import_untranslated_macros_clear()
     c_import_omitted_symbols_clear()
     c_import_included_files_clear()
+    // Cross builds would parse HOST headers and bake host C ABI facts
+    // into target code — silently wrong output. Fail loudly until
+    // c_import can parse against a target sysroot (§18.5).
+    if not target_spec_is_native():
+        g_cimport_last_error = "c_import is not supported with --target " ++ target_spec_name() ++ " yet: header parsing would use host headers, not the target's"
+        return ""
     g_cimport_raw_function_names = ""
     ci_record_field_caches_clear()
     g_cimport_report_untranslated_macros = ci_should_report_untranslated_macros(header_spec)

--- a/src/Codegen.w
+++ b/src/Codegen.w
@@ -17,6 +17,7 @@ use Source
 use Resolve
 use compiler.LlvmBridge.*
 use Overflow
+use TargetSpec
 use AnalysisTypes
 
 extern fn exit(code: i32) -> Unit
@@ -75,8 +76,6 @@ enum AtomicOrdering: i32:
 extern fn with_str_concat(a: str, b: str) -> str
 extern fn with_str_eq(a: str, b: str) -> i32
 extern fn with_write(s: str) -> Unit
-extern fn with_sysinfo_os() -> str
-extern fn with_sysinfo_arch() -> str
 
 // ── Codegen state ─────────────────────────────────────────────────
 
@@ -4839,18 +4838,18 @@ fn codegen_extern_uses_internal_abi(name: str, cc_name: str) -> bool:
     codegen_is_runtime_abi_symbol(name)
 
 fn codegen_c_abi_needs_byval_attr() -> bool:
-    let os = with_sysinfo_os()
-    let arch = with_sysinfo_arch()
+    let os = target_spec_os()
+    let arch = target_spec_arch()
     arch == "x86_64" and (os == "Linux" or os == "Macos")
 
 fn codegen_c_abi_darwin_arm64() -> bool:
-    let os = with_sysinfo_os()
-    let arch = with_sysinfo_arch()
+    let os = target_spec_os()
+    let arch = target_spec_arch()
     os == "Macos" and (arch == "armv8" or arch == "aarch64")
 
 fn codegen_windows_x86_64() -> bool:
-    let os = with_sysinfo_os()
-    let arch = with_sysinfo_arch()
+    let os = target_spec_os()
+    let arch = target_spec_arch()
     os == "Windows" and arch == "x86_64"
 
 impl Codegen:

--- a/src/ComptimeEval.w
+++ b/src/ComptimeEval.w
@@ -14,6 +14,7 @@ use std.crypto.sha256
 use render
 use CiMigrate
 use Overflow
+use TargetSpec
 
 extern fn with_eprint(s: str) -> Unit
 extern fn with_fs_read_file(path: str) -> str
@@ -65,8 +66,6 @@ extern fn with_str_from_byte(byte: i32) -> str
 extern fn with_str_starts_with(s: str, prefix: str) -> i32
 extern fn with_str_ends_with(s: str, suffix: str) -> i32
 extern fn with_str_replace(s: str, old: str, new_s: str) -> str
-extern fn with_sysinfo_os() -> str
-extern fn with_sysinfo_arch() -> str
 extern fn with_sysinfo_hostname() -> str
 
 const COMPTIME_RECURSION_LIMIT: i32 = 256
@@ -6723,10 +6722,13 @@ impl ComptimeEvaluator:
         if fn_name == "with_sysinfo_os" or fn_name == "with_sysinfo_arch" or fn_name == "with_sysinfo_hostname":
             if arg_values.len() as i32 != 0:
                 return self.fail(node, "sysinfo runtime call takes no arguments")
+            // os/arch reflect the --target selection so comptime platform
+            // dispatch bakes target values, never the host's (§18.5).
+            // hostname is inherently a host property and stays host.
             if fn_name == "with_sysinfo_os":
-                return comptime_control_value(comptime_value_str(with_sysinfo_os()))
+                return comptime_control_value(comptime_value_str(target_spec_os()))
             if fn_name == "with_sysinfo_arch":
-                return comptime_control_value(comptime_value_str(with_sysinfo_arch()))
+                return comptime_control_value(comptime_value_str(target_spec_arch()))
             return comptime_control_value(comptime_value_str(with_sysinfo_hostname()))
         comptime_control_error()
 

--- a/src/Parser.w
+++ b/src/Parser.w
@@ -9,15 +9,16 @@ use Span
 use Lexer
 use InternPool
 use Diagnostic
+use TargetSpec
 
 extern fn with_parse_i64(s: str) -> i64
 extern fn str_from_byte(b: i32) -> str
-extern fn with_sysinfo_arch() -> str
 
 // Canonical active target architecture for @[target("arch")] guards.
-// Until CLI-selected cross targets land (#425) this is the host arch.
+// Resolved from the driver-selected --target (§18.5); native builds
+// resolve to the host arch as before.
 fn parser_active_arch() -> str:
-    let a = with_sysinfo_arch()
+    let a = target_spec_arch()
     if a == "x86_64" or a == "amd64": "x86_64" else: "aarch64"
 pub type Parser {
     tokens: TokenList,

--- a/src/TargetSpec.w
+++ b/src/TargetSpec.w
@@ -105,4 +105,4 @@ pub fn target_spec_name() -> str:
 // binaries for today. Gate is checked by the driver; anything else
 // non-native must fail loudly (§18.5: never fall back to native).
 pub fn target_spec_cross_supported(kind: i32) -> bool:
-    kind == 1
+    kind == 1 or kind == 2

--- a/src/TargetSpec.w
+++ b/src/TargetSpec.w
@@ -1,0 +1,108 @@
+// TargetSpec — the single source of truth for the active build target.
+//
+// `--target <triple>` (§18.5) selects a target kind: the same 0-5
+// numbering `std.build.BuildTarget` and `driver_target_triple_kind`
+// use (0 native, 1 linux_x86_64, 2 linux_aarch64, 3 darwin_x86_64,
+// 4 darwin_aarch64, 5 windows_x86_64). The driver records the active
+// kind once per compile; parse-time @[target] guards, comptime
+// sysinfo, codegen C-ABI decisions, and the link stage read the
+// resolved target from here instead of querying host sysinfo.
+// Kind 0 ("native") resolves to the host, so a native build behaves
+// exactly as before this module existed.
+
+extern fn with_sysinfo_os() -> str
+extern fn with_sysinfo_arch() -> str
+
+var target_spec_active: i32 = 0
+
+pub fn target_spec_set_active(kind: i32) -> Unit:
+    target_spec_active = kind
+
+pub fn target_spec_active_kind() -> i32:
+    target_spec_active
+
+pub fn target_spec_is_native() -> bool:
+    if target_spec_active == 0:
+        return true
+    target_spec_active == target_spec_host_kind()
+
+// Host kind in the shared 0-5 numbering. Mirrors
+// build_graph_host_target_kind (BuildGraphKinds.w); kept extern-only
+// here so TargetSpec stays import-free for early pipeline stages.
+pub fn target_spec_host_kind() -> i32:
+    let os = with_sysinfo_os()
+    let arch = with_sysinfo_arch()
+    if os == "Macos":
+        if arch == "armv8" or arch == "aarch64":
+            return 4
+        if arch == "x86_64":
+            return 3
+    if os == "Linux":
+        if arch == "armv8" or arch == "aarch64":
+            return 2
+        if arch == "x86_64":
+            return 1
+    if os == "Windows":
+        if arch == "x86_64":
+            return 5
+    0
+
+// Resolved target OS in host-sysinfo spelling: "Macos"/"Linux"/"Windows".
+pub fn target_spec_os() -> str:
+    let kind = target_spec_active
+    if kind == 1 or kind == 2:
+        return "Linux"
+    if kind == 3 or kind == 4:
+        return "Macos"
+    if kind == 5:
+        return "Windows"
+    with_sysinfo_os()
+
+// Resolved target arch. Cross targets use the canonical spelling
+// ("x86_64"/"aarch64"); native returns the host sysinfo spelling
+// unchanged (e.g. "armv8") so native behavior is byte-identical to
+// the pre-TargetSpec compiler.
+pub fn target_spec_arch() -> str:
+    let kind = target_spec_active
+    if kind == 1 or kind == 3 or kind == 5:
+        return "x86_64"
+    if kind == 2 or kind == 4:
+        return "aarch64"
+    with_sysinfo_arch()
+
+// LLVM triple for the active target; "" means "use the host default"
+// (llvm_object_triple keeps its historical host behavior for that).
+pub fn target_spec_llvm_triple() -> str:
+    let kind = target_spec_active
+    if kind == 1:
+        return "x86_64-unknown-linux-gnu"
+    if kind == 2:
+        return "aarch64-unknown-linux-gnu"
+    if kind == 3:
+        return "x86_64-apple-macosx11.0.0"
+    if kind == 4:
+        return "arm64-apple-macosx11.0.0"
+    if kind == 5:
+        return "x86_64-pc-windows-msvc"
+    ""
+
+// Display name in the build_graph_target_name spelling.
+pub fn target_spec_name() -> str:
+    let kind = target_spec_active
+    if kind == 1:
+        return "linux_x86_64"
+    if kind == 2:
+        return "linux_aarch64"
+    if kind == 3:
+        return "darwin_x86_64"
+    if kind == 4:
+        return "darwin_aarch64"
+    if kind == 5:
+        return "windows_x86_64"
+    "native"
+
+// The non-native targets this compiler can actually produce code and
+// binaries for today. Gate is checked by the driver; anything else
+// non-native must fail loudly (§18.5: never fall back to native).
+pub fn target_spec_cross_supported(kind: i32) -> bool:
+    kind == 1

--- a/src/compiler/Compilation.w
+++ b/src/compiler/Compilation.w
@@ -22,9 +22,11 @@ use compiler.Zcu
 use compiler.Runtime
 use Overflow
 use Analysis
+use TargetSpec
 
 extern fn with_alloc(size: i64) -> *mut u8
 extern fn with_free(ptr: *mut u8) -> Unit
+extern fn wl_set_active_target_triple(triple: str) -> Unit
 
 fn profile_enabled() -> bool:
     runtime_getenv("WITH_PROFILE").len() > 0
@@ -362,6 +364,11 @@ impl Compilation:
         self.set_overflow_mode(options.overflow_mode)
         self.set_debug_info(options.debug_info)
         self.set_compiler_hooks_enabled(options.compiler_hooks_enabled)
+        // Install the --target selection (§18.5) before any parse or
+        // codegen: @[target] guards, comptime sysinfo, C-ABI decisions,
+        // LLVM triple, and the link stage all read the active target.
+        target_spec_set_active(options.target_kind)
+        wl_set_active_target_triple(target_spec_llvm_triple())
 
     fn apply_runtime_config(cfg: ProjectConfig) -> ProjectConfig:
         var out = cfg

--- a/src/compiler/Compilation.w
+++ b/src/compiler/Compilation.w
@@ -364,10 +364,13 @@ impl Compilation:
         self.set_overflow_mode(options.overflow_mode)
         self.set_debug_info(options.debug_info)
         self.set_compiler_hooks_enabled(options.compiler_hooks_enabled)
-        // Install the --target selection (§18.5) before any parse or
-        // codegen: @[target] guards, comptime sysinfo, C-ABI decisions,
-        // LLVM triple, and the link stage all read the active target.
-        target_spec_set_active(options.target_kind)
+        self.set_target_kind(options.target_kind)
+
+    // Install the --target selection (§18.5) before any parse or
+    // codegen: @[target] guards, comptime sysinfo, C-ABI decisions,
+    // LLVM triple, and the link stage all read the active target.
+    mut fn set_target_kind(kind: i32):
+        target_spec_set_active(kind)
         wl_set_active_target_triple(target_spec_llvm_triple())
 
     fn apply_runtime_config(cfg: ProjectConfig) -> ProjectConfig:

--- a/src/compiler/DriverOptions.w
+++ b/src/compiler/DriverOptions.w
@@ -262,14 +262,14 @@ pub fn driver_target_triple_kind(triple: str) -> i32:
         return 5
     -1
 
-type DriverTargetParseResult {
+pub type DriverTargetParseResult {
     ok: bool,
     kind: i32,
     explicit: bool,
     error_msg: str,
 }
 
-fn driver_parse_build_target(argc: i32) -> DriverTargetParseResult:
+pub fn driver_parse_build_target(argc: i32) -> DriverTargetParseResult:
     var kind = 0
     var explicit = false
     var i = 2

--- a/src/compiler/DriverOptions.w
+++ b/src/compiler/DriverOptions.w
@@ -292,7 +292,7 @@ fn driver_parse_build_target(argc: i32) -> DriverTargetParseResult:
         if seen:
             let parsed = driver_target_triple_kind(value)
             if parsed < 0:
-                return DriverTargetParseResult { false, 0, true, "unsupported target triple '" ++ value ++ "'; cross-target codegen/linking is not implemented yet" }
+                return DriverTargetParseResult { false, 0, true, "unsupported target triple '" ++ value ++ "'; see §18.5 for the accepted triples" }
             kind = parsed
             explicit = true
     DriverTargetParseResult { true, kind, explicit, "" }

--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -607,6 +607,8 @@ fn link_stage_make_llvm_link_command(llvm_ld: str, obj_path: str, bin_path: str,
     let arch = runtime_sysinfo_arch()
     if os == "Linux" and arch == "x86_64":
         return link_stage_make_linux_llvm_link_command(llvm_ld, obj_path, bin_path, extras, link_libs, link_args)
+    if os == "Linux" and (arch == "armv8" or arch == "aarch64"):
+        return link_stage_make_linux_llvm_link_command(llvm_ld, obj_path, bin_path, extras, link_libs, link_args)
     if os == "Macos" and (arch == "armv8" or arch == "aarch64"):
         return link_stage_make_darwin_llvm_link_command(llvm_ld, obj_path, bin_path, extras, link_libs, link_args)
     if os == "Windows" and arch == "x86_64":

--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -325,7 +325,7 @@ fn link_stage_make_link_command(linker: str, obj_path: str, bin_path: str, extra
 fn link_stage_file_exists(path: str) -> bool:
     runtime_file_exists(path) != 0
 
-// Sysroot prefix for Linux x86_64 link inputs. Native Linux hosts link
+// Sysroot prefix for Linux link inputs. Native Linux hosts link
 // against the real root (""); a cross host must supply a Linux sysroot
 // (crt objects, libc, libgcc) via WITH_LINUX_SYSROOT.
 fn link_stage_linux_sysroot() -> str:
@@ -334,7 +334,31 @@ fn link_stage_linux_sysroot() -> str:
         return explicit
     ""
 
+// The Linux target arch this link is for: the --target selection when
+// cross, else the host arch (native Linux links).
+fn link_stage_linux_arch() -> str:
+    if not target_spec_is_native():
+        return target_spec_arch()
+    runtime_sysinfo_arch()
+
+// Debian-style multiarch directory name for the Linux target arch.
+fn link_stage_linux_multiarch() -> str:
+    if link_stage_linux_arch() == "aarch64":
+        return "aarch64-linux-gnu"
+    "x86_64-linux-gnu"
+
+fn link_stage_linux_emulation() -> str:
+    if link_stage_linux_arch() == "aarch64":
+        return "aarch64linux"
+    "elf_x86_64"
+
 fn link_stage_linux_dynamic_linker(sysroot: str) -> str:
+    if link_stage_linux_arch() == "aarch64":
+        if link_stage_file_exists(sysroot ++ "/lib/ld-linux-aarch64.so.1"):
+            return "/lib/ld-linux-aarch64.so.1"
+        if link_stage_file_exists(sysroot ++ "/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"):
+            return "/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+        return ""
     if link_stage_file_exists(sysroot ++ "/lib64/ld-linux-x86-64.so.2"):
         return "/lib64/ld-linux-x86-64.so.2"
     if link_stage_file_exists(sysroot ++ "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"):
@@ -342,23 +366,25 @@ fn link_stage_linux_dynamic_linker(sysroot: str) -> str:
     ""
 
 fn link_stage_linux_crt_object(sysroot: str, name: str) -> str:
-    let usr = sysroot ++ "/usr/lib/x86_64-linux-gnu/" ++ name
+    let multiarch = link_stage_linux_multiarch()
+    let usr = sysroot ++ "/usr/lib/" ++ multiarch ++ "/" ++ name
     if link_stage_file_exists(usr):
         return usr
-    let lib = sysroot ++ "/lib/x86_64-linux-gnu/" ++ name
+    let lib = sysroot ++ "/lib/" ++ multiarch ++ "/" ++ name
     if link_stage_file_exists(lib):
         return lib
     ""
 
 fn link_stage_linux_gcc_dir(sysroot: str) -> str:
+    let base = sysroot ++ "/usr/lib/gcc/" ++ link_stage_linux_multiarch() ++ "/"
     let candidates: Vec[str] = Vec.new()
-    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/15")
-    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/14")
-    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/13")
-    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/12")
-    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/11")
-    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/10")
-    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/9")
+    candidates.push(base ++ "15")
+    candidates.push(base ++ "14")
+    candidates.push(base ++ "13")
+    candidates.push(base ++ "12")
+    candidates.push(base ++ "11")
+    candidates.push(base ++ "10")
+    candidates.push(base ++ "9")
     for i in 0..candidates.len() as i32:
         let dir = candidates.get(i as i64)
         if link_stage_file_exists(dir ++ "/crtbegin.o"):
@@ -366,21 +392,22 @@ fn link_stage_linux_gcc_dir(sysroot: str) -> str:
     ""
 
 fn link_stage_linux_system_lib_path(sysroot: str, name: str) -> str:
+    let libdir = sysroot ++ "/usr/lib/" ++ link_stage_linux_multiarch()
     if name == "z":
-        if link_stage_file_exists(sysroot ++ "/usr/lib/x86_64-linux-gnu/libz.so"):
+        if link_stage_file_exists(libdir ++ "/libz.so"):
             return ""
-        if link_stage_file_exists(sysroot ++ "/usr/lib/x86_64-linux-gnu/libz.so.1"):
-            return sysroot ++ "/usr/lib/x86_64-linux-gnu/libz.so.1"
+        if link_stage_file_exists(libdir ++ "/libz.so.1"):
+            return libdir ++ "/libz.so.1"
     if name == "zstd":
-        if link_stage_file_exists(sysroot ++ "/usr/lib/x86_64-linux-gnu/libzstd.so"):
+        if link_stage_file_exists(libdir ++ "/libzstd.so"):
             return ""
-        if link_stage_file_exists(sysroot ++ "/usr/lib/x86_64-linux-gnu/libzstd.so.1"):
-            return sysroot ++ "/usr/lib/x86_64-linux-gnu/libzstd.so.1"
+        if link_stage_file_exists(libdir ++ "/libzstd.so.1"):
+            return libdir ++ "/libzstd.so.1"
     if name == "xml2":
-        if link_stage_file_exists(sysroot ++ "/usr/lib/x86_64-linux-gnu/libxml2.so"):
+        if link_stage_file_exists(libdir ++ "/libxml2.so"):
             return ""
-        if link_stage_file_exists(sysroot ++ "/usr/lib/x86_64-linux-gnu/libxml2.so.16"):
-            return sysroot ++ "/usr/lib/x86_64-linux-gnu/libxml2.so.16"
+        if link_stage_file_exists(libdir ++ "/libxml2.so.16"):
+            return libdir ++ "/libxml2.so.16"
     ""
 
 fn link_stage_make_darwin_llvm_link_command(llvm_ld: str, obj_path: str, bin_path: str, extras: Vec[str], link_libs: Vec[str], link_args: Vec[str]) -> LinkStageCommand:
@@ -428,15 +455,15 @@ fn link_stage_make_linux_llvm_link_command(llvm_ld: str, obj_path: str, bin_path
     let gcc_dir = link_stage_linux_gcc_dir(sysroot)
     if dynamic_linker.len() == 0 or crt1.len() == 0 or crti.len() == 0 or crtn.len() == 0 or gcc_dir.len() == 0:
         if sysroot.len() > 0:
-            with_eprint("error: could not locate Linux x86_64 crt/linker files under sysroot " ++ sysroot)
+            with_eprint("error: could not locate Linux " ++ link_stage_linux_arch() ++ " crt/linker files under sysroot " ++ sysroot)
         else if runtime_sysinfo_os() == "Linux":
-            with_eprint("error: could not locate Linux x86_64 crt/linker files for direct ld.lld link")
+            with_eprint("error: could not locate Linux " ++ link_stage_linux_arch() ++ " crt/linker files for direct ld.lld link")
         else:
-            with_eprint("error: linking a Linux x86_64 binary from this host needs a Linux sysroot (crt1.o, libc, libgcc); set WITH_LINUX_SYSROOT=<dir>")
+            with_eprint("error: linking a Linux " ++ link_stage_linux_arch() ++ " binary from this host needs a Linux sysroot (crt1.o, libc, libgcc); set WITH_LINUX_SYSROOT=<dir>")
         return LinkStageCommand { linker: "", args, cwd: "", env, inputs, outputs, cleanup_files: Vec.new() }
 
     args.push("-m")
-    args.push("elf_x86_64")
+    args.push(link_stage_linux_emulation())
     args.push("--eh-frame-hdr")
     args.push("--hash-style=gnu")
     args.push("--build-id")
@@ -469,8 +496,8 @@ fn link_stage_make_linux_llvm_link_command(llvm_ld: str, obj_path: str, bin_path
         inputs.push(extra)
 
     args.push("-L" ++ gcc_dir)
-    args.push("-L" ++ sysroot ++ "/usr/lib/x86_64-linux-gnu")
-    args.push("-L" ++ sysroot ++ "/lib/x86_64-linux-gnu")
+    args.push("-L" ++ sysroot ++ "/usr/lib/" ++ link_stage_linux_multiarch())
+    args.push("-L" ++ sysroot ++ "/lib/" ++ link_stage_linux_multiarch())
     args.push("-L" ++ sysroot ++ "/usr/lib")
     args.push("-L" ++ sysroot ++ "/lib")
     for i in 0..link_libs.len() as i32:
@@ -567,7 +594,8 @@ fn link_stage_make_llvm_link_command(llvm_ld: str, obj_path: str, bin_path: str,
     // A --target selection overrides the host: pick the target's link
     // recipe and lld flavor (§18.5 — cross-compilation is a normal mode).
     if not target_spec_is_native():
-        if target_spec_active_kind() == 1:
+        let cross_kind = target_spec_active_kind()
+        if cross_kind == 1 or cross_kind == 2:
             let elf_ld = link_stage_elf_lld_for(llvm_ld)
             if elf_ld.len() == 0:
                 with_eprint("error: cross link needs the ELF lld driver (ld.lld) next to " ++ llvm_ld)
@@ -908,6 +936,8 @@ fn link_stage_platform_runtime_object() -> str:
     if not target_spec_is_native():
         if target_spec_active_kind() == 1:
             return "rt_linux_x86_64.o"
+        if target_spec_active_kind() == 2:
+            return "rt_linux_aarch64.o"
         with_eprint("error: unsupported cross runtime platform: " ++ target_spec_name())
         return ""
     link_stage_host_platform_runtime_object()
@@ -917,6 +947,10 @@ fn link_stage_host_platform_runtime_object() -> str:
     let arch = runtime_sysinfo_arch()
     if os == "Linux" and arch == "x86_64":
         return "rt_linux_x86_64.o"
+    if os == "Linux" and (arch == "armv8" or arch == "aarch64"):
+        // No embedded slot yet — resolved from the on-disk runtime root
+        // only (see link_stage_embedded_runtime_object).
+        return "rt_linux_aarch64.o"
     if os == "Macos" and (arch == "armv8" or arch == "aarch64"):
         return "rt_darwin_aarch64.o"
     if os == "Windows" and arch == "x86_64":

--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -1,5 +1,6 @@
 use Archive
 use compiler.Runtime
+use TargetSpec
 
 extern let with_embedded_cimport_stubs_o_start: u8
 extern let with_embedded_cimport_stubs_o_end: u8
@@ -324,53 +325,62 @@ fn link_stage_make_link_command(linker: str, obj_path: str, bin_path: str, extra
 fn link_stage_file_exists(path: str) -> bool:
     runtime_file_exists(path) != 0
 
-fn link_stage_linux_dynamic_linker() -> str:
-    if link_stage_file_exists("/lib64/ld-linux-x86-64.so.2"):
+// Sysroot prefix for Linux x86_64 link inputs. Native Linux hosts link
+// against the real root (""); a cross host must supply a Linux sysroot
+// (crt objects, libc, libgcc) via WITH_LINUX_SYSROOT.
+fn link_stage_linux_sysroot() -> str:
+    let explicit = runtime_getenv("WITH_LINUX_SYSROOT")
+    if explicit.len() > 0:
+        return explicit
+    ""
+
+fn link_stage_linux_dynamic_linker(sysroot: str) -> str:
+    if link_stage_file_exists(sysroot ++ "/lib64/ld-linux-x86-64.so.2"):
         return "/lib64/ld-linux-x86-64.so.2"
-    if link_stage_file_exists("/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"):
+    if link_stage_file_exists(sysroot ++ "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"):
         return "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
     ""
 
-fn link_stage_linux_crt_object(name: str) -> str:
-    let usr = "/usr/lib/x86_64-linux-gnu/" ++ name
+fn link_stage_linux_crt_object(sysroot: str, name: str) -> str:
+    let usr = sysroot ++ "/usr/lib/x86_64-linux-gnu/" ++ name
     if link_stage_file_exists(usr):
         return usr
-    let lib = "/lib/x86_64-linux-gnu/" ++ name
+    let lib = sysroot ++ "/lib/x86_64-linux-gnu/" ++ name
     if link_stage_file_exists(lib):
         return lib
     ""
 
-fn link_stage_linux_gcc_dir() -> str:
+fn link_stage_linux_gcc_dir(sysroot: str) -> str:
     let candidates: Vec[str] = Vec.new()
-    candidates.push("/usr/lib/gcc/x86_64-linux-gnu/15")
-    candidates.push("/usr/lib/gcc/x86_64-linux-gnu/14")
-    candidates.push("/usr/lib/gcc/x86_64-linux-gnu/13")
-    candidates.push("/usr/lib/gcc/x86_64-linux-gnu/12")
-    candidates.push("/usr/lib/gcc/x86_64-linux-gnu/11")
-    candidates.push("/usr/lib/gcc/x86_64-linux-gnu/10")
-    candidates.push("/usr/lib/gcc/x86_64-linux-gnu/9")
+    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/15")
+    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/14")
+    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/13")
+    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/12")
+    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/11")
+    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/10")
+    candidates.push(sysroot ++ "/usr/lib/gcc/x86_64-linux-gnu/9")
     for i in 0..candidates.len() as i32:
         let dir = candidates.get(i as i64)
         if link_stage_file_exists(dir ++ "/crtbegin.o"):
             return dir
     ""
 
-fn link_stage_linux_system_lib_path(name: str) -> str:
+fn link_stage_linux_system_lib_path(sysroot: str, name: str) -> str:
     if name == "z":
-        if link_stage_file_exists("/usr/lib/x86_64-linux-gnu/libz.so"):
+        if link_stage_file_exists(sysroot ++ "/usr/lib/x86_64-linux-gnu/libz.so"):
             return ""
-        if link_stage_file_exists("/usr/lib/x86_64-linux-gnu/libz.so.1"):
-            return "/usr/lib/x86_64-linux-gnu/libz.so.1"
+        if link_stage_file_exists(sysroot ++ "/usr/lib/x86_64-linux-gnu/libz.so.1"):
+            return sysroot ++ "/usr/lib/x86_64-linux-gnu/libz.so.1"
     if name == "zstd":
-        if link_stage_file_exists("/usr/lib/x86_64-linux-gnu/libzstd.so"):
+        if link_stage_file_exists(sysroot ++ "/usr/lib/x86_64-linux-gnu/libzstd.so"):
             return ""
-        if link_stage_file_exists("/usr/lib/x86_64-linux-gnu/libzstd.so.1"):
-            return "/usr/lib/x86_64-linux-gnu/libzstd.so.1"
+        if link_stage_file_exists(sysroot ++ "/usr/lib/x86_64-linux-gnu/libzstd.so.1"):
+            return sysroot ++ "/usr/lib/x86_64-linux-gnu/libzstd.so.1"
     if name == "xml2":
-        if link_stage_file_exists("/usr/lib/x86_64-linux-gnu/libxml2.so"):
+        if link_stage_file_exists(sysroot ++ "/usr/lib/x86_64-linux-gnu/libxml2.so"):
             return ""
-        if link_stage_file_exists("/usr/lib/x86_64-linux-gnu/libxml2.so.16"):
-            return "/usr/lib/x86_64-linux-gnu/libxml2.so.16"
+        if link_stage_file_exists(sysroot ++ "/usr/lib/x86_64-linux-gnu/libxml2.so.16"):
+            return sysroot ++ "/usr/lib/x86_64-linux-gnu/libxml2.so.16"
     ""
 
 fn link_stage_make_darwin_llvm_link_command(llvm_ld: str, obj_path: str, bin_path: str, extras: Vec[str], link_libs: Vec[str], link_args: Vec[str]) -> LinkStageCommand:
@@ -410,13 +420,19 @@ fn link_stage_make_linux_llvm_link_command(llvm_ld: str, obj_path: str, bin_path
     let env: Vec[LinkStageEnvVar] = Vec.new()
     let inputs: Vec[str] = Vec.new()
     let outputs: Vec[str] = Vec.new()
-    let dynamic_linker = link_stage_linux_dynamic_linker()
-    let crt1 = link_stage_linux_crt_object("crt1.o")
-    let crti = link_stage_linux_crt_object("crti.o")
-    let crtn = link_stage_linux_crt_object("crtn.o")
-    let gcc_dir = link_stage_linux_gcc_dir()
+    let sysroot = link_stage_linux_sysroot()
+    let dynamic_linker = link_stage_linux_dynamic_linker(sysroot)
+    let crt1 = link_stage_linux_crt_object(sysroot, "crt1.o")
+    let crti = link_stage_linux_crt_object(sysroot, "crti.o")
+    let crtn = link_stage_linux_crt_object(sysroot, "crtn.o")
+    let gcc_dir = link_stage_linux_gcc_dir(sysroot)
     if dynamic_linker.len() == 0 or crt1.len() == 0 or crti.len() == 0 or crtn.len() == 0 or gcc_dir.len() == 0:
-        with_eprint("error: could not locate Linux x86_64 crt/linker files for direct ld.lld link")
+        if sysroot.len() > 0:
+            with_eprint("error: could not locate Linux x86_64 crt/linker files under sysroot " ++ sysroot)
+        else if runtime_sysinfo_os() == "Linux":
+            with_eprint("error: could not locate Linux x86_64 crt/linker files for direct ld.lld link")
+        else:
+            with_eprint("error: linking a Linux x86_64 binary from this host needs a Linux sysroot (crt1.o, libc, libgcc); set WITH_LINUX_SYSROOT=<dir>")
         return LinkStageCommand { linker: "", args, cwd: "", env, inputs, outputs, cleanup_files: Vec.new() }
 
     args.push("-m")
@@ -427,6 +443,10 @@ fn link_stage_make_linux_llvm_link_command(llvm_ld: str, obj_path: str, bin_path
     args.push("--gc-sections")
     args.push("--icf=all")
     args.push("--as-needed")
+    if sysroot.len() > 0:
+        // Keep every implicit library search inside the sysroot; the
+        // embedded dynamic-linker path below stays the target's own.
+        args.push("--sysroot=" ++ sysroot)
     args.push("-dynamic-linker")
     args.push(dynamic_linker)
     args.push("-o")
@@ -449,16 +469,16 @@ fn link_stage_make_linux_llvm_link_command(llvm_ld: str, obj_path: str, bin_path
         inputs.push(extra)
 
     args.push("-L" ++ gcc_dir)
-    args.push("-L/usr/lib/x86_64-linux-gnu")
-    args.push("-L/lib/x86_64-linux-gnu")
-    args.push("-L/usr/lib")
-    args.push("-L/lib")
+    args.push("-L" ++ sysroot ++ "/usr/lib/x86_64-linux-gnu")
+    args.push("-L" ++ sysroot ++ "/lib/x86_64-linux-gnu")
+    args.push("-L" ++ sysroot ++ "/usr/lib")
+    args.push("-L" ++ sysroot ++ "/lib")
     for i in 0..link_libs.len() as i32:
         let lib = link_libs.get(i as i64)
         if link_stage_framework_name(lib).len() > 0:
             with_eprint("error: link: \"" ++ lib ++ "\" — Apple frameworks are only available on macOS targets\n")
         else:
-            let fallback_lib = link_stage_linux_system_lib_path(lib)
+            let fallback_lib = link_stage_linux_system_lib_path(sysroot, lib)
             if fallback_lib.len() > 0:
                 args.push(fallback_lib)
                 inputs.push(fallback_lib)
@@ -532,7 +552,29 @@ fn link_stage_make_windows_llvm_link_command(llvm_ld: str, obj_path: str, bin_pa
     let cleanup_files = link_stage_collect_cleanup_files(&extras)
     LinkStageCommand { linker: llvm_ld, args, cwd: "", env, inputs, outputs, cleanup_files }
 
+// The lld flavor for a Linux ELF link. The build's llvm_ld metadata
+// records the host flavor (ld64.lld on macOS); the ELF driver ships
+// beside it in the same SDK bin directory.
+fn link_stage_elf_lld_for(llvm_ld: str) -> str:
+    if link_stage_basename(llvm_ld) == "ld.lld":
+        return llvm_ld
+    let sibling = link_stage_dirname(llvm_ld) ++ "/ld.lld"
+    if link_stage_file_exists(sibling):
+        return sibling
+    ""
+
 fn link_stage_make_llvm_link_command(llvm_ld: str, obj_path: str, bin_path: str, extras: Vec[str], link_libs: Vec[str], link_args: Vec[str]) -> LinkStageCommand:
+    // A --target selection overrides the host: pick the target's link
+    // recipe and lld flavor (§18.5 — cross-compilation is a normal mode).
+    if not target_spec_is_native():
+        if target_spec_active_kind() == 1:
+            let elf_ld = link_stage_elf_lld_for(llvm_ld)
+            if elf_ld.len() == 0:
+                with_eprint("error: cross link needs the ELF lld driver (ld.lld) next to " ++ llvm_ld)
+                return LinkStageCommand { linker: "", args: Vec.new(), cwd: "", env: Vec.new(), inputs: Vec.new(), outputs: Vec.new(), cleanup_files: Vec.new() }
+            return link_stage_make_linux_llvm_link_command(elf_ld, obj_path, bin_path, extras, link_libs, link_args)
+        with_eprint("error: unsupported cross link target: " ++ target_spec_name())
+        return LinkStageCommand { linker: "", args: Vec.new(), cwd: "", env: Vec.new(), inputs: Vec.new(), outputs: Vec.new(), cleanup_files: Vec.new() }
     let os = runtime_sysinfo_os()
     let arch = runtime_sysinfo_arch()
     if os == "Linux" and arch == "x86_64":
@@ -634,11 +676,16 @@ fn link_stage_link_with_extras_and_libs_plan(obj_path: str, bin_path: str, extra
     link_stage_link_with_extras_libs_args_plan(obj_path, bin_path, extras, link_libs, link_args)
 
 fn link_stage_link_with_extras_libs_args_plan(obj_path: str, bin_path: str, extras: Vec[str], link_libs: Vec[str], link_args: Vec[str]) -> LinkStagePlan:
-    if runtime_sysinfo_os() == "Windows":
+    // Cross links never go through the host cc driver: route to the
+    // LLVM linker plan, which dispatches on the active target.
+    if runtime_sysinfo_os() == "Windows" or not target_spec_is_native():
         let root = link_stage_resolve_runtime_root()
         let ld_path = link_stage_read_file_trimmed(root ++ "/llvm_ld")
         if ld_path.len() == 0:
-            with_eprint("error: missing Windows LLVM linker metadata")
+            if runtime_sysinfo_os() == "Windows":
+                with_eprint("error: missing Windows LLVM linker metadata")
+            else:
+                with_eprint("error: cross-target link requires LLVM linker metadata (" ++ root ++ "/llvm_ld)")
             return link_stage_plan_fail()
         return link_stage_link_with_llvm_args_plan(obj_path, bin_path, extras, link_libs, link_args, ld_path)
     let command = link_stage_make_link_command("cc", obj_path, bin_path, extras, link_libs, link_args)
@@ -699,6 +746,15 @@ fn link_stage_undefined_symbols_for_object(obj_path: str) -> str:
             nm_tool = link_stage_dirname(ld_path) ++ "/llvm-nm.exe"
         else:
             nm_tool = "llvm-nm.exe"
+    else if not target_spec_is_native():
+        // Cross objects are foreign to the host toolchain; use the
+        // SDK's llvm-nm (beside lld) when it's available.
+        let root = link_stage_resolve_runtime_root()
+        let ld_path = link_stage_read_file_trimmed(root ++ "/llvm_ld")
+        if ld_path.len() > 0:
+            let llvm_nm = link_stage_dirname(ld_path) ++ "/llvm-nm"
+            if link_stage_file_exists(llvm_nm):
+                nm_tool = llvm_nm
     argv = link_stage_argv_append(argv, nm_tool)
     argv = link_stage_argv_append(argv, "-u")
     argv = link_stage_argv_append(argv, obj_path)
@@ -815,6 +871,15 @@ fn link_stage_artifact_root() -> str:
 
 fn link_stage_find_runtime_object_path(name: str) -> str:
     let root = link_stage_resolve_runtime_root()
+    // Cross targets only ever link runtime objects built for the
+    // target; the embedded objects are host-built and never a valid
+    // fallback here (§18.5: fail loudly, never link native output).
+    if not target_spec_is_native():
+        let cross_path = root ++ "/cross/" ++ target_spec_name() ++ "/" ++ name
+        if runtime_read_file(cross_path).len() > 0:
+            return cross_path
+        with_eprint("error: missing " ++ target_spec_name() ++ " runtime object: " ++ cross_path ++ " (run `with build :cross-rt` first)")
+        return ""
     let p = root ++ "/" ++ name
     if runtime_read_file(p).len() > 0:
         return p
@@ -826,6 +891,16 @@ fn link_stage_find_runtime_object_path(name: str) -> str:
     if link_stage_extract_runtime_obj(name, tmp_path) == 0:
         return tmp_path
     ""
+
+// The platform runtime object for the ACTIVE target (native resolves
+// to the host's, exactly as before cross targets existed).
+fn link_stage_platform_runtime_object() -> str:
+    if not target_spec_is_native():
+        if target_spec_active_kind() == 1:
+            return "rt_linux_x86_64.o"
+        with_eprint("error: unsupported cross runtime platform: " ++ target_spec_name())
+        return ""
+    link_stage_host_platform_runtime_object()
 
 fn link_stage_host_platform_runtime_object() -> str:
     let os = runtime_sysinfo_os()
@@ -1014,7 +1089,7 @@ fn link_stage_link_object_to_binary_plan_with_units(obj_path: str, extra_objects
                 with_eprint("error: missing rt_core.o")
                 return link_stage_plan_fail()
             extras.push(rt_core_path)
-            let rt_platform_object = link_stage_host_platform_runtime_object()
+            let rt_platform_object = link_stage_platform_runtime_object()
             if rt_platform_object.len() == 0:
                 return link_stage_plan_fail()
             let rt_platform_path = link_stage_find_runtime_object_path(rt_platform_object)
@@ -1058,7 +1133,7 @@ fn link_stage_link_object_to_binary_plan_with_units(obj_path: str, extra_objects
                 with_eprint("error: missing rt_core.o")
                 return link_stage_plan_fail()
             extras.push(rt_core_path)
-            let rt_platform_object = link_stage_host_platform_runtime_object()
+            let rt_platform_object = link_stage_platform_runtime_object()
             if rt_platform_object.len() == 0:
                 return link_stage_plan_fail()
             let rt_platform_path = link_stage_find_runtime_object_path(rt_platform_object)
@@ -1102,7 +1177,7 @@ fn link_stage_link_object_to_binary_plan_with_units(obj_path: str, extra_objects
                 with_eprint("error: missing rt_core.o")
                 return link_stage_plan_fail()
             extras.push(rt_core_path)
-            let rt_platform_object = link_stage_host_platform_runtime_object()
+            let rt_platform_object = link_stage_platform_runtime_object()
             if rt_platform_object.len() == 0:
                 return link_stage_plan_fail()
             let rt_platform_path = link_stage_find_runtime_object_path(rt_platform_object)

--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -844,10 +844,20 @@ fn link_stage_resolve_runtime_root() -> str:
     // Fall back to compiler-relative runtime dir.
     compiler_dir ++ "/runtime"
 
+// Directory holding the link inputs built FOR the active target:
+// the runtime root itself for native, its cross/<target>/ subdir
+// for a cross target (bridge objects, embedded objects, lld rsp).
+fn link_stage_runtime_variant_dir() -> str:
+    let root = link_stage_resolve_runtime_root()
+    if target_spec_is_native():
+        return root
+    root ++ "/cross/" ++ target_spec_name()
+
 fn link_stage_find_llvm_static_bridge() -> str:
     let root = link_stage_resolve_runtime_root()
-    let bridge_o = root ++ "/llvm_bridge.o"
-    let rsp = root ++ "/llvm_ld.rsp"
+    let variant = link_stage_runtime_variant_dir()
+    let bridge_o = variant ++ "/llvm_bridge.o"
+    let rsp = variant ++ "/llvm_ld.rsp"
     let ld_file = root ++ "/llvm_ld"
     if runtime_read_file(bridge_o).len() > 0 and runtime_read_file(rsp).len() > 0 and runtime_read_file(ld_file).len() > 0:
         return bridge_o
@@ -1222,17 +1232,21 @@ fn link_stage_link_object_to_binary_plan_with_units(obj_path: str, extra_objects
     if link_stage_undefined_symbols_need_llvm_bridge(undef):
         let static_bridge = link_stage_find_llvm_static_bridge()
         if static_bridge.len() > 0:
-            // Static LLVM linking: use llvm_bridge.o + LLVM static libs
+            // Static LLVM linking: use llvm_bridge.o + LLVM static libs.
+            // All target-built inputs come from the variant dir (the
+            // cross/<target>/ subdir on a cross link); only the linker
+            // path metadata is the host's.
             let root = link_stage_resolve_runtime_root()
-            let rsp_path = root ++ "/llvm_ld.rsp"
+            let variant = link_stage_runtime_variant_dir()
+            let rsp_path = variant ++ "/llvm_ld.rsp"
             let ld_path = link_stage_read_file_trimmed(root ++ "/llvm_ld")
             extras.push(static_bridge)
             // Include embedded runtime objects for self-contained binary
-            let embedded_path = root ++ "/embedded_objects.o"
+            let embedded_path = variant ++ "/embedded_objects.o"
             if runtime_read_file(embedded_path).len() > 0:
                 extras.push(embedded_path)
             // Include clang bridge for c_import support
-            let clang_bridge_path = root ++ "/clang_bridge.o"
+            let clang_bridge_path = variant ++ "/clang_bridge.o"
             if runtime_read_file(clang_bridge_path).len() > 0:
                 extras.push(clang_bridge_path)
             extras.push("@" ++ rsp_path)

--- a/src/compiler/LlvmBridge.w
+++ b/src/compiler/LlvmBridge.w
@@ -117,6 +117,7 @@ extern fn LLVMCreateTargetMachine(target: *mut u8, triple: *const u8, cpu: *cons
 extern fn LLVMCreateTargetDataLayout(tm: *mut u8) -> *mut u8
 extern fn LLVMSetModuleDataLayout(m: *mut u8, dl: *mut u8)
 extern fn LLVMSetTarget(m: *mut u8, triple: *const u8)
+extern fn LLVMGetTarget(m: *mut u8) -> *const u8
 extern fn LLVMDisposeTargetData(dl: *mut u8)
 extern fn LLVMDisposeMessage(msg: *mut u8)
 extern fn LLVMDisposeTargetMachine(tm: *mut u8)
@@ -1494,6 +1495,12 @@ fn path_to_cstr(path: str, buf: *mut u8) -> *const u8:
     buf as *const u8
 
 pub fn wl_assemble_to_object(source_path: str, output_path: str) -> i32:
+    wl_assemble_to_object_for_triple(source_path, output_path, "")
+
+// Assemble a .s file for an explicit target triple ("" = the active/
+// host triple). Build-graph compile_asm_object targets pass a
+// `triple=` arg for cross-target runtime assembly.
+pub fn wl_assemble_to_object_for_triple(source_path: str, output_path: str, triple_str: str) -> i32:
     unsafe:
         let _ = wl_init_native_target()
         let _ = wl_init_native_asm_printer()
@@ -1512,7 +1519,7 @@ pub fn wl_assemble_to_object(source_path: str, output_path: str) -> i32:
         let ctx = LLVMContextCreate()
         let m = LLVMModuleCreateWithNameInContext("asm\0" as *const u8, ctx)
         let default_triple = LLVMGetDefaultTargetTriple()
-        let triple = llvm_object_triple(default_triple)
+        let triple = if triple_str.len() > 0: to_cstr(triple_str) else: llvm_object_triple(default_triple)
         LLVMSetTarget(m, triple)
         LLVMSetModuleInlineAsm2(m, asm_ptr, asm_len)
         LLVMDisposeMemoryBuffer(mem_buf)
@@ -1561,8 +1568,14 @@ pub fn wl_compile_ir_to_object(source_path: str, output_path: str) -> i32:
             LLVMContextDispose(ctx)
             return 1
         let default_triple = LLVMGetDefaultTargetTriple()
-        let triple = llvm_object_triple(default_triple)
-        LLVMSetTarget(m, triple)
+        // Respect the triple the IR was emitted for (`with ir --target`
+        // embeds it); an IR file without one gets the active/host triple.
+        // Compiling IR as-written is what makes CompileLlvmIrObject
+        // correct for cross-target .ll inputs.
+        var triple = LLVMGetTarget(m) as *const u8
+        if triple as i64 == 0 or *(triple) == 0:
+            triple = llvm_object_triple(default_triple)
+            LLVMSetTarget(m, triple)
         var target: *mut u8 = 0 as *mut u8
         var terr: *mut u8 = 0 as *mut u8
         if LLVMGetTargetFromTriple(triple, &raw mut target, &raw mut terr) != 0:

--- a/src/compiler/LlvmBridge.w
+++ b/src/compiler/LlvmBridge.w
@@ -528,7 +528,30 @@ fn codegen_level(level: i32) -> i32:
     if level == 3: return LLVM_CodeGenLevelAggressive
     LLVM_CodeGenLevelDefault
 
-fn llvm_host_object_triple(default_triple: *mut u8) -> *const u8:
+// Active target triple override, set once by the driver for --target
+// cross builds (§18.5). Fixed buffer because the bridge is compiled as
+// a standalone object (llvm_bridge.o) and stays import-free. Empty =
+// native: keep the historical host-triple behavior.
+var wl_active_triple_buf: [128]u8 = [0 as u8; 128]
+var wl_active_triple_len: i32 = 0
+
+pub fn wl_set_active_target_triple(triple: str) -> Unit:
+    var n = triple.len() as i32
+    if n > 127:
+        n = 127
+    var i = 0
+    while i < n:
+        wl_active_triple_buf[i as i64] = triple.byte_at(i as i64)
+        i = i + 1
+    wl_active_triple_buf[n as i64] = 0 as u8
+    wl_active_triple_len = n
+
+// The triple every emission path (target machine, .s assembly, IR
+// compile) targets: the driver's --target override when set, else the
+// host object triple.
+fn llvm_object_triple(default_triple: *mut u8) -> *const u8:
+    if wl_active_triple_len > 0:
+        return &wl_active_triple_buf as *const u8
     if rt_sysinfo_os() == "Macos" and (rt_sysinfo_arch() == "armv8" or rt_sysinfo_arch() == "aarch64"):
         return c"arm64-apple-macosx11.0.0".ptr
     default_triple as *const u8
@@ -536,7 +559,7 @@ fn llvm_host_object_triple(default_triple: *mut u8) -> *const u8:
 pub fn wl_init_target_machine(mod_ref: i64, level: i32) -> i64:
     unsafe:
         let default_triple = LLVMGetDefaultTargetTriple()
-        let triple = llvm_host_object_triple(default_triple)
+        let triple = llvm_object_triple(default_triple)
         var target: *mut u8 = 0 as *mut u8
         var err: *mut u8 = 0 as *mut u8
         if LLVMGetTargetFromTriple(triple, &raw mut target, &raw mut err) != 0:
@@ -1489,7 +1512,7 @@ pub fn wl_assemble_to_object(source_path: str, output_path: str) -> i32:
         let ctx = LLVMContextCreate()
         let m = LLVMModuleCreateWithNameInContext("asm\0" as *const u8, ctx)
         let default_triple = LLVMGetDefaultTargetTriple()
-        let triple = llvm_host_object_triple(default_triple)
+        let triple = llvm_object_triple(default_triple)
         LLVMSetTarget(m, triple)
         LLVMSetModuleInlineAsm2(m, asm_ptr, asm_len)
         LLVMDisposeMemoryBuffer(mem_buf)
@@ -1538,7 +1561,7 @@ pub fn wl_compile_ir_to_object(source_path: str, output_path: str) -> i32:
             LLVMContextDispose(ctx)
             return 1
         let default_triple = LLVMGetDefaultTargetTriple()
-        let triple = llvm_host_object_triple(default_triple)
+        let triple = llvm_object_triple(default_triple)
         LLVMSetTarget(m, triple)
         var target: *mut u8 = 0 as *mut u8
         var terr: *mut u8 = 0 as *mut u8

--- a/src/main.w
+++ b/src/main.w
@@ -802,6 +802,11 @@ fn run_cli(argc: i32) -> i32:
         comp.configure(opt_level, no_std, alloc_mode, runtime_available)
         comp.set_prelude_mode(prelude_mode)
         comp.set_overflow_mode(driver_internal_overflow_mode())
+        let ir_target = driver_parse_build_target(argc)
+        if not ir_target.ok:
+            with_eprint("error: " ++ ir_target.error_msg)
+            return 1
+        comp.set_target_kind(ir_target.kind)
         let pool = comp.compile_file(source)
         if pool.decl_count() == 0:
             with_eprint("error: IR generation failed during compilation")

--- a/src/main.w
+++ b/src/main.w
@@ -33,6 +33,7 @@ use BuildGraphCache
 use compiler.DriverOptions
 use Analysis
 use ReceiverMigration
+use TargetSpec
 
 extern fn with_arg_count() -> i32
 extern fn with_arg_at(idx: i32) -> str
@@ -2081,9 +2082,10 @@ fn build_command_validate_target(options: &BuildCommandOptions, cfg: &ProjectCon
     if options.target_kind < 0:
         with_eprint("error: invalid with.toml: unsupported target.default '" ++ cfg.target_default ++ "'")
         return 1
-    // §18.5: non-native target selections must fail loudly until
-    // cross-target codegen/linking exists; never fall back to native.
-    if not build_graph_target_is_host(options.target_kind):
+    // §18.5: a non-native target selection either has a real cross
+    // path (target_spec_cross_supported) or fails loudly; it never
+    // falls back to native output.
+    if not build_graph_target_is_host(options.target_kind) and not target_spec_cross_supported(options.target_kind):
         with_eprint("error: cross-target build for '" ++ build_graph_target_name(options.target_kind) ++ "' is not implemented yet; host is " ++ build_graph_target_name(build_graph_host_target_kind()))
         return 1
     0


### PR DESCRIPTION
## Summary

Implements the deferred step 4 of #425: `--target x86_64-unknown-linux-gnu` now selects target codegen, C ABI, target-faithful comptime/parse guards, ELF linking, and target runtime objects — no silent native fallback anywhere. A macOS arm64 host cross-builds both user programs and the full compiler as x86_64 Linux ELF; the cross-built compiler was verified on Linux (`--version` and program compiles under qemu-free Rosetta docker).

## What's in here

- **src/TargetSpec.w** (new): single source of truth for the active `--target` kind (same 0-5 numbering as `std.build.BuildTarget`). Native resolves to host, so native builds are byte-identical (fixpoint green throughout).
- **LlvmBridge**: driver-installed triple override consulted by object emission, `.s` assembly, and IR compile. `wl_compile_ir_to_object` now respects the triple embedded in the IR module. `wl_assemble_to_object_for_triple` for cross asm.
- **Codegen**: C-ABI predicates (byval/darwin-arm64/windows) read the target, not host sysinfo.
- **Parser/ComptimeEval**: `@[target]` guards and comptime `sysinfo` os/arch reflect the target.
- **Link**: target-dispatched link plans; linux cross links use the SDK's `ld.lld` with crt/libc probed under `WITH_LINUX_SYSROOT`; cross links resolve runtime objects **only** from `out/lib/cross/<target>/` (embedded host objects are never a fallback); compiler links pull bridge/embedded/rsp inputs from the same variant dir; `llvm-nm` used for ELF undef probing.
- **CImport**: `c_import` + `--target` fails loudly (host headers must not leak into target ABI). The cross-built compiler itself keeps full c_import support on its native platform.
- **Driver**: `with ir` honors `--target` (was silently host). Unknown triples keep failing loudly per §18.5.
- **build.w**: `with build :cross-rt` builds the complete linux_x86_64 link input set (runtime objects, whole-module regex IR object with the pcre2 modules, fiber asm, ELF embedded objects, bridges, linux-SDK lld rsp) into `out/lib/cross/linux_x86_64/`.

## Cross workflow

```
with build                      # native compiler with --target support
WITH=out/release/bin/with with build :cross-rt
WITH_LINUX_SYSROOT=<glibc-2.38+ sysroot> \
  out/release/bin/with build out/gen/main.w --target=x86_64-unknown-linux-gnu -O2 -o out/cross/with-linux-x86_64
```

Needs the published `with-llvm-sdk-<v>-linux-x86_64` extracted into `.deps/` and a Debian-trixie-class sysroot (the linux LLVM SDK references glibc 2.38 `__isoc23_*` symbols).

## Verified

- `with build`, `with build :fixpoint` green at every commit (darwin-aarch64)
- Cross hello-world: ELF runs on linux/amd64 (`hello from with`)
- Cross compiler: 104MB ELF, zero undefined symbols, runs `with --version` on linux/amd64 → `with v0.15.1-g6fdf05568`

## Notes / follow-ups

- `:cross-rt` graph actions run in the driver process, so it must be driven by a `--target`-capable compiler (`WITH=out/release/bin/with`) until the next seed update.
- The `deps` target still fetches `.tar.gz` SDK assets while v0.15.1 published `.tar.zst` — worked around manually, worth a follow-up.
- c_import-with-sysroot for cross user programs is future work (guarded loudly today).