### PR TITLE
CI: get macOS bootstrap green — provision LLVM SDK across .tar.gz/.tar.zst release skew

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,62 @@ jobs:
           chmod +x src/main
           src/main version
 
+      # The static LLVM SDK that `build :deps` fetches is published as a per-
+      # platform release asset. The build tree currently expects a `.tar.gz`
+      # asset (self-hosted zlib_gunzip in `run_deps_download_action`), but every
+      # release published so far ships the SDK only as `.tar.zst`. Until a
+      # release is cut with `.tar.gz` assets, `build :deps` cannot find its
+      # asset and the build fails. Provision `.deps/` directly here, preferring
+      # the correct `.tar.gz` and falling back to the `.tar.zst` that shipped in
+      # the last release, so `build :deps` finds its marker already present and
+      # succeeds without changing the self-hosted fetch path.
+      - name: Provision LLVM SDK (bridge .tar.gz/.tar.zst release skew)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WITH_SDK_REPO: withlang-dev/with
+        run: |
+          set -euo pipefail
+          prefix="$LLVM_PREFIX"
+          if [ -f "$prefix/lib/libclang.a" ]; then
+            echo "SDK already provisioned at $prefix"
+            exit 0
+          fi
+          # Derive "<ver>" and the darwin-aarch64 asset base from the prefix dir
+          # name (.deps/llvm-<ver>-darwin-arm64).
+          dir="$(basename "$prefix")"        # llvm-<ver>-darwin-arm64
+          ver="${dir#llvm-}"; ver="${ver%-darwin-arm64}"
+          base="with-llvm-sdk-${ver}-darwin-aarch64"
+          asset=""; tag=""
+          # Newest release first; within a release prefer .tar.gz over .tar.zst.
+          while IFS= read -r candidate; do
+            names="$(gh release view "$candidate" --repo "$WITH_SDK_REPO" --json assets --jq '.assets[].name')"
+            if printf '%s\n' "$names" | grep -qx "${base}.tar.gz"; then
+              asset="${base}.tar.gz"; tag="$candidate"; break
+            fi
+            if printf '%s\n' "$names" | grep -qx "${base}.tar.zst"; then
+              asset="${base}.tar.zst"; tag="$candidate"; break
+            fi
+          done < <(gh release list --repo "$WITH_SDK_REPO" --limit 50 --json tagName --jq '.[].tagName')
+          if [ -z "$asset" ]; then
+            echo "error: no release publishes ${base}.tar.gz or ${base}.tar.zst" >&2
+            exit 1
+          fi
+          echo "provisioning SDK from $tag: $asset"
+          mkdir -p .deps
+          curl -fL -o "$RUNNER_TEMP/$asset" \
+            "https://github.com/$WITH_SDK_REPO/releases/download/$tag/$asset"
+          case "$asset" in
+            *.tar.gz)  tar -xzf "$RUNNER_TEMP/$asset" -C .deps ;;
+            *.tar.zst)
+              if tar --help 2>&1 | grep -q -- --zstd; then
+                tar --zstd -xf "$RUNNER_TEMP/$asset" -C .deps
+              else
+                zstd -d -c "$RUNNER_TEMP/$asset" | tar -xf - -C .deps
+              fi ;;
+          esac
+          test -f "$prefix/lib/libclang.a"
+          echo "SDK provisioned at $prefix"
+
       - name: Fetch SDK
         run: src/main build :deps
 


### PR DESCRIPTION
## Root cause

The macOS `selfhost (macOS)` job fails at **Fetch SDK** (`src/main build :deps`).

`build :deps` resolves the static LLVM SDK release asset as
`with-llvm-sdk-<ver>-darwin-aarch64.tar.gz` and decompresses it with the
self-hosted `zlib_gunzip` helper (`run_deps_download_action` in
`build/seed.w`). This `.tar.gz` expectation was introduced in
`fefe8840` (2026-06-19, "Remove host fetch tools from dependency targets"),
which migrated the fetch path off the external `zstd` tool.

However, **every published release ships the SDK only as `.tar.zst`** — the
latest release (v0.15.1, 2026-06-08) predates `fefe8840`, and no `.tar.gz`
SDK release has been cut since. `seed_release_from_api` matches asset names
exactly (`name == asset_name`), so it finds no matching asset across all
releases and `:deps` fails. The current workflow (Bootstrap seed / Fetch SDK
/ Build / Fixpoint / Test) had never actually run — the last CI activity
(2026-04-01) used the previous workflow — so this had gone unobserved.

## Fix

The build tree is internally consistent on `.tar.gz` (it both produces via
`write_tar_gz` and consumes via `zlib_gunzip`); the correct long-term
resolution is a release cut with `.tar.gz` SDK assets. Rather than reverse
`fefe8840`'s self-hosted direction, this bridges the release skew in CI:

A new **Provision LLVM SDK** step downloads the SDK release asset directly
into `.deps/`, **preferring `.tar.gz`** and **falling back to the `.tar.zst`**
that shipped in the last release (extracting via `tar --zstd`, or
`zstd -d | tar` if the runner's `tar` lacks zstd). With `.deps/` pre-populated,
the subsequent `build :deps` finds its marker
(`.deps/llvm-<ver>-darwin-arm64/lib/libclang.a`) already present and returns
success immediately — the self-hosted fetch path is left unchanged. Once a
`.tar.gz` SDK release exists, the step transparently prefers it and the
fallback becomes dead.

## Verified

- Asset selection logic run against the live GitHub API: derives
  `ver=22.1.6`, selects `v0.15.1 / with-llvm-sdk-22.1.6-darwin-aarch64.tar.zst`.
- The published zst tarball extracts to top-level `llvm-22.1.6-<host>/` and
  contains `lib/libclang.a`, `bin/clang++`, and
  `lib/clang/22/include/stddef.h` — exactly what `LLVM_PREFIX` needs. Both
  extraction paths (`tar --zstd` and `zstd -d | tar`) verified.
- `:deps` marker short-circuit confirmed in `run_deps_download_action`
  (`if fs.exists(marker): return 0`).
- Workflow YAML parses; step order Checkout / Bootstrap seed / Provision LLVM
  SDK / Fetch SDK / Build / Fixpoint / Test.

## Not verified (no macOS host available)

- A full macOS runner pass (Build / Fixpoint / Test). This PR unblocks the
  step that was hard-failing (Fetch SDK); it does not attempt to diagnose any
  downstream failure that only a green Fetch SDK could expose.
- Only the macOS job is in scope, per request.

## Follow-up (not in this PR)

`build :deps` remains broken for local developers against current releases
until a release is cut with `.tar.gz` SDK assets (which the build already
produces). This CI step is a bridge, not a substitute for that release.
