### PR TITLE
Cross-compilation: Windows x86_64 target (COFF link, :cross-rt-windows)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ node_modules/
 *~
 .vscode/
 .idea/
+
+# Local cross-Windows toolchain workarounds (not part of the build)
+.link-shim/
+.xwin-cache/
+with-linux-x86_64

--- a/build.w
+++ b/build.w
@@ -246,6 +246,68 @@ fn run_cross_linux_llvm_link_metadata_action(ctx: ActionCtx) -> i32:
         return 1
     0
 
+// ── Cross-target (windows_x86_64) helpers ───────────────────────────
+
+fn cross_windows_dir() -> str:
+    "out/lib/cross/windows_x86_64"
+
+fn cross_windows_triple() -> str:
+    "x86_64-pc-windows-msvc"
+
+fn cross_windows_llvm_prefix() -> str:
+    ".deps/llvm-" ++ compiler_llvm_version() ++ "-windows-x86_64-msvc"
+
+fn cross_windows_object_target_named(name: str, source: str, obj_name: str, opt: str) -> Target:
+    var target = with_object_target(name, release_compiler_bin("with"), source, cross_windows_dir() ++ "/" ++ obj_name, opt, "build")
+    target = target.arg("--target=" ++ cross_windows_triple())
+    target
+
+fn cross_windows_object_target(name: str, source: str, opt: str) -> Target:
+    let base = comp_path_basename(source)
+    let stem = if base.ends_with(".w"): base.slice(0, base.len() - 2) else: base
+    cross_windows_object_target_named(name, source, stem ++ ".o", opt)
+
+// Generate cross/windows_x86_64/llvm_ld.rsp: the windows LLVM SDK's
+// static clang+LLVM import/static archives, in lld-link positional
+// form (one .lib per line, no GNU flags). The MSVC CRT and Windows
+// SDK import libraries are appended by the windows link recipe
+// (link_stage_make_windows_llvm_link_command) from the WITH_WINDOWS_*
+// lib dirs, so they are not repeated here.
+fn run_cross_windows_llvm_link_metadata_action(ctx: ActionCtx) -> i32:
+    let fs = ctx.fs()
+    let output_path = ctx.output()
+    let lib_dir = cross_windows_llvm_prefix() ++ "/lib"
+    let libclang = lib_dir ++ "/libclang.lib"
+    if not fs.host_exists(libclang):
+        ctx.diagnostics().error("cross-windows-llvm-link-metadata: missing " ++ libclang ++ "; extract the with-llvm-sdk-" ++ compiler_llvm_version() ++ "-windows-x86_64 release asset into .deps/")
+        return 1
+    let lib_files = fs.host_list_files(lib_dir)
+    if lib_files.len() == 0:
+        ctx.diagnostics().error("cross-windows-llvm-link-metadata: could not list: " ++ lib_dir)
+        return 1
+    var clang_archives: Vec[str] = Vec.new()
+    var llvm_archives: Vec[str] = Vec.new()
+    for i in 0..lib_files.len() as i32:
+        let path = lib_files.get(i as i64)
+        let name = comp_path_basename(path)
+        if name.ends_with(".lib"):
+            if (name.starts_with("clang") or name.starts_with("libclang")) and path != libclang:
+                clang_archives.push(path)
+            else:
+                if name.starts_with("LLVM") and name != "LLVM-C.lib":
+                    llvm_archives.push(path)
+    var ld_rsp = comp_rsp_path(libclang) ++ "\n"
+    let sorted_clang = comp_sort_strings(clang_archives)
+    for i in 0..sorted_clang.len() as i32:
+        ld_rsp = ld_rsp ++ comp_rsp_path(sorted_clang.get(i as i64)) ++ "\n"
+    let sorted_llvm = comp_sort_strings(llvm_archives)
+    for i in 0..sorted_llvm.len() as i32:
+        ld_rsp = ld_rsp ++ comp_rsp_path(sorted_llvm.get(i as i64)) ++ "\n"
+    if fs.write_text(output_path, ld_rsp) != 0:
+        ctx.diagnostics().error("cross-windows-llvm-link-metadata: could not write: " ++ output_path)
+        return 1
+    0
+
 fn empty_file_target(name: str, output: str) -> Target:
     var target = target_new(.Action, name, "").output(output)
     target.action = run_write_empty_file_action
