### PR TITLE
Bootstrap: repair the emit-C bundle path

### DIFF
--- a/build.w
+++ b/build.w
@@ -1351,8 +1351,6 @@ pub fn build(ctx: BuildCtx) -> Build:
     package_bootstrap_c = package_bootstrap_c.input("out/release/bin/with")
     package_bootstrap_c = package_bootstrap_c.input("out/bootstrap-c/src/with_compiler.c")
     package_bootstrap_c = package_bootstrap_c.input("out/gen/wl_decls.h")
-    package_bootstrap_c = package_bootstrap_c.input("src/compiler/LlvmBridge.w")
-    package_bootstrap_c = package_bootstrap_c.input("src/compiler/ClangBridge.w")
     package_bootstrap_c = package_bootstrap_c.input("rt/rt_core.w")
     package_bootstrap_c = package_bootstrap_c.input("rt/panic_runtime.w")
     package_bootstrap_c = package_bootstrap_c.input("rt/regex_runtime.w")

--- a/build.w
+++ b/build.w
@@ -1333,6 +1333,12 @@ pub fn build(ctx: BuildCtx) -> Build:
     bootstrap_c_emit_sources = bootstrap_c_emit_sources.write_scope("out/command/bootstrap-c-emit-sources")
     bootstrap_c_emit_sources = bootstrap_c_emit_sources.input("out/gen/versioned_main.w")
     bootstrap_c_emit_sources = bootstrap_c_emit_sources.dep("compiler-version-sources")
+    // The compiler source imports the generated EmbeddedStdlibData and
+    // EmbeddedClangResourceData modules (same as stage1/2/3); without these
+    // deps a standalone `:bootstrap-c-emit-sources` on a clean tree fails
+    // with "import module not found".
+    bootstrap_c_emit_sources = bootstrap_c_emit_sources.dep("compat-runtime-source")
+    bootstrap_c_emit_sources = bootstrap_c_emit_sources.dep("embedded-clang-resource-source")
     out = out.add_target(bootstrap_c_emit_sources)
 
     var package_bootstrap_c = target_new(.Action, "package-bootstrap-c", "").output("out/release/with-bootstrap-c-" ++ release_version ++ ".tar.gz")

--- a/build/package.w
+++ b/build/package.w
@@ -375,10 +375,8 @@ fn pkg_readme(version: str) -> str:
     "    mkdir -p obj\n\n" ++
     "    \"$CLANG\" -std=gnu11 -O2 -D_GNU_SOURCE -Iruntime -I\"$LLVM_PREFIX/include\" \\\n" ++
     "      -include runtime/wl_decls.h -c src/with_compiler.c -o obj/with_compiler.o\n\n" ++
-    "    for file in src/llvm_bridge.c src/clang_bridge.c src/linux_platform.c; do\n" ++
-    "      \"$CLANG\" -std=gnu11 -O2 -D_GNU_SOURCE -Iruntime -I\"$LLVM_PREFIX/include\" \\\n" ++
-    "        -c \"$file\" -o \"obj/$(basename \"$file\" .c).o\"\n" ++
-    "    done\n\n" ++
+    "    \"$CLANG\" -std=gnu11 -O2 -D_GNU_SOURCE -Iruntime -I\"$LLVM_PREFIX/include\" \\\n" ++
+    "      -c src/linux_platform.c -o obj/linux_platform.o\n\n" ++
     "    for file in src/rt_core.c src/panic_runtime.c src/regex_runtime.c src/fiber_stubs.c src/compat_runtime.c; do\n" ++
     "      \"$CLANG\" -std=gnu11 -O2 -D_GNU_SOURCE -DWITH_RUNTIME_H -Iruntime -I\"$LLVM_PREFIX/include\" \\\n" ++
     "        -include runtime/bootstrap_types.h -c \"$file\" -o \"obj/$(basename \"$file\" .c).o\"\n" ++
@@ -509,10 +507,9 @@ pub fn run_package_bootstrap_c_action(ctx: ActionCtx) -> i32:
 
     var rc = pkg_copy_file(ctx, "out/bootstrap-c/src/with_compiler.c", pkg_join(stage_root, "src/with_compiler.c"))
     if rc != 0: return rc
