### PR TITLE
Head self-hosts: complete D22 contextual-Copy coverage; fix self-compile-exposed double-frees

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -10,6 +10,51 @@ decision supersedes an earlier one, say so in both.
 
 ---
 
+## Enum discriminant resolution is enum-scoped; no bare-name fallback
+
+**Date:** 2026-07-25
+**Status:** Accepted
+**Deciders:** Rob O'Callahan
+
+**Decision.** `enum_variant_discriminant_for_type` and
+`type_reflection_variant_discriminant` trust `disc_values` **only** through the
+qualified `Enum.Variant` key. When the qualified key is absent they fall through
+to the variant `index` (for payload enums) rather than to the bare variant-name
+key.
+
+**Context.** `disc_values` is populated only for DiscEnums (`enum X: i32: A =
+0`), keyed by BOTH the bare variant-name sym and the qualified `X.A` sym. Payload
+enums (`enum Option[T] { Some(T) | None }`) never register `disc_values`; their
+discriminant is the declaration index. The bare key is therefore shared across
+every enum that declares a variant of that name. The compiler's own `enum
+CliOneLinerMode { None = 0 }` set `disc_values["None"] = 0`, and the old bare
+fallback made `enum_variant_discriminant_for_type(Option[..], None)` return 0
+instead of 1. For a niche-encoded `Option[&V]` (the D22 map-view type), codegen's
+`RK_DISCRIMINANT` computes `None = (ptr == null) = 1`, so `x.is_none()` lowered
+to `discriminant == 0` (i.e. `is_some`) — every niche `is_none` was inverted,
+sending `None` into `unwrap` (`unwrap on None` abort). This is why head
+self-hosting aborted at `CodegenDispatch.mir_indirect_value_local_ptr`: the
+niche `Option[&i64]` returned by `mir_local_types.get(..)` never crashed on a
+tiny program (no other enum named a `None` variant), only inside the full
+compiler.
+
+**Alternatives weighed.** (a) Register `disc_values` for payload enums too — but
+the bare key still collides, so it only papers over the lookup; the bare entry
+stays ambiguous. (b) Make codegen's niche path derive the discriminant from the
+semantic disc — insufficient, because the bug is that the semantic disc itself
+was resolved through a colliding global name key. (c, chosen) Never consult the
+bare `disc_values` key: both enum kinds register their qualified variant in
+`variant_lookup`, so `qualified_enum_variant_sym` always yields the genuine
+`Enum.Variant` key for a valid enum decl; DiscEnums resolve via that qualified
+`disc_values` entry, payload enums fall through to `index` (== their implicit
+discriminant). No enum's discriminant is ever read through a name another enum
+can shadow.
+
+**Reopen if** a variant discriminant is ever needed without a resolvable owning
+enum type; then it must be stored per-enum, never under a bare global name.
+
+---
+
 ## D22 — Keyed-map lookup returns a uniform view; Copy materializes only under owned demand
 
 **Date:** 2026-07-23

--- a/src/Codegen.w
+++ b/src/Codegen.w
@@ -24,6 +24,7 @@ extern fn exit(code: i32) -> Unit
 extern fn with_fs_read_file(path: str) -> str
 extern fn with_vec_free(v: *mut u8) -> Unit
 extern fn with_hashmap_free(map: *mut u8) -> Unit
+extern fn with_memset(dst: *mut u8, c: i32, n: i64) -> Unit
 extern fn with_parse_float(s: str) -> f64
 extern fn with_eprint(s: str) -> Unit
 extern fn with_getenv_str(name: str) -> str
@@ -1171,6 +1172,17 @@ impl Codegen:
         with_hashmap_free(unsafe { *(&raw const self.mir_ref_capture_local_types as *const *mut u8) })
         with_vec_free(&raw mut self.mir_bb_values as *mut u8)
         with_vec_free(&raw mut self.mir_default_unreachable_bbs as *mut u8)
+        // The manual frees above are the sole, curated teardown: they free only
+        // the tables Codegen owns and deliberately skip the shared/aliased
+        // fields (intern↔Backend.pool, decl_source_paths↔caller, the source
+        // strings, the placeholder sema). But `self` is this move fn's terminal
+        // owner, so the compiler schedules a scope-exit `__drop_struct_<Codegen>`
+        // here — a full deep destructor that would (a) double-free every table
+        // just freed and (b) free those shared buffers. (Pre-D22 that auto-drop
+        // was empty, so this went unnoticed; D22 made the container drop glue
+        // real.) Zero self so the guarded auto-drop is a null-safe no-op —
+        // exactly the move-reset the compiler already emits for `deinit`.
+        with_memset(&raw mut self as *mut u8, 0, size_of[Codegen]())
 
     // #685 inc-2: deinit CONSUMES the Codegen — LLVM resources first (they
     // read self), then the table backings via the consuming tail call.

--- a/src/Codegen.w
+++ b/src/Codegen.w
@@ -2217,7 +2217,13 @@ impl Codegen:
         var byval_types: Vec[i64] = Vec.new()
         let byval_types_opt = self.extern_fn_byval_types.get(fn_sym)
         if byval_types_opt.is_some():
-            byval_types = byval_types_opt.unwrap()
+            // D22: `get` yields Option[&Vec]; copy the Copy elements into an
+            // owned Vec rather than aliasing the map's stored value.
+            let bt_src = byval_types_opt.unwrap()
+            var bt_i = 0
+            while bt_i < bt_src.len() as i32:
+                byval_types.push(bt_src.get(bt_i as i64))
+                bt_i = bt_i + 1
         let param_offset = if has_sret != 0: 1 else: 0
         for ai in 0..arg_count:
             var arg_val = args.get(ai as i64)
@@ -2275,7 +2281,13 @@ impl Codegen:
             byval_mask = byval_opt.unwrap() as i64
         let byval_types_opt = self.extern_fn_byval_types.get(fn_sym)
         if byval_types_opt.is_some():
-            byval_types = byval_types_opt.unwrap()
+            // D22: `get` yields Option[&Vec]; copy the Copy elements into an
+            // owned Vec rather than aliasing the map's stored value.
+            let bt_src = byval_types_opt.unwrap()
+            var bt_i = 0
+            while bt_i < bt_src.len() as i32:
+                byval_types.push(bt_src.get(bt_i as i64))
+                bt_i = bt_i + 1
         self.apply_c_abi_call_attrs(call_val, has_sret, sret_ty, byval_mask, byval_types, arg_count, 0)
         if has_sret != 0 and sret_buf != 0 and sret_ty != 0:
             return wl_build_load(self.builder, sret_ty, sret_buf)

--- a/src/CodegenDispatch.w
+++ b/src/CodegenDispatch.w
@@ -3980,7 +3980,12 @@ impl Codegen:
         var byval_types: Vec[i64] = Vec.new()
         let byval_types_opt = self.extern_fn_byval_types.get(concrete.sym)
         if byval_types_opt.is_some():
-            byval_types = byval_types_opt.unwrap()
+            // D22: copy the Copy elements; `get` returns a borrow of the map's Vec.
+            let bt_src = byval_types_opt.unwrap()
+            var bt_i = 0
+            while bt_i < bt_src.len() as i32:
+                byval_types.push(bt_src.get(bt_i as i64))
+                bt_i = bt_i + 1
         self.apply_c_abi_call_attrs(call, 0, 0, byval_mask, byval_types, 1, 0)
 
     mut fn mir_emit_guarded_concrete_drop(ptr: i64, ty: i64, concrete: ConcreteMirFunction):
@@ -14504,13 +14509,21 @@ impl Codegen:
                 abi_byval_mask = bv_opt.unwrap() as i64
             let bvt_opt = self.extern_fn_byval_types.get(callee_fn_sym)
             if bvt_opt.is_some():
-                abi_byval_types = bvt_opt.unwrap()
+                let bvt_src = bvt_opt.unwrap()
+                var bvt_i = 0
+                while bvt_i < bvt_src.len() as i32:
+                    abi_byval_types.push(bvt_src.get(bvt_i as i64))
+                    bvt_i = bvt_i + 1
             let dp_opt = self.extern_fn_direct_params.get(callee_fn_sym)
             if dp_opt.is_some():
                 abi_direct_mask = dp_opt.unwrap() as i64
             let dpt_opt = self.extern_fn_direct_param_types.get(callee_fn_sym)
             if dpt_opt.is_some():
-                abi_direct_types = dpt_opt.unwrap()
+                let dpt_src = dpt_opt.unwrap()
+                var dpt_i = 0
+                while dpt_i < dpt_src.len() as i32:
+                    abi_direct_types.push(dpt_src.get(dpt_i as i64))
+                    dpt_i = dpt_i + 1
             let drt_opt = self.extern_fn_direct_ret_type.get(callee_fn_sym)
             if drt_opt.is_some():
                 abi_direct_ret_ty = drt_opt.unwrap() as i64
@@ -15073,13 +15086,21 @@ impl Codegen:
         var fn_byval_types: Vec[i64] = Vec.new()
         let fn_byval_types_opt = self.extern_fn_byval_types.get(name_sym)
         if fn_byval_types_opt.is_some():
-            fn_byval_types = fn_byval_types_opt.unwrap()
+            let fn_bt_src = fn_byval_types_opt.unwrap()
+            var fn_bt_i = 0
+            while fn_bt_i < fn_bt_src.len() as i32:
+                fn_byval_types.push(fn_bt_src.get(fn_bt_i as i64))
+                fn_bt_i = fn_bt_i + 1
         let fn_direct_mask_opt = self.extern_fn_direct_params.get(name_sym)
         let fn_direct_mask = if fn_direct_mask_opt.is_some(): fn_direct_mask_opt.unwrap() as i64 else: 0
         var fn_direct_types: Vec[i64] = Vec.new()
         let fn_direct_types_opt = self.extern_fn_direct_param_types.get(name_sym)
         if fn_direct_types_opt.is_some():
-            fn_direct_types = fn_direct_types_opt.unwrap()
+            let fn_dt_src = fn_direct_types_opt.unwrap()
+            var fn_dt_i = 0
+            while fn_dt_i < fn_dt_src.len() as i32:
+                fn_direct_types.push(fn_dt_src.get(fn_dt_i as i64))
+                fn_dt_i = fn_dt_i + 1
 
         var method_owner_sym = 0
         for di in 0..name_str.len() as i32:
@@ -15525,13 +15546,21 @@ impl Codegen:
         var fn_byval_types: Vec[i64] = Vec.new()
         let fn_byval_types_opt = self.extern_fn_byval_types.get(mono_sym)
         if fn_byval_types_opt.is_some():
-            fn_byval_types = fn_byval_types_opt.unwrap()
+            let fn_bt_src = fn_byval_types_opt.unwrap()
+            var fn_bt_i = 0
+            while fn_bt_i < fn_bt_src.len() as i32:
+                fn_byval_types.push(fn_bt_src.get(fn_bt_i as i64))
+                fn_bt_i = fn_bt_i + 1
         let fn_direct_mask_opt = self.extern_fn_direct_params.get(mono_sym)
         let fn_direct_mask = if fn_direct_mask_opt.is_some(): fn_direct_mask_opt.unwrap() as i64 else: 0
         var fn_direct_types: Vec[i64] = Vec.new()
         let fn_direct_types_opt = self.extern_fn_direct_param_types.get(mono_sym)
         if fn_direct_types_opt.is_some():
-            fn_direct_types = fn_direct_types_opt.unwrap()
+            let fn_dt_src = fn_direct_types_opt.unwrap()
+            var fn_dt_i = 0
+            while fn_dt_i < fn_dt_src.len() as i32:
+                fn_direct_types.push(fn_dt_src.get(fn_dt_i as i64))
+                fn_dt_i = fn_dt_i + 1
 
         // Detect method owner from mangled name (e.g. "Vec__i32.push")
         var method_owner_sym = 0

--- a/src/Lsp.w
+++ b/src/Lsp.w
@@ -511,7 +511,13 @@ impl LspDocument:
             var methods: Vec[str] = Vec.new()
             let existing = self.cached_trait_methods.get(type_name)
             if existing.is_some():
-                methods = existing.unwrap()
+                // D22: `get` yields Option[&Vec]; copy the Copy str elements
+                // into this owned, later-mutated Vec instead of aliasing.
+                let ex_src = existing.unwrap()
+                var ex_i = 0
+                while ex_i < ex_src.len() as i32:
+                    methods.push(ex_src.get(ex_i as i64))
+                    ex_i = ex_i + 1
             var ti = 0
             while ti < count:
                 let trait_sym = sema.impl_extra.get((start + ti) as i64)
@@ -549,7 +555,15 @@ impl LspDocument:
             return Vec.new()
         let opt = self.cached_trait_methods.get(type_name)
         if opt.is_some():
-            return opt.unwrap()
+            // D22: `get` yields Option[&Vec]; return an independent owned Vec
+            // (copying the Copy str elements) rather than aliasing the cache.
+            var out: Vec[str] = Vec.new()
+            let src = opt.unwrap()
+            var i = 0
+            while i < src.len() as i32:
+                out.push(src.get(i as i64))
+                i = i + 1
+            return out
         Vec.new()
 
     mut fn invalidate():

--- a/src/MirLower.w
+++ b/src/MirLower.w
@@ -8450,13 +8450,12 @@ impl MirBuilder:
         let adjustment = self.sema.contextual_copy_adjustment(arg_node)
         if adjustment.target_type != expected_ty:
             return -1
-        var source = arg_node
-        while self.ast.kind(source) == NodeKind.NK_GROUPED or self.ast.kind(source) == NodeKind.NK_NO_SUSPEND:
-            source = self.ast.get_data0(source)
-        if self.ast.kind(source) == NodeKind.NK_UNARY and self.ast.get_data0(source) == UnaryOp.UOP_REF:
-            return self.body.new_operand(OperandKind.OK_COPY, self.lower_expr_place(self.ast.get_data1(source)))
-        let place = self.lower_expr_place(arg_node)
-        self.body.new_operand(OperandKind.OK_COPY, self.new_deref_place(place))
+        // Delegate to the single guarded materialization path. Duplicating the
+        // lower_expr_place+deref here (without setting materializing_copy_node)
+        // let lower_expr_place's fallback re-enter lower_expr, which materializes
+        // the &V→V copy a second time, then this path dereferenced the resulting
+        // owned value as if it were the &V — reading a bad address.
+        self.materialize_contextual_copy(arg_node)
 
     // D22 Stage 5: materialize the owned Copy pointee of a shared-reference
     // node whose Sema record marks a contextual-Copy adjustment. Reuses the

--- a/src/MirLower.w
+++ b/src/MirLower.w
@@ -11985,7 +11985,7 @@ impl MirBuilder:
                         // never registered; the fn-level frame exposed it.
                         if vc_arg != 0:
                             let vc_arg_drop_ty = if vc_payload_ty != 0: vc_payload_ty else: self.expr_type(vc_arg)
-                            if self.sema.type_needs_drop_frozen(vc_arg_drop_ty) != 0:
+                            if self.sema.is_copy_frozen(vc_arg_drop_ty) == 0:
                                 self.consume_moved_operand(vc_arg_op)
                     let vc_fid = self.body.new_agg_fields(vc_fields, vc_names)
                     let vc_rv = self.body.new_rvalue(RvalueKind.RK_AGGREGATE, 1, vc_fid, vc_variant_idx)
@@ -12160,13 +12160,20 @@ impl MirBuilder:
                 sl_fields.push(f_op)
                 sl_names.push(resolved_name)
                 self.expected_type = saved_expected
-                // #605: a Drop-bearing field value is moved into the aggregate; mark
+                // #605: a non-Copy field value is moved into the aggregate; mark
                 // the source consumed so it is not also dropped at its scope exit
-                // (otherwise its destructor runs twice -> double-free). Gated on a
-                // Drop impl: non-Drop value types are left to copy, which the
-                // codebase relies on to share data across constructions and which is
-                // harmless without a destructor.
-                if self.sema.type_needs_drop_frozen(f_ty) != 0:
+                // (otherwise the buffer it now shares with the aggregate is freed
+                // twice -> double-free). The gate must match the drop scheduler,
+                // which schedules a value drop for every non-Copy local
+                // (is_copy_frozen == 0 in lower_let_binding) — including
+                // compiler-managed heap types (HashMap/Vec/str) that own a buffer
+                // but carry no user Drop impl, so type_needs_drop_frozen reports 0
+                // for them. Gating the consume on type_needs_drop_frozen left those
+                // fields dropped-and-aliased: the exact double-free that blocked
+                // self-host (sema_empty_state and every struct built from moved
+                // non-Copy locals). A genuinely POD non-Copy field gets a no-op
+                // drop that the moved-skip elides — harmless.
+                if self.sema.is_copy_frozen(f_ty) == 0:
                     self.consume_moved_operand(f_op)
             if self.sema.type_decl_nodes.contains(sl_name_sym):
                 let sl_td_node = self.sema.type_decl_nodes.get(sl_name_sym).unwrap()
@@ -12198,7 +12205,7 @@ impl MirBuilder:
                             sl_fields.push(def_op)
                             sl_names.push(decl_field_name)
                             self.expected_type = saved_expected
-                            if self.sema.type_has_drop_impl(decl_field_ty) != 0:
+                            if self.sema.is_copy_frozen(decl_field_ty) == 0:
                                 self.consume_moved_operand(def_op)
             let sl_fid = self.body.new_agg_fields(sl_fields, sl_names)
             let sl_rv = self.body.new_rvalue(RvalueKind.RK_AGGREGATE, 0, sl_fid, 0)
@@ -12273,7 +12280,7 @@ impl MirBuilder:
                 // source so its destructor is not also run at its scope exit (which
                 // would double-free). Paired with the tuple's element-drop
                 // (mir_emit_drop_tuple_ptr) — both land together.
-                if self.sema.type_needs_drop_frozen(elem_ty) != 0:
+                if self.sema.is_copy_frozen(elem_ty) == 0:
                     self.consume_moved_operand(elem_op)
             let tup_fid = self.body.new_agg_fields(tup_fields, tup_names)
             let tup_rv = self.body.new_rvalue(RvalueKind.RK_AGGREGATE, 0, tup_fid, 0)
@@ -12337,7 +12344,7 @@ impl MirBuilder:
                 // #605/#606: move a Drop element into the array; consume the source so
                 // it is not also dropped at scope exit. Paired with the array's
                 // element-drop (mir_emit_drop_array_ptr) — both land together.
-                if self.sema.type_needs_drop_frozen(self.expr_type(elem_node)) != 0:
+                if self.sema.is_copy_frozen(self.expr_type(elem_node)) == 0:
                     self.consume_moved_operand(arr_elem_op)
             let arr_fid = self.body.new_agg_fields(arr_fields, arr_names)
             let arr_rv = self.body.new_rvalue(RvalueKind.RK_AGGREGATE, 0, arr_fid, 0)
@@ -12397,7 +12404,7 @@ impl MirBuilder:
                 // source so it is not also dropped at scope exit. Paired with the
                 // enum's variant-aware payload drop (mir_emit_drop_enum_ptr).
                 let vs_arg_drop_ty = if vs_payload_ty != 0: vs_payload_ty else: self.expr_type(vs_arg)
-                if self.sema.type_needs_drop_frozen(vs_arg_drop_ty) != 0:
+                if self.sema.is_copy_frozen(vs_arg_drop_ty) == 0:
                     self.consume_moved_operand(vs_arg_op)
             let vs_fid = self.body.new_agg_fields(vs_fields, vs_names)
             let vs_rv = self.body.new_rvalue(RvalueKind.RK_AGGREGATE, 1, vs_fid, vs_variant_idx)

--- a/src/MirLower.w
+++ b/src/MirLower.w
@@ -136,6 +136,10 @@ type MirBuilder = ephemeral {
     // call against this exact place. The override is scoped by lower_pipeline.
     pipeline_receiver_override_node: i32,
     pipeline_receiver_override_place: i32,
+    // D22: node currently being contextual-Copy materialized, so the deref
+    // path's re-entry into lower_expr for the same node lowers the exact &V
+    // value instead of recursing into materialization again.
+    materializing_copy_node: i32,
     in_generator: i32,
     generator_yield_count: i32,
 
@@ -214,6 +218,7 @@ fn MirBuilder.init(sema: &Sema, ast: AstPool, pool: InternPool, fn_sym: i32) -> 
         expected_type: 0,
         pipeline_receiver_override_node: 0,
         pipeline_receiver_override_place: -1,
+        materializing_copy_node: 0,
         in_generator: 0,
         generator_yield_count: 0,
         regex_capture_pat_nodes: Vec.new(),
@@ -2171,9 +2176,9 @@ impl MirBuilder:
             let range_inclusive = self.ast.get_data2(node)
             var range_elem = self.sema.ty_i32 as i32
             if range_start != 0:
-                range_elem = self.expr_type(range_start)
+                range_elem = self.materialized_operand_type(range_start)
             else if range_end != 0:
-                range_elem = self.expr_type(range_end)
+                range_elem = self.materialized_operand_type(range_end)
             let range_found = self.sema.find_range_type(range_elem, range_inclusive) as i32
             if range_found != 0:
                 return range_found
@@ -5582,7 +5587,7 @@ impl MirBuilder:
         self.field_move_in_branch = self.field_move_in_branch + 1
         if regex_capture_node != 0:
             self.lower_regex_capture_bindings_from_option(regex_capture_node, regex_captures_opt_place)
-        let then_op = if want_result != 0: self.lower_expr(then_expr) else: self.lower_expr_discard(then_expr)
+        let then_op = if want_result != 0: self.lower_operand_materialized(then_expr) else: self.lower_expr_discard(then_expr)
         if want_result != 0:
             self.assign_operand_to_place(result_place, then_op, self.ast.get_start(then_expr))
         // Reset-on-move (spec §2.5.1): flush this branch's pending source-resets
@@ -5598,7 +5603,7 @@ impl MirBuilder:
         self.switch_to(else_bb)
         self.field_move_in_branch = self.field_move_in_branch + 1
         let else_op = if else_expr_opt != 0:
-            if want_result != 0: self.lower_expr(else_expr_opt) else: self.lower_expr_discard(else_expr_opt)
+            if want_result != 0: self.lower_operand_materialized(else_expr_opt) else: self.lower_expr_discard(else_expr_opt)
         else:
             self.unit_operand()
         if want_result != 0:
@@ -6533,8 +6538,8 @@ impl MirBuilder:
         let elem_ty = self.sema.infer_for_element_type_frozen(self.expr_type(range_node))
 
         // Evaluate start and end
-        let start_op = if start_node != 0: self.lower_expr(start_node) else: self.int_const_operand(0, elem_ty)
-        let end_op = self.lower_expr(end_node)
+        let start_op = if start_node != 0: self.lower_operand_materialized(start_node) else: self.int_const_operand(0, elem_ty)
+        let end_op = self.lower_operand_materialized(end_node)
 
         // Create counter local
         let counter_local = self.new_temp(elem_ty)
@@ -8452,6 +8457,40 @@ impl MirBuilder:
             return self.body.new_operand(OperandKind.OK_COPY, self.lower_expr_place(self.ast.get_data1(source)))
         let place = self.lower_expr_place(arg_node)
         self.body.new_operand(OperandKind.OK_COPY, self.new_deref_place(place))
+
+    // D22 Stage 5: materialize the owned Copy pointee of a shared-reference
+    // node whose Sema record marks a contextual-Copy adjustment. Reuses the
+    // exact call-argument mechanism (OK_COPY of the deref place). The re-entry
+    // guard makes the deref's own place lowering read the exact &V value when a
+    // node kind falls back to value materialization inside lower_expr_place.
+    mut fn materialize_contextual_copy(node: i32) -> i32:
+        var source = node
+        while self.ast.kind(source) == NodeKind.NK_GROUPED or self.ast.kind(source) == NodeKind.NK_NO_SUSPEND:
+            source = self.ast.get_data0(source)
+        if self.ast.kind(source) == NodeKind.NK_UNARY and self.ast.get_data0(source) == UnaryOp.UOP_REF:
+            return self.body.new_operand(OperandKind.OK_COPY, self.lower_expr_place(self.ast.get_data1(source)))
+        let saved = self.materializing_copy_node
+        self.materializing_copy_node = node
+        let place = self.lower_expr_place(node)
+        self.materializing_copy_node = saved
+        self.body.new_operand(OperandKind.OK_COPY, self.new_deref_place(place))
+
+    // Lower an owned-demand operand, materializing a contextual-Copy adjustment
+    // when present. Kept for call sites that lower a specific owned-demand
+    // position (range bounds, if/match joins); lower_expr also materializes
+    // adjusted nodes so every value position is covered uniformly.
+    mut fn lower_operand_materialized(node: i32) -> i32:
+        if node == 0 or self.sema.has_contextual_copy_adjustment(node) == 0:
+            return self.lower_expr(node)
+        self.materialize_contextual_copy(node)
+
+    // The owned value type an owned-demand position observes for `node`: the
+    // materialized Copy pointee when a contextual-Copy adjustment applies,
+    // otherwise the node's exact expression type.
+    mut fn materialized_operand_type(node: i32) -> i32:
+        if node != 0 and self.sema.has_contextual_copy_adjustment(node) != 0:
+            return self.sema.contextual_copy_adjustment(node).owned_value_type
+        self.expr_type(node)
 
     mut fn lower_auto_deref_call_arg(arg_node: i32, expected_ty: i32) -> i32:
         if arg_node == 0 or expected_ty == 0:
@@ -11499,6 +11538,14 @@ impl MirBuilder:
         if node == self.pipeline_receiver_override_node and self.pipeline_receiver_override_place >= 0:
             return self.body.new_operand(OperandKind.OK_COPY, self.pipeline_receiver_override_place)
 
+        // D22 Stage 5: an owned-demand position recorded a contextual-Copy
+        // adjustment on this node (binary/unary operands, receivers, enum
+        // payloads, casts, joins, range bounds, …). Materialize the owned Copy
+        // pointee here so every value position is covered by one MIR path; the
+        // guard lets the deref's place lowering read the exact &V value.
+        if self.materializing_copy_node != node and self.sema.has_contextual_copy_adjustment(node) != 0:
+            return self.materialize_contextual_copy(node)
+
         self.cur_node = node
         let kind = self.ast.kind(node)
 
@@ -12173,11 +12220,11 @@ impl MirBuilder:
             let range_inclusive = self.ast.get_data2(node)
             var range_elem = self.sema.ty_i32 as i32
             if range_start_node != 0:
-                range_elem = self.expr_type(range_start_node)
+                range_elem = self.materialized_operand_type(range_start_node)
             else if range_end_node != 0:
-                range_elem = self.expr_type(range_end_node)
-            let start_op = if range_start_node != 0: self.lower_expr(range_start_node) else: self.int_const_operand(0, range_elem)
-            let end_op = self.lower_expr(range_end_node)
+                range_elem = self.materialized_operand_type(range_end_node)
+            let start_op = if range_start_node != 0: self.lower_operand_materialized(range_start_node) else: self.int_const_operand(0, range_elem)
+            let end_op = self.lower_operand_materialized(range_end_node)
             let incl_op = self.int_const_operand(range_inclusive, self.sema.ty_bool)
             let range_fields: Vec[i32] = Vec.new()
             let range_names: Vec[i32] = Vec.new()

--- a/src/Sema.w
+++ b/src/Sema.w
@@ -3196,10 +3196,11 @@ impl Sema:
                 continue
             let te_start = self.type_d1.get(ti as i64)
             if self.type_extra_matches(te_start, args, arg_count) != 0:
-                // interior-mut cache: HashMap is a stable heap handle, so inserting
-                // through a copy of the handle keeps `self` a read borrow (D7).
-                var gic = self.generic_inst_cache
-                gic.insert(key, ti)
+                // Memoize the resolved instance. Mutate the cache in place; do
+                // NOT bind `self.generic_inst_cache` into a local — that shallow-
+                // copies the handle and schedules a drop that frees `self`'s
+                // buffer at scope end (aliasing XOR mutation; §2.5.1 / D7).
+                self.generic_inst_cache.insert(key, ti)
                 return ti as TypeId
         0 as TypeId
 
@@ -4798,8 +4799,7 @@ impl Sema:
                 return 1
         if self.needs_drop_visit.contains(resolved as i32):
             return 0
-        var __ndv_in = self.needs_drop_visit
-        __ndv_in.insert(resolved as i32)
+        self.needs_drop_visit.insert(resolved as i32)
         var result = 0
         if tk == TypeKind.TY_TUPLE:
             let te_start = self.get_type_d0(resolved)
@@ -4828,8 +4828,7 @@ impl Sema:
                             result = 1
                             break
                     vidx = vidx + 1
-        var __ndv_out = self.needs_drop_visit
-        let _ = __ndv_out.remove(resolved as i32)
+        let _ = self.needs_drop_visit.remove(resolved as i32)
         result
 
     mut fn emit_implicit_drop_view_use_error(view_sym: i32, origin_sym: i32, origin_node: i32):
@@ -6556,8 +6555,7 @@ impl Sema:
             // Break copy-check recursion on cyclic type graphs.
             if self.copy_visit_stack.contains(resolved as i32):
                 return 0
-            var __cvs_in = self.copy_visit_stack
-            __cvs_in.insert(resolved as i32)
+            self.copy_visit_stack.insert(resolved as i32)
 
             var out = 1
             if tk == TypeKind.TY_ARRAY:
@@ -6572,8 +6570,7 @@ impl Sema:
             else: // TypeKind.TY_RANGE
                 out = self.is_copy(self.get_type_d0(resolved))
 
-            var __cvs_out = self.copy_visit_stack
-            let _ = __cvs_out.remove(resolved as i32)
+            let _ = self.copy_visit_stack.remove(resolved as i32)
             return out
         if tk == TypeKind.TY_ENUM:
             // Enums are non-Copy by default; opt-in via `impl Copy for T`.
@@ -6608,8 +6605,7 @@ impl Sema:
             return self.drop_method_cache.get(type_name).unwrap()
 
         let has = self.select_trait_impl(type_name, self.syms.drop)
-        var __dc = self.drop_method_cache
-        __dc.insert(type_name, has)
+        self.drop_method_cache.insert(type_name, has)
         has
 
     fn record_drop_consumed_field(owner_sym: i32, field_sym: i32):

--- a/src/Sema.w
+++ b/src/Sema.w
@@ -5619,12 +5619,14 @@ impl Sema:
             let file_id = self.consume_call_sites.get((i + 3) as i64)
             i = i + 9
             // share-place param: the caller keeps ownership; no transfer needed.
-            // (Only movable named bindings were recorded, so an owned param here is a
-            // genuine ownership transfer that must be made explicit.)
+            // D5 call-site `move` ceremony retired (spec §3.8: a plain call f(x)
+            // is always legal; a consuming signature never requires a redundant
+            // call-site `move`). The transfer is decided by the callee signature,
+            // not by a spelling at the call site, so this site emits no diagnostic.
             if self.sig_param_uses_value_ref_abi(callee_sig, callee_pi) != 0:
                 continue
-            self.local_file_id = file_id
-            self.emit_error("this parameter takes ownership of a non-Copy value (it is consumed or escapes the call); pass `move x` to transfer ownership, or `copy x` for an independent copy (§3.8)", arg_node)
+            let _ = arg_node
+            let _ = file_id
 
     fn get_sig(name: i32) -> i32:
         if self.sig_lookup.contains(name):

--- a/src/Sema.w
+++ b/src/Sema.w
@@ -1349,6 +1349,21 @@ fn sema_clone_i32_vec(values: &Vec[i32]) -> Vec[i32]:
         out.push(values.get(i as i64))
     out
 
+// Deep-clone a HashMap[str, str] so the destination owns independent backing
+// arrays and string payloads. A plain `dst = src.field` only shallow-copies the
+// map header, leaving both maps pointing at one buffer — two owners that
+// double-free at teardown (Zcu.c_import_omitted_symbols aliased into the round's
+// Sema was exactly this bug). Mirrors sema_clone_str_vec's owned-text policy.
+fn sema_clone_str_str_hashmap(src: &HashMap[str, str]) -> HashMap[str, str]:
+    var out: HashMap[str, str] = HashMap.new()
+    let ks = src.keys()
+    for i in 0..ks.len() as i32:
+        let k = ks.get(i as i64)
+        let v = src.get(k)
+        if v.is_some():
+            out.insert(sema_owned_text(k), sema_owned_text(v.unwrap()))
+    out
+
 impl Sema:
     pub move fn prepare_comptime_eval_copy() -> Sema:
         self.type_kinds = sema_clone_i32_vec(&self.type_kinds)

--- a/src/SemaCheck.w
+++ b/src/SemaCheck.w
@@ -8403,6 +8403,26 @@ impl Sema:
             self.emit_error(f"{what} condition must be bool", cond)
         t
 
+    // D22 join: when one branch is an owned Copy value and the other is a
+    // shared reference to the same Copy pointee, the owned branch anchors the
+    // join and the reference arm materializes its pointee. Reference-only joins
+    // (handled elsewhere) keep their references; this only fires when exactly
+    // one owned Copy anchor is present.
+    mut fn join_contextual_copy(then_node: i32, then_ty: i32, else_node: i32, else_ty: i32) -> i32:
+        if then_ty == 0 or else_ty == 0:
+            return 0
+        let then_pointee = self.shared_copy_pointee(then_ty)
+        let else_pointee = self.shared_copy_pointee(else_ty)
+        // then owned Copy, else &then
+        if then_pointee == 0 and else_pointee != 0 and self.is_copy(then_ty as TypeId) != 0:
+            if self.record_contextual_copy_adjustment(else_node, then_ty, else_ty) != 0:
+                return then_ty
+        // else owned Copy, then &else
+        if else_pointee == 0 and then_pointee != 0 and self.is_copy(else_ty as TypeId) != 0:
+            if self.record_contextual_copy_adjustment(then_node, else_ty, then_ty) != 0:
+                return else_ty
+        0
+
     mut fn check_if_expr(node: i32) -> i32:
         let cond = self.ast.get_data0(node)
         let then_body = self.ast.get_data1(node)
@@ -8472,6 +8492,12 @@ impl Sema:
                     result_type = self.preferred_compatible_type(then_type, else_type)
                 else:
                     result_type = self.arithmetic_result_type(then_type, else_type)
+                    if result_type == 0:
+                        // D22 contextual-Copy join: an owned Copy anchor lets a
+                        // compatible &Copy arm materialize to the owned value.
+                        let joined = self.join_contextual_copy(then_body, then_type as i32, else_body, else_type as i32)
+                        if joined != 0:
+                            result_type = joined as TypeId
                     if result_type == 0 and in_value_context:
                         // #549: a value-position if must not silently poison to
                         // <error>. Distinct types compare by base first, so
@@ -12854,8 +12880,19 @@ impl Sema:
         var elem_type: TypeId = self.ty_i32
         if start != 0:
             elem_type = self.check_expr(start)
+            // A range bound is an independently established owned scalar demand.
+            // A shared &Copy bound (e.g. a map `get(k).unwrap()` of a Copy value)
+            // materializes its pointee here; inference of the bound stays exact.
+            let start_pointee = self.shared_copy_pointee(elem_type as i32)
+            if start_pointee != 0:
+                let _ = self.record_contextual_copy_adjustment(start, start_pointee, elem_type as i32)
+                elem_type = start_pointee as TypeId
         if end != 0:
-            let end_ty = self.check_expr(end)
+            var end_ty = self.check_expr(end)
+            let end_pointee = self.shared_copy_pointee(end_ty as i32)
+            if end_pointee != 0:
+                let _ = self.record_contextual_copy_adjustment(end, end_pointee, end_ty as i32)
+                end_ty = end_pointee as TypeId
             if start == 0:
                 elem_type = end_ty
             else if self.types_compatible(elem_type, end_ty) == 0:
@@ -17368,6 +17405,12 @@ impl Sema:
         if owner_sym == self.syms.vec:
             if (field == self.syms.push or field == self.syms.contains) and arg_index == 0:
                 return self.get_generic_inst_arg(resolved as i32, 0)
+            // set_i32(idx: i64, val: i32) is the raw i32-storage setter; its
+            // value operand is always i32. Publish that so an owned-value demand
+            // is established (a shared &i32 argument then materializes its Copy
+            // pointee rather than storing the reference).
+            if field == self.syms.set_i32 and arg_index == 1:
+                return self.ty_i32 as i32
             // `map`/`traverse` closure parameters are the element type; push `fn(elem) -> _`
             // as the expected arg type so the closure param is typed from the Vec's
             // element instead of defaulting to i32 (#306). The closure return is

--- a/src/SemaCheck.w
+++ b/src/SemaCheck.w
@@ -18278,16 +18278,11 @@ impl Sema:
             if self.method_arg_stores_value(obj_type as i32, field, ai) != 0:
                 self.check_ephemeral_task_storage(mc_arg_node, "generic container")
                 // Container stores take ownership of their element just like an
-                // owned function parameter. Builtins have no ordinary signature
-                // for finalize_call_site_ownership to inspect, so enforce D5 at
-                // this semantic boundary instead of silently moving a plain named
-                // binding in MIR. Rvalues need no spelling; `copy` keeps the
-                // source; `move` is invalidated by check_expr itself.
-                let mc_store_arg_kind = self.ast.kind(mc_arg_node)
-                if mc_store_arg_kind != NodeKind.NK_MOVE_ARG and mc_store_arg_kind != NodeKind.NK_COPY_ARG and self.is_copy(mc_arg_ty as TypeId) == 0:
-                    let mc_store_root = self.place_root_sym(mc_arg_node)
-                    if mc_store_root != 0 and self.scope_has(mc_store_root) != 0:
-                        self.emit_error("this parameter takes ownership of a non-Copy value (it is consumed or escapes the call); pass `move x` to transfer ownership, or `copy x` for an independent copy (§3.8)", mc_arg_node)
+                // owned function parameter. D5 call-site `move` ceremony retired
+                // (spec §3.8: a plain call — including a container store like
+                // `xs.push(x)` — is always legal; the consuming signature is
+                // authoritative). No diagnostic here; ownership transfer is
+                // decided by the callee, not by a spelling at the call site.
                 // #625 (viral-escape, decisions.md D2): storing an ephemeral
                 // element propagates its stack view-origins onto the container
                 // binding, so a later escape (return / heap-store / box) of the

--- a/src/SemaCheck.w
+++ b/src/SemaCheck.w
@@ -15215,8 +15215,7 @@ impl Sema:
 
         // Check blanket impls: impl[T: Bound] Trait for T
         if found == 0:
-            var __bg_in = self.blanket_guard
-            __bg_in.insert(key)
+            self.blanket_guard.insert(key)
             for bi in 0..self.blanket_trait_syms.len() as i32:
                 if self.blanket_trait_syms.get(bi as i64) != trait_sym:
                     continue
@@ -15238,11 +15237,9 @@ impl Sema:
                         all_satisfied = 0
                 if all_satisfied != 0:
                     found = 1
-            var __bg_out = self.blanket_guard
-            let _ = __bg_out.remove(key)
+            let _ = self.blanket_guard.remove(key)
 
-        var __sc = self.selection_cache
-        __sc.insert(key, found)
+        self.selection_cache.insert(key, found)
         found
 
     fn subst_vec_lookup(names: &Vec[i32], types: &Vec[i32], name: i32) -> i32:

--- a/src/SemaCheck.w
+++ b/src/SemaCheck.w
@@ -11837,11 +11837,16 @@ impl Sema:
         let index = self.enum_variant_index_for_type(enum_decl, bare_variant_sym)
         if index < 0:
             return -1
+        // Only a qualified (enum-scoped) key may be trusted: disc_values is keyed
+        // by variant name, so a bare-name lookup returns whichever enum registered
+        // that name last. A DiscEnum variant `None = 0` would otherwise shadow
+        // `Option.None` (a payload enum whose implicit discriminant is its index).
+        // Both enum kinds register their qualified variant in variant_lookup, so
+        // qualified_enum_variant_sym always yields the genuine `Enum.Variant` key;
+        // payload enums (no disc_values entry) correctly fall through to `index`.
         let qualified = self.qualified_enum_variant_sym(enum_decl, bare_variant_sym)
         if self.disc_values.contains(qualified):
             return self.disc_values.get(qualified).unwrap()
-        if self.disc_values.contains(bare_variant_sym):
-            return self.disc_values.get(bare_variant_sym).unwrap()
         index
 
     mut fn enum_accessor_return_type(enum_tid: i32, variant_sym: i32, accessor_kind: i32) -> i32:
@@ -19680,12 +19685,12 @@ impl Sema:
         if type_name_sym != 0:
             let qual_name = self.pool_resolve(type_name_sym) ++ "." ++ self.pool_resolve(name_sym)
             // Enum checking interns qualified variants before storing disc_values;
-            // reflection and codegen only look them up.
+            // reflection and codegen only look them up. A bare-name fallback is
+            // unsafe: disc_values is name-keyed, so a DiscEnum `None = 0` would
+            // shadow a payload enum's `Option.None` (implicit disc = index).
             let qual_sym = self.pool_lookup_symbol(qual_name)
             if qual_sym != 0 and self.disc_values.contains(qual_sym):
                 return self.disc_values.get(qual_sym).unwrap() as i64
-        if self.disc_values.contains(name_sym):
-            return self.disc_values.get(name_sym).unwrap() as i64
         variant_index as i64
 
     mut fn type_reflection_variant_payload_type(tid: i32, variant_index: i32, payload_index: i32) -> i32:

--- a/src/SemaCheck.w
+++ b/src/SemaCheck.w
@@ -8488,16 +8488,20 @@ impl Sema:
             else if else_is_never != 0 and then_type != 0:
                 result_type = then_type
             else if then_type != 0 and else_type != 0:
-                if self.types_compatible(then_type as i32, else_type as i32) != 0:
+                // D22 contextual-Copy join FIRST, before ordinary compatibility:
+                // when exactly one arm is an owned Copy anchor and the other a
+                // compatible &Copy view, the view materializes to the owned value
+                // (arm-order-independent). Checking this ahead of types_compatible
+                // prevents preferred_compatible_type from picking the &Copy view as
+                // the join type (which then materializes inconsistently across the
+                // branch/join/return and double-derefs).
+                let joined = self.join_contextual_copy(then_body, then_type as i32, else_body, else_type as i32)
+                if joined != 0:
+                    result_type = joined as TypeId
+                else if self.types_compatible(then_type as i32, else_type as i32) != 0:
                     result_type = self.preferred_compatible_type(then_type, else_type)
                 else:
                     result_type = self.arithmetic_result_type(then_type, else_type)
-                    if result_type == 0:
-                        // D22 contextual-Copy join: an owned Copy anchor lets a
-                        // compatible &Copy arm materialize to the owned value.
-                        let joined = self.join_contextual_copy(then_body, then_type as i32, else_body, else_type as i32)
-                        if joined != 0:
-                            result_type = joined as TypeId
                     if result_type == 0 and in_value_context:
                         // #549: a value-position if must not silently poison to
                         // <error>. Distinct types compare by base first, so

--- a/src/SemaCheck.w
+++ b/src/SemaCheck.w
@@ -367,7 +367,23 @@ impl Sema:
         self.builtin_arg_type_compatible(expected, pointee)
 
     mut fn record_contextual_copy_adjustment(source_node: i32, expected: i32, actual: i32) -> i32:
-        if source_node <= 0 or self.can_contextually_copy_ref(expected, actual) == 0:
+        if source_node <= 0:
+            return 0
+        // D22: value-carriers are transparent to a Copy-view origin. Record the
+        // adjustment on the carried value leaf, never on the carrier node itself.
+        // A carrier that also held an adjustment would be materialized a second
+        // time on top of its leaf's materialization (a double deref of the &V
+        // pointee → a bad-address load). The carrier's type equals its value
+        // leaf's type, so the same demand applies unchanged to the leaf.
+        let sk = self.ast.kind(source_node)
+        if sk == NodeKind.NK_GROUPED or sk == NodeKind.NK_NO_SUSPEND:
+            return self.record_contextual_copy_adjustment(self.ast.get_data0(source_node), expected, actual)
+        if sk == NodeKind.NK_BLOCK:
+            let tail = self.ast.get_data2(source_node)
+            if tail == 0:
+                return 0
+            return self.record_contextual_copy_adjustment(tail, expected, actual)
+        if self.can_contextually_copy_ref(expected, actual) == 0:
             return 0
         let actual_resolved = self.resolve_alias(actual as TypeId)
         let pointee = self.get_type_d0(actual_resolved)
@@ -4926,7 +4942,7 @@ impl Sema:
                     self.emit_error(msg, node)
                     return 0
             return 1
-        if value_path != 0:
+        if value_path != 0 and kind != NodeKind.NK_BLOCK and kind != NodeKind.NK_IF_EXPR and kind != NodeKind.NK_MATCH and kind != NodeKind.NK_MATCH_ARM:
             let actual = self.recorded_expr_type_or_zero(node)
             if actual != 0 and actual != self.ty_void and actual != self.ty_never:
                 if self.expr_mutates_any_current_binding(node) != 0:

--- a/src/compiler/Frontend.w
+++ b/src/compiler/Frontend.w
@@ -1582,7 +1582,7 @@ impl Zcu:
             pre_sema.source_text_file_ids = sema_clone_i32_vec(&self.source_text_file_ids)
             pre_sema.source_text_names = sema_clone_str_vec(&self.source_text_names)
             pre_sema.source_texts = sema_clone_str_vec(&self.source_texts)
-            pre_sema.ci_omitted_symbols = self.c_import_omitted_symbols
+            pre_sema.ci_omitted_symbols = sema_clone_str_str_hashmap(&self.c_import_omitted_symbols)
             pre_sema.tool_mode_entry_path = self.tool_mode_entry_path
             pre_sema.runtime_available = if self.project_config.runtime_available: 1 else: 0
             pre_sema.runtime_fiber_stack_size = self.project_config.runtime_fiber_stack_size
@@ -1606,7 +1606,7 @@ impl Zcu:
             self.source_text_file_ids = sema_clone_i32_vec(&pre_sema.source_text_file_ids)
             self.source_text_names = sema_clone_str_vec(&pre_sema.source_text_names)
             self.source_texts = sema_clone_str_vec(&pre_sema.source_texts)
-            self.c_import_omitted_symbols = pre_sema.ci_omitted_symbols
+            self.c_import_omitted_symbols = sema_clone_str_str_hashmap(&pre_sema.ci_omitted_symbols)
             var tracked_paths = self.tracked_input_paths
             self.tracked_input_paths = tracked_input_merge_unique(move tracked_paths, &pre_sema.tracked_input_paths)
             if self.diagnostics.has_errors() and self.analysis_partial_semantics == 0:
@@ -1637,7 +1637,7 @@ impl Zcu:
         sema.source_text_file_ids = sema_clone_i32_vec(&self.source_text_file_ids)
         sema.source_text_names = sema_clone_str_vec(&self.source_text_names)
         sema.source_texts = sema_clone_str_vec(&self.source_texts)
-        sema.ci_omitted_symbols = self.c_import_omitted_symbols
+        sema.ci_omitted_symbols = sema_clone_str_str_hashmap(&self.c_import_omitted_symbols)
         sema.tool_mode_entry_path = self.tool_mode_entry_path
         sema.runtime_available = if self.project_config.runtime_available: 1 else: 0
         sema.runtime_fiber_stack_size = self.project_config.runtime_fiber_stack_size


### PR DESCRIPTION
## Head self-hosts again: complete D22 contextual-Copy coverage + the latent bugs only self-compilation could expose

### The problem
Since e5c84325, no compiler enforcing head's own semantics could compile head. That commit implemented D21 **and** flipped builtin `HashMap.get` to the D22-normative `Option[&V]` before contextual-materialization coverage existed. The gap was invisible upstream because head is always built by an older, more lenient seed — the first faithful head-semantics self-compile (reachable via the `seed-d17-0c87593c` bootstrap ladder plus a D21 bridge compiler) surfaced 28 errors in compiler source and 135 in the build layer.

### What this branch does (10 commits, each one logical change)
1. **Drops the superseded D5 call-site-move diagnostic** — spec §3.8 states a plain call `f(x)` is always legal; the legacy check contradicted the shipped spec and produced all 135 build-layer errors.
2. **Completes D22 contextual-Copy materialization** for the owned-demand positions head's own source exercises: range bounds, if/match joins (arm-order independent), call arguments (`map.get(k).unwrap()` in Copy position), builtin setters, value-carriers — lowered in one MIR path per the ruling's single-semantic-rule requirement. The `Option[&V]` lookup contract stays exactly as Eric's canonical ruling specifies.
3. **Fixes five latent bugs exposed by self-compilation**: two self-host teardown double-frees (Codegen `dispose_tables`, Zcu `ci_omitted_symbols`); a struct-literal double-free (MIR now consumes moved non-Copy aggregate fields, matching the drop scheduler); enum discriminants resolved enum-scoped (drops the bare-name fallback); and forbidding implicit interior mutability through a read receiver.

### Verification
Full bootstrap chain, machine-verified: bridge compiler → stage1 → stage2 → stage3, with the object-level fixpoint **byte-identical** (`sha256 ccb24687e27642a3…` for both stage2 and stage3 emissions). This is the first post-D21 compiler that compiles its own source under its own rules — the self-host invariant is restored without retracting any ruling.

### Suggested follow-ups (separate work)
- Make "head-semantics stage compiles head source" a hard battery gate so this class of break cannot land silently again.
- Publish a seed release at every semantic flag-day; the linux x86_64 seed built from this branch is ready to publish.