@@ -1719,6 +1781,91 @@ pub fn build(ctx: BuildCtx) -> Build:
     // (WITH=out/release/bin/with) until the seed is updated.
     out = add_cross_rt_targets(move out, "linux_x86_64", "cross-", "cross-rt")
     out = add_cross_rt_targets(move out, "linux_aarch64", "cross-arm-", "cross-rt-arm")
+
+    // ── Cross-target runtime (windows_x86_64) ───────────────────────
+    // `with build :cross-rt-windows` builds the full windows_x86_64
+    // runtime + compiler link inputs into out/lib/cross/windows_x86_64/
+    // (COFF objects, windows triple) so a `--target x86_64-pc-windows-msvc`
+    // link resolves entirely from that directory (§18.5). Mirrors the
+    // linux cross-rt set; fiber core/asm are the windows variants.
+    out = out.add_target(cross_windows_object_target("cross-win-rt-core-object", "rt/rt_core.w", "-O2"))
+    out = out.add_target(cross_windows_object_target_named("cross-win-rt-platform-object", "rt/windows_x86_64.w", "rt_windows_x86_64.o", "-O2"))
+    out = out.add_target(cross_windows_object_target("cross-win-cimport-stubs-object", "rt/cimport_stubs.w", "-O1"))
+    var cross_win_compat = cross_windows_object_target_named("cross-win-compat-runtime-object", "out/gen/compat_runtime.w", "compat_runtime.o", "-O1")
+    cross_win_compat = cross_win_compat.dep("compat-runtime-source")
+    out = out.add_target(cross_win_compat)
+    out = out.add_target(cross_windows_object_target("cross-win-panic-runtime-object", "rt/panic_runtime.w", "-O1"))
+    out = out.add_target(cross_windows_object_target("cross-win-fiber-stubs-object", "rt/fiber_stubs.w", "-O1"))
+    out = out.add_target(cross_windows_object_target("cross-win-channel-runtime-object", "rt/channel_runtime.w", "-O1"))
+    out = out.add_target(cross_windows_object_target("cross-win-fiber-runtime-object", "rt/fiber_runtime.w", "-O1"))
+    out = out.add_target(cross_windows_object_target_named("cross-win-fiber-core-object", "rt/fiber_core_windows.w", "fiber.o", "-O1"))
+    out = out.add_target(cross_windows_object_target_named("cross-win-llvm-bridge-object", "src/compiler/LlvmBridge.w", "llvm_bridge.o", "-O1"))
+    out = out.add_target(cross_windows_object_target_named("cross-win-clang-bridge-object", "src/compiler/ClangBridge.w", "clang_bridge.o", "-O1"))
+
+    var cross_win_regex_ir = with_ir_target_overflow("cross-win-regex-runtime-ir", release_compiler_bin("with"), "rt/regex_runtime.w", "out/tmp/cross_win_regex_runtime.ll", "build", "wrap")
+    cross_win_regex_ir = cross_win_regex_ir.arg("--target=" ++ cross_windows_triple())
+    out = out.add_target(cross_win_regex_ir)
+    var cross_win_regex = target_new(.CompileLlvmIrObject, "cross-win-regex-runtime-object", "out/tmp/cross_win_regex_runtime.ll").output(cross_windows_dir() ++ "/regex_runtime.o")
+    cross_win_regex = cross_win_regex.dep("cross-win-regex-runtime-ir")
+    out = out.add_target(cross_win_regex)
+
+    var cross_win_fiber_asm = target_new(.CompileAsmObject, "cross-win-fiber-asm-object", "runtime/fiber_asm_windows_x86_64.s").output(cross_windows_dir() ++ "/fiber_asm.o")
+    cross_win_fiber_asm = cross_win_fiber_asm.arg("triple=" ++ cross_windows_triple())
+    out = out.add_target(cross_win_fiber_asm)
+
+    var cross_win_embedded = target_new(.EmbedObjectFiles, "cross-win-embedded-objects-asm", "windows_x86_64").output(cross_windows_dir() ++ "/embedded_objects.s")
+    cross_win_embedded = cross_win_embedded.input(cross_windows_dir() ++ "/cimport_stubs.o")
+    cross_win_embedded = cross_win_embedded.arg("cimport_stubs_o")
+    cross_win_embedded = cross_win_embedded.input(cross_windows_dir() ++ "/compat_runtime.o")
+    cross_win_embedded = cross_win_embedded.arg("compat_runtime_o")
+    cross_win_embedded = cross_win_embedded.input(cross_windows_dir() ++ "/panic_runtime.o")
+    cross_win_embedded = cross_win_embedded.arg("panic_runtime_o")
+    cross_win_embedded = cross_win_embedded.input(cross_windows_dir() ++ "/regex_runtime.o")
+    cross_win_embedded = cross_win_embedded.arg("regex_runtime_o")
+    cross_win_embedded = cross_win_embedded.input(cross_windows_dir() ++ "/fiber_stubs.o")
+    cross_win_embedded = cross_win_embedded.arg("fiber_stubs_o")
+    cross_win_embedded = cross_win_embedded.input(cross_windows_dir() ++ "/channel_runtime.o")
+    cross_win_embedded = cross_win_embedded.arg("channel_runtime_o")
+    cross_win_embedded = cross_win_embedded.input(cross_windows_dir() ++ "/fiber_runtime.o")
+    cross_win_embedded = cross_win_embedded.arg("fiber_runtime_o")
+    cross_win_embedded = cross_win_embedded.input(cross_windows_dir() ++ "/fiber.o")
+    cross_win_embedded = cross_win_embedded.arg("fiber_o")
+    cross_win_embedded = cross_win_embedded.input(cross_windows_dir() ++ "/fiber_asm.o")
+    cross_win_embedded = cross_win_embedded.arg("fiber_asm_o")
+    cross_win_embedded = cross_win_embedded.input(cross_windows_dir() ++ "/rt_core.o")
+    cross_win_embedded = cross_win_embedded.arg("rt_core_o")
+    cross_win_embedded = cross_win_embedded.input(cross_windows_dir() ++ "/rt_windows_x86_64.o")
+    cross_win_embedded = cross_win_embedded.arg("rt_windows_x86_64_o")
+    cross_win_embedded = cross_win_embedded.dep("cross-win-cimport-stubs-object")
+    cross_win_embedded = cross_win_embedded.dep("cross-win-compat-runtime-object")
+    cross_win_embedded = cross_win_embedded.dep("cross-win-panic-runtime-object")
+    cross_win_embedded = cross_win_embedded.dep("cross-win-regex-runtime-object")
+    cross_win_embedded = cross_win_embedded.dep("cross-win-fiber-stubs-object")
+    cross_win_embedded = cross_win_embedded.dep("cross-win-channel-runtime-object")
+    cross_win_embedded = cross_win_embedded.dep("cross-win-fiber-runtime-object")
+    cross_win_embedded = cross_win_embedded.dep("cross-win-fiber-core-object")
+    cross_win_embedded = cross_win_embedded.dep("cross-win-fiber-asm-object")
+    cross_win_embedded = cross_win_embedded.dep("cross-win-rt-core-object")
+    cross_win_embedded = cross_win_embedded.dep("cross-win-rt-platform-object")
+    out = out.add_target(cross_win_embedded)
+
+    var cross_win_embedded_obj = target_new(.CompileAsmObject, "cross-win-embedded-objects-object", cross_windows_dir() ++ "/embedded_objects.s").output(cross_windows_dir() ++ "/embedded_objects.o")
+    cross_win_embedded_obj = cross_win_embedded_obj.arg("triple=" ++ cross_windows_triple())
+    cross_win_embedded_obj = cross_win_embedded_obj.dep("cross-win-embedded-objects-asm")
+    out = out.add_target(cross_win_embedded_obj)
+
+    var cross_win_ld_rsp = target_new(.Action, "cross-win-llvm-link-metadata", "").output(cross_windows_dir() ++ "/llvm_ld.rsp")
+    cross_win_ld_rsp.action = run_cross_windows_llvm_link_metadata_action
+    cross_win_ld_rsp = cross_win_ld_rsp.write_scope(cross_windows_dir())
+    cross_win_ld_rsp = cross_win_ld_rsp.write_scope("out/command/cross-win-llvm-link-metadata")
+    out = out.add_target(cross_win_ld_rsp)
+
+    var cross_rt_windows = target_new(.Group, "cross-rt-windows", "")
+    cross_rt_windows = cross_rt_windows.dep("cross-win-embedded-objects-object")
+    cross_rt_windows = cross_rt_windows.dep("cross-win-llvm-bridge-object")
+    cross_rt_windows = cross_rt_windows.dep("cross-win-clang-bridge-object")
+    cross_rt_windows = cross_rt_windows.dep("cross-win-llvm-link-metadata")
+    out = out.add_target(cross_rt_windows)
 
     // The compiler links to an UNSTAMPED intermediate whose inputs (out/gen/main.w
     // + src) are commit-independent, so it caches across commits (#650). A cheap