-    rc = pkg_emit_c(ctx, compiler_path, "src/compiler/LlvmBridge.w", pkg_join(stage_root, "src/llvm_bridge.c"), "llvm-bridge")
-    if rc != 0: return rc
-    rc = pkg_emit_c(ctx, compiler_path, "src/compiler/ClangBridge.w", pkg_join(stage_root, "src/clang_bridge.c"), "clang-bridge")
-    if rc != 0: return rc
+    // The LLVM/Clang bridges are compiler modules, so they are already part of
+    // the emitted with_compiler.c; shipping them as separate C files made the
+    // bundle link fail with multiple definitions.
     rc = pkg_emit_c(ctx, compiler_path, "rt/rt_core.w", pkg_join(stage_root, "src/rt_core.c"), "rt-core")
     if rc != 0: return rc
     rc = pkg_emit_c(ctx, compiler_path, "rt/panic_runtime.w", pkg_join(stage_root, "src/panic_runtime.c"), "panic-runtime")

--- a/scripts/bootstrap/linux_platform.c
+++ b/scripts/bootstrap/linux_platform.c
@@ -12,9 +12,11 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/random.h>
+#include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/sysinfo.h>
 #include <sys/time.h>
+#include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -260,6 +262,271 @@ void rt_fill_random(uint8_t *buf, uint64_t len) {
 }
 
 int *__error(void) { return __errno_location(); }