--- a/build/compiler.w
+++ b/build/compiler.w
@@ -1485,6 +1485,12 @@ pub fn run_patch_version_action(ctx: ActionCtx) -> i32:
     let version = comp_resolve_compiler_version(ctx)
     if version.len() == 0:
         return comp_fail(ctx, "could not resolve compiler version from src/version")
+    // Materialize the out/command/<name> marker directory that the action
+    // verifier expects for every declared extra_output (the sibling
+    // run_with_compiler_build_action creates its capture dir the same way).
+    let capture_dir = comp_join("out/command", ctx.target_name())
+    if ctx.fs().mkdir_all(capture_dir) != 0:
+        return comp_fail(ctx, "could not create capture directory: " ++ capture_dir)
     comp_patch_version_binary(ctx, unstamped, output_path, version)
 
 pub fn run_generate_llvm_link_metadata_action(ctx: ActionCtx) -> i32:

--- a/src/BuildGraphOps.w
+++ b/src/BuildGraphOps.w
@@ -300,10 +300,14 @@ pub fn build_graph_embed_object_files(root: str, target: &BuildGraphTarget) -> i
     // The embed target's entry names the PLATFORM the assembly is for
     // (e.g. "linux_x86_64" for a cross-built compiler); empty = host.
     var macho_sections = build_graph_host_target_kind() == 3 or build_graph_host_target_kind() == 4
+    var coff_sections = build_graph_host_target_kind() == 5
     if target.entry.len() > 0:
         macho_sections = target.entry.starts_with("darwin")
+        coff_sections = target.entry.starts_with("windows")
     if macho_sections:
         asm_text = asm_text ++ ".section __TEXT,__const\n.subsections_via_symbols\n\n"
+    else if coff_sections:
+        asm_text = asm_text ++ ".section .rdata,\"dr\"\n\n"
     else:
         asm_text = asm_text ++ ".section .rodata\n\n"
     for ii in 0..target.inputs.len() as i32:

--- a/src/TargetSpec.w
+++ b/src/TargetSpec.w
@@ -105,4 +105,4 @@ pub fn target_spec_name() -> str:
 // binaries for today. Gate is checked by the driver; anything else
 // non-native must fail loudly (§18.5: never fall back to native).
 pub fn target_spec_cross_supported(kind: i32) -> bool:
-    kind == 1 or kind == 2
+    kind == 1 or kind == 2 or kind == 5

--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -524,6 +524,12 @@ fn link_stage_make_linux_llvm_link_command(llvm_ld: str, obj_path: str, bin_path
     let cleanup_files = link_stage_collect_cleanup_files(&extras)
     LinkStageCommand { linker: llvm_ld, args, cwd: "", env, inputs, outputs, cleanup_files }
 
+fn link_stage_windows_libpath(var_name: str, fallback: str) -> str:
+    let v = runtime_getenv(var_name)
+    if v.len() > 0:
+        return v
+    fallback
+
 fn link_stage_make_windows_llvm_link_command(llvm_ld: str, obj_path: str, bin_path: str, extras: Vec[str], link_libs: Vec[str], link_args: Vec[str]) -> LinkStageCommand:
     let args: Vec[str] = Vec.new()
     let env: Vec[LinkStageEnvVar] = Vec.new()
@@ -536,9 +542,13 @@ fn link_stage_make_windows_llvm_link_command(llvm_ld: str, obj_path: str, bin_pa
     args.push("/stack:8388608")
     args.push("/opt:ref")
     args.push("/opt:icf")
-    args.push("/libpath:C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/um/x64")
-    args.push("/libpath:C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/ucrt/x64")
-    args.push("/libpath:C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.29.30133/lib/x64")
+    // Library search paths. On a Windows host these are the standard
+    // MSVC/WinSDK install locations; for a cross link from another host
+    // point them at a splatted lib tree (e.g. xwin output) via the
+    // WITH_WINDOWS_* env vars.
+    args.push("/libpath:" ++ link_stage_windows_libpath("WITH_WINDOWS_UM_LIBDIR", "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/um/x64"))
+    args.push("/libpath:" ++ link_stage_windows_libpath("WITH_WINDOWS_UCRT_LIBDIR", "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/ucrt/x64"))
+    args.push("/libpath:" ++ link_stage_windows_libpath("WITH_WINDOWS_MSVC_LIBDIR", "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.29.30133/lib/x64"))
     args.push("/out:" ++ bin_path)
     outputs.push(bin_path)
     args.push(obj_path)
@@ -590,6 +600,18 @@ fn link_stage_elf_lld_for(llvm_ld: str) -> str:
         return sibling
     ""
 
+// The lld flavor for a Windows COFF/PE link. `lld-link` ships beside
+// the host llvm_ld in the same SDK bin directory (a symlink to `lld`
+// in the published SDKs); invoking lld as lld-link performs a native
+// COFF link from any host, so no wine is needed for the link itself.
+fn link_stage_coff_lld_for(llvm_ld: str) -> str:
+    if link_stage_basename(llvm_ld) == "lld-link" or link_stage_basename(llvm_ld) == "lld-link.exe":
+        return llvm_ld
+    let sibling = link_stage_dirname(llvm_ld) ++ "/lld-link"
+    if link_stage_file_exists(sibling):
+        return sibling
+    ""
+
 fn link_stage_make_llvm_link_command(llvm_ld: str, obj_path: str, bin_path: str, extras: Vec[str], link_libs: Vec[str], link_args: Vec[str]) -> LinkStageCommand:
     // A --target selection overrides the host: pick the target's link
     // recipe and lld flavor (§18.5 — cross-compilation is a normal mode).
@@ -601,6 +623,12 @@ fn link_stage_make_llvm_link_command(llvm_ld: str, obj_path: str, bin_path: str,
                 with_eprint("error: cross link needs the ELF lld driver (ld.lld) next to " ++ llvm_ld)
                 return LinkStageCommand { linker: "", args: Vec.new(), cwd: "", env: Vec.new(), inputs: Vec.new(), outputs: Vec.new(), cleanup_files: Vec.new() }
             return link_stage_make_linux_llvm_link_command(elf_ld, obj_path, bin_path, extras, link_libs, link_args)
+        if target_spec_active_kind() == 5:
+            let coff_ld = link_stage_coff_lld_for(llvm_ld)
+            if coff_ld.len() == 0:
+                with_eprint("error: cross link needs the COFF lld driver (lld-link) next to " ++ llvm_ld)
+                return LinkStageCommand { linker: "", args: Vec.new(), cwd: "", env: Vec.new(), inputs: Vec.new(), outputs: Vec.new(), cleanup_files: Vec.new() }
+            return link_stage_make_windows_llvm_link_command(coff_ld, obj_path, bin_path, extras, link_libs, link_args)
         with_eprint("error: unsupported cross link target: " ++ target_spec_name())
         return LinkStageCommand { linker: "", args: Vec.new(), cwd: "", env: Vec.new(), inputs: Vec.new(), outputs: Vec.new(), cleanup_files: Vec.new() }
     let os = runtime_sysinfo_os()
@@ -940,6 +968,8 @@ fn link_stage_platform_runtime_object() -> str:
             return "rt_linux_x86_64.o"
         if target_spec_active_kind() == 2:
             return "rt_linux_aarch64.o"
+        if target_spec_active_kind() == 5:
+            return "rt_windows_x86_64.o"
         with_eprint("error: unsupported cross runtime platform: " ++ target_spec_name())
         return ""
     link_stage_host_platform_runtime_object()
@@ -961,7 +991,7 @@ fn link_stage_host_platform_runtime_object() -> str:
     ""
 
 fn link_stage_make_archive(obj_path: str) -> str:
-    if runtime_sysinfo_os() == "Windows":
+    if runtime_sysinfo_os() == "Windows" or target_spec_active_kind() == 5:
         return obj_path
     // Wrap a .o file in a .a archive so the linker treats it as a library
     // (only pulling in symbols that aren't already defined).


### PR DESCRIPTION
## Windows x86_64 cross-compilation (Linux → Windows, verified under wine)

Adds an `x86_64-pc-windows-msvc` cross target (kind 5) so `with` can cross-compile Windows PE executables from a Linux host. Builds on the linux_x86_64 cross pipeline.

### Verified working
A hello-world **and** a non-trivial program using `std.process.args()` cross-compile on Linux and run correctly under wine (exit 0; argv, stdlib, `print` all fine):
```
with build --target x86_64-pc-windows-msvc hello.w -o hello.exe   # PE32+ console exe
wine hello.exe                                                     # -> prints correctly
```
Linking is native on Linux (the LLVM SDK's `lld-link` in COFF mode) against an [xwin](https://github.com/Jake-Shadle/xwin)-splatted MSVC CRT + Windows SDK import libs; wine is only used to *run* the produced exe.

### Changes (Windows cross enablement)
- **`TargetSpec`** — `target_spec_cross_supported` accepts kind 5.
- **`Link.w`** — route kind 5 to the Windows link recipe via the COFF `lld-link` driver (`link_stage_coff_lld_for`); kind 5 → `rt_windows_x86_64.o`; `link_stage_make_archive` returns **raw** objects for a Windows target (lld-link won't pull members from GNU `.a` archives on a cross link); MSVC/UCRT/UM libpaths overridable via `WITH_WINDOWS_{MSVC,UCRT,UM}_LIBDIR` (`C:/…` fallbacks kept for on-Windows).
- **`BuildGraphOps`** — embed generator emits COFF `.section .rdata` for a `windows` entry.
- **`build.w`** — `:cross-rt-windows` builds the full Windows runtime + LLVM/clang bridges + a COFF-form `llvm_ld.rsp`, mirroring `:cross-rt`. Also fixes the platform runtime object name (`rt_<platform>.o`) in **both** cross-rt sets.

### Incidental fix (separate commit)
- The default `build` stamp action never created its declared `out/command/build` marker, so the action verifier failed *every* default `with build` and no state was blessed.

### Known follow-up
The compiler itself cross-links to a `with-windows-x86_64.exe` that loads under wine but exits immediately (~0.5s) without doing work — a full stage1–3 self-bootstrap under wine is **not yet green**. Ordinary With programs run fine under wine; the only difference for the compiler is the statically-linked LLVM/libclang, so this points at LLVM/clang static-init under wine, not the cross plumbing. Under investigation.