+
+/* --- platform surface added after the original shim (mirrors
+ * rt/linux_x86_64.w): stdio handles, lstat mode, readlink, wall clock,
+ * rlimits, and the rt_compat_* process-exec boundary that
+ * rt/compat_runtime.w declares as externs. --- */
+
+/* runtime/sys/resource.h (shipped stub, first on the include path) no-ops
+ * rlimits and only defines RLIMIT_STACK; keep these fallbacks so the same
+ * code also builds against a real <sys/resource.h>. */
+#ifndef RLIMIT_AS
+#define RLIMIT_AS RLIMIT_STACK
+#endif
+#ifndef RLIM_INFINITY
+#define RLIM_INFINITY (~0ULL)
+#endif
+
+void *rt_libc_stdin(void) { return stdin; }
+void *rt_libc_stdout(void) { return stdout; }
+void *rt_libc_stderr(void) { return stderr; }
+
+int64_t rt_wall_clock_sec(void) {
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0) return 0;
+    return (int64_t)ts.tv_sec;
+}
+
+int32_t rt_file_mode(const uint8_t *path) {
+    struct stat st;
+    if (lstat(rt_cstr(path), &st) != 0) return -rt_errno();
+    return (int32_t)st.st_mode;
+}
+
+with_str rt_readlink(const uint8_t *path) {
+    char buf[4096];
+    ssize_t n = readlink(rt_cstr(path), buf, sizeof(buf) - 1);
+    if (n < 0) return rt_owned_str("");
+    buf[n] = 0;
+    return rt_owned_str(buf);
+}
+
+int32_t rt_set_process_memory_limit_bytes(int64_t limit) {
+    if (limit <= 0) return 0;
+    struct rlimit lim;
+    if (getrlimit(RLIMIT_AS, &lim) != 0) return -1;
+    uint64_t want = (uint64_t)limit;
+    if (lim.rlim_max != RLIM_INFINITY && want > lim.rlim_max) want = lim.rlim_max;
+    if (lim.rlim_cur != RLIM_INFINITY && lim.rlim_cur <= want) return 0;
+    lim.rlim_cur = want;
+    return setrlimit(RLIMIT_AS, &lim);
+}
+
+static char *rt_compat_str_to_cbuf(with_str s) {
+    char *out = (char *)malloc((size_t)s.len + 1);
+    if (out == NULL) return NULL;
+    if (s.len > 0) memcpy(out, s.ptr, (size_t)s.len);
+    out[s.len] = 0;
+    return out;
+}
+
+static volatile sig_atomic_t rt_compat_interrupt_flag = 0;
+static volatile int rt_compat_active_child_pgid = 0;
+
+static void rt_compat_interrupt_handler(int signo) {
+    rt_compat_interrupt_flag = 1;
+    if (rt_compat_active_child_pgid > 0)
+        kill(-rt_compat_active_child_pgid, signo);
+    _exit(128 + signo);
+}
+
+int32_t rt_compat_setenv_str(with_str name, with_str value) {
+    char *name_buf = rt_compat_str_to_cbuf(name);
+    char *value_buf = rt_compat_str_to_cbuf(value);
+    int rc = -1;
+    if (name_buf != NULL && value_buf != NULL)
+        rc = setenv(name_buf, value_buf, 1);
+    free(name_buf);
+    free(value_buf);
+    return rc;
+}
+
+void rt_compat_install_interrupt_handlers(void) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = rt_compat_interrupt_handler;
+    sigaction(SIGINT, &sa, NULL);
+    sigaction(SIGTERM, &sa, NULL);
+    sigaction(SIGHUP, &sa, NULL);
+}
+
+void rt_compat_raise_stack_limit(void) {
+    struct rlimit lim;
+    if (getrlimit(RLIMIT_STACK, &lim) != 0) return;
+    uint64_t want = 8u * 1024 * 1024;
+    if (lim.rlim_max != RLIM_INFINITY && want > lim.rlim_max) want = lim.rlim_max;
+    if (want > lim.rlim_cur) {
+        lim.rlim_cur = want;
+        setrlimit(RLIMIT_STACK, &lim);
+    }
+}
+
+int32_t rt_compat_interrupt_requested(void) { return rt_compat_interrupt_flag != 0; }
+
+static int32_t rt_compat_wait_child(int pid, int32_t timeout_ms) {
+    int status = -1;
+    struct timespec start;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    for (;;) {
+        pid_t waited = waitpid(pid, &status, timeout_ms > 0 ? WNOHANG : 0);
+        if (waited == pid) {
+            int termsig = status & 0x7f;
+            if (termsig == 0) return (status >> 8) & 0xff;
+            if (termsig != 0x7f) return 128 + termsig;
+            return status;
+        }
+        if (waited < 0) {
+            if (errno == EINTR) continue;
+            return -1;
+        }
+        if (timeout_ms > 0) {
+            struct timespec now;
+            clock_gettime(CLOCK_MONOTONIC, &now);
+            int64_t elapsed_ms = (int64_t)(now.tv_sec - start.tv_sec) * 1000 +
+                                 (now.tv_nsec - start.tv_nsec) / 1000000;
+            if (elapsed_ms >= timeout_ms) {
+                kill(-pid, SIGTERM);
+                usleep(10000);
+                if (waitpid(pid, &status, WNOHANG) != pid) {
+                    kill(-pid, SIGKILL);
+                    waitpid(pid, &status, 0);
+                }
+                return 124; /* capture timeout rc, matches rt/linux_x86_64.w */
+            }
+            usleep(10000);
+        }
+    }
+}
+
+/* args blob: argv strings separated by NUL bytes, length-delimited. */
+static int32_t rt_compat_run_argv(const char *blob, int64_t len,
+                                  const char *stdout_path, const char *stderr_path,
+                                  const char *stdin_path, const char *cwd,
+                                  int32_t timeout_ms, int wait_child) {
+    int argc = 0;
+    for (int64_t off = 0; off < len;) {
+        argc++;
+        while (off < len && blob[off] != 0) off++;
+        off++;
+    }
+    if (argc <= 0 || argc >= 256) return -1;
+    sigset_t blocked, prev;
+    sigemptyset(&blocked);
+    sigaddset(&blocked, SIGINT);
+    sigaddset(&blocked, SIGTERM);
+    sigaddset(&blocked, SIGHUP);
+    int mask_rc = sigprocmask(SIG_BLOCK, &blocked, &prev);
+    pid_t pid = fork();
+    if (pid == 0) {
+        if (mask_rc == 0) sigprocmask(SIG_SETMASK, &prev, NULL);
+        setpgid(0, 0);
+        signal(SIGINT, SIG_DFL);
+        signal(SIGTERM, SIG_DFL);
+        signal(SIGHUP, SIG_DFL);
+        signal(SIGQUIT, SIG_DFL);
+        if (stdin_path != NULL) {
+            int fd = open(stdin_path, O_RDONLY);
+            if (fd < 0 || dup2(fd, 0) < 0) _exit(127);
+            close(fd);
+        }
+        if (stdout_path != NULL) {
+            int fd = open(stdout_path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+            if (fd < 0 || dup2(fd, 1) < 0) _exit(127);
+            close(fd);
+        }
+        if (stderr_path != NULL) {
+            int fd = open(stderr_path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+            if (fd < 0 || dup2(fd, 2) < 0) _exit(127);
+            close(fd);
+        }
+        if (cwd != NULL) {
+            if (chdir(cwd) != 0) _exit(127);
+            setenv("PWD", cwd, 1);
+        }
+        const char *argv[256];
+        int argi = 0;
+        for (int64_t off = 0; off < len && argi < 255;) {
+            argv[argi++] = blob + off;
+            while (off < len && blob[off] != 0) off++;
+            off++;
+        }
+        argv[argi] = NULL;
+        execvp(argv[0], (char *const *)argv);
+        _exit(127);
+    }
+    if (pid < 0) {
+        if (mask_rc == 0) sigprocmask(SIG_SETMASK, &prev, NULL);
+        return -1;
+    }
+    setpgid(pid, pid);
+    if (mask_rc == 0) sigprocmask(SIG_SETMASK, &prev, NULL);
+    if (!wait_child) return pid;
+    rt_compat_active_child_pgid = pid;
+    int32_t rc = rt_compat_wait_child(pid, timeout_ms);
+    rt_compat_active_child_pgid = 0;
+    return rc;
+}
+
+static int32_t rt_compat_exec_common(with_str args, const with_str *stdout_path,
+                                     const with_str *stderr_path, const with_str *stdin_path,
+                                     const with_str *cwd, int32_t timeout_ms, int wait_child) {
+    if (rt_compat_interrupt_flag) return -1;
+    char *arg_buf = rt_compat_str_to_cbuf(args);
+    char *out_buf = stdout_path != NULL ? rt_compat_str_to_cbuf(*stdout_path) : NULL;
+    char *err_buf = stderr_path != NULL ? rt_compat_str_to_cbuf(*stderr_path) : NULL;
+    char *in_buf = stdin_path != NULL ? rt_compat_str_to_cbuf(*stdin_path) : NULL;
+    char *cwd_buf = (cwd != NULL && cwd->len > 0) ? rt_compat_str_to_cbuf(*cwd) : NULL;
+    int32_t rc = -1;
+    if (arg_buf != NULL &&
+        (stdout_path == NULL || out_buf != NULL) &&
+        (stderr_path == NULL || err_buf != NULL) &&
+        (stdin_path == NULL || in_buf != NULL))
+        rc = rt_compat_run_argv(arg_buf, args.len, out_buf, err_buf, in_buf, cwd_buf,
+                                timeout_ms, wait_child);
+    free(arg_buf);
+    free(out_buf);
+    free(err_buf);
+    free(in_buf);
+    free(cwd_buf);
+    return rc;
+}
+
+int32_t rt_compat_exec_binary(with_str path) {
+    return rt_compat_exec_common(path, NULL, NULL, NULL, NULL, 0, 1);
+}
+
+int32_t rt_compat_exec_argv(with_str args) {
+    return rt_compat_exec_common(args, NULL, NULL, NULL, NULL, 0, 1);
+}
+
+int32_t rt_compat_exec_argv_cwd(with_str args, with_str cwd) {
+    return rt_compat_exec_common(args, NULL, NULL, NULL, &cwd, 0, 1);
+}
+
+int32_t rt_compat_exec_argv_capture(with_str args, with_str stdout_path, with_str stderr_path, int32_t timeout_ms) {
+    return rt_compat_exec_common(args, &stdout_path, &stderr_path, NULL, NULL, timeout_ms, 1);
+}
+
+int32_t rt_compat_exec_argv_capture_input(with_str args, with_str stdout_path, with_str stderr_path, int32_t timeout_ms, with_str stdin_path) {
+    return rt_compat_exec_common(args, &stdout_path, &stderr_path, &stdin_path, NULL, timeout_ms, 1);
+}
+
+int32_t rt_compat_exec_argv_capture_cwd(with_str args, with_str stdout_path, with_str stderr_path, int32_t timeout_ms, with_str cwd) {
+    return rt_compat_exec_common(args, &stdout_path, &stderr_path, NULL, &cwd, timeout_ms, 1);
+}
+
+int32_t rt_compat_exec_argv_capture_spawn(with_str args, with_str stdout_path, with_str stderr_path) {
+    return rt_compat_exec_common(args, &stdout_path, &stderr_path, NULL, NULL, 0, 0);
+}
+
+int32_t rt_compat_exec_wait(int32_t pid, int32_t timeout_ms) {
+    if (pid <= 0) return -1;
+    rt_compat_active_child_pgid = pid;
+    int32_t rc = rt_compat_wait_child(pid, timeout_ms);
+    rt_compat_active_child_pgid = 0;
+    return rc;
+}
 
 int __open(const uint8_t *path, int flags, int mode) {
     int native = flags & 3;


### PR DESCRIPTION
## What was broken

The Bootstrap C Bundle path (`:bootstrap-c-emit-sources` / `:package-bootstrap-c`, shipped as `with-bootstrap-c-v0.14.2.tar.zst`) has bit-rotted in three independent ways since v0.14.2:

1. **`:bootstrap-c-emit-sources` fails on a clean tree** with `import module not found`. The compiler source imports the generated `EmbeddedStdlibData` / `EmbeddedClangResourceData` modules, but the target only depended on `compiler-version-sources`. Stage1/2/3 already declare exactly these two generator deps; the emit target was missed.

2. **The Linux link of the bundle fails with 19 undefined references.** `scripts/bootstrap/linux_platform.c` predates the `rt_compat_*` process-exec boundary (`rt/compat_runtime.w` externs) and several newer platform symbols (`rt_libc_std{in,out,err}`, `rt_wall_clock_sec`, `rt_file_mode`, `rt_readlink`, `rt_set_process_memory_limit_bytes`). The Linux instructions shipped in the v0.14.2 bundle were never runnable — that release was produced and consumed in the darwin-only era.

3. **The bundle double-ships the LLVM/Clang bridges.** The bridges are compiler modules now, so the emitted `with_compiler.c` already contains every `wl_*`/`with_ci_*` definition; packaging separately-emitted `llvm_bridge.c`/`clang_bridge.c` (and instructing consumers to compile them) makes the link fail with hundreds of multiple-definition errors.

## The fix

- `build.w`: add `compat-runtime-source` and `embedded-clang-resource-source` deps to `bootstrap-c-emit-sources`; drop the two bridge source inputs from `package-bootstrap-c`.
- `scripts/bootstrap/linux_platform.c`: add the missing platform surface, mirroring `rt/linux_x86_64.w` semantics exactly (NUL-separated argv blob, fork/execvp with capture redirection, cwd, timeout -> rc 124 with SIGTERM-then-SIGKILL to the process group, interrupt handlers, rlimit raising against the shipped no-op `runtime/sys/resource.h` stub).
- `build/package.w`: stop emitting/staging the bridge C files; update the README compile sketch accordingly.

## Verification (Linux x86_64, head source)

- `:bootstrap-c-emit-sources` produced `out/bootstrap-c/src/with_compiler.c` (45.7 MB) + `out/gen/wl_decls.h`; the runtime modules (`rt_core`, `panic_runtime`, `regex_runtime`, `fiber_stubs`, `compat_runtime`) emitted per the packaging recipe.
- Every C file compiles with stock **gcc** (`-std=gnu11 -O1 -D_GNU_SOURCE`, no clang required), and the result links with stock **g++** against the static LLVM SDK archives (`--start-group libclang*.a libLLVM*.a liblld*.a --end-group -lpthread -ldl -lm -lz -lzstd -lxml2`).
- The resulting `with-bootstrap` (121 MB, statically linked LLVM) runs: `--version` reports correctly, it type-checks the full compiler source (`check src/main.w` reproduces exactly the known head-source noncompliance diagnostics, matching the native compiler), and its real LLVM backend emits valid x86-64 ELF objects (`build --emit-obj` for `test/hello.w` and `rt/rt_core.w`).

## Why this matters

This is the C-toolchain bootstrap anchor: with these repairs, a host with only a C/C++ compiler and the With-owned static LLVM SDK can build a working With compiler from emitted C, with no prior With binary — the escape hatch that makes the binary seed chain auditable and recoverable.

## Fourth commit: emit-C global runtime initializers

Exercising the repaired bundle exposed one more genuine emit-C gap: the C backend never ran global runtime initializers. The LLVM backend synthesizes `__with_init_const_*` helpers and stores their results from the main wrapper; the C backend silently zero-initialized such globals. Result: the bundle-built compiler segfaulted in `hm_set_is_str_key` (via `with_hashmap_insert` from `build_cache_fingerprint_file`) the moment it ran the build graph, because `build_cache_fp_memo: HashMap[str, str] = HashMap.new()` (src/BuildGraphCache.w:28) was a zero handle — and any `Vec.new()` global would silently corrupt pushes via `elem_size = 0`.

The fix emits the provable initializer forms from the C main wrapper (`Vec.new()`, `HashMap.new()`/`HashSet.new()`) and fails loudly on any other global runtime initializer instead of silently zeroing (No Silent Fallbacks).
