### PR TITLE
Linux x86_64 self-host: fix IR-object link wall + bootstrap CI

### DIFF
--- a/.github/workflows/selfhost-linux.yml
+++ b/.github/workflows/selfhost-linux.yml
@@ -58,7 +58,9 @@ jobs:
           [ -n "$xml2" ] || xml2="$(ls /lib/x86_64-linux-gnu/libxml2.so.2* 2>/dev/null | head -1)"
           [ -n "$xml2" ] || { echo "no system libxml2.so.2"; exit 1; }
           ln -sf "$xml2" .link-shim/libxml2.so.16
-          "$LLVM_PREFIX/bin/ld.lld" --version
+          # Verify lld runs — it needs the aliased libxml2.so.16 on the search
+          # path, so point LD_LIBRARY_PATH at the shim (as the build steps do).
+          LD_LIBRARY_PATH="$PWD/.link-shim:${LD_LIBRARY_PATH:-}" "$LLVM_PREFIX/bin/ld.lld" --version
 
       - name: Bootstrap seed
         env:

--- a/.github/workflows/selfhost-linux.yml
+++ b/.github/workflows/selfhost-linux.yml
@@ -1,0 +1,91 @@
+name: selfhost (linux x86_64)
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  selfhost-linux:
+    name: selfhost (linux x86_64)
+    runs-on: ubuntu-latest
+    env:
+      WITH_OUT_DIR: ${{ github.workspace }}/out
+      LLVM_PREFIX: ${{ github.workspace }}/.deps/llvm-22.1.6-linux-x86_64
+      # Pre-flip (+187-era) seed carrying the globaldce fix from this branch's
+      # first commit. Tip's build.w requires a str=Copy compiler to run, so the
+      # seed cannot be tip's own stage3 — by design tip is never its own seed.
+      WITH_SEED_REPO: ${{ github.repository }}
+      WITH_SEED_ASSET: with-linux-x86_64
+      WITH_SEED_VERSION: seed-linux-tip-368c81bf
+      WITH_SDK_REPO: withlang-dev/with
+      WITH_SDK_VERSION: v0.15.1
+      WITH_SDK_ASSET: with-llvm-sdk-22.1.6-linux-x86_64.tar.zst
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install host packages
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          # zstd: extract the SDK tarball. dev libs: the compiler link line uses
+          # -lz -lzstd -lxml2 (build/compiler.w), which need the .so dev symlinks.
+          sudo apt-get install -y --no-install-recommends zstd zlib1g-dev libzstd-dev libxml2-dev
+
+      - name: Fetch LLVM SDK
+        run: |
+          set -euo pipefail
+          mkdir -p .deps
+          curl -fL -o /tmp/sdk.tar.zst \
+            "https://github.com/$WITH_SDK_REPO/releases/download/$WITH_SDK_VERSION/$WITH_SDK_ASSET"
+          # asset is .tar.zst; `with build :deps` expects .tar.gz, so extract by hand.
+          zstd -d -c /tmp/sdk.tar.zst | tar -x -C .deps
+          test -d "$LLVM_PREFIX/bin" || { echo "unexpected SDK layout"; ls -la .deps; exit 1; }
+          test -x "$LLVM_PREFIX/bin/lld" || { echo "SDK lld missing"; exit 1; }
+
+      - name: Set up linker shim (SDK lld + libxml2.so.16)
+        run: |
+          set -euo pipefail
+          mkdir -p .link-shim
+          # The seed emits -fuse-ld=lld; expose the SDK's lld under the names the
+          # driver looks for. SDK lld has DT_NEEDED libxml2.so.16 while Ubuntu
+          # ships libxml2.so.2 — ABI-safe for linking (ELF link never calls into
+          # libxml2), so alias it.
+          ln -sf "$LLVM_PREFIX/bin/ld.lld" .link-shim/ld.lld
+          ln -sf "$LLVM_PREFIX/bin/ld.lld" .link-shim/ld64.lld
+          ln -sf "$LLVM_PREFIX/bin/lld"    .link-shim/lld
+          xml2="$(ldconfig -p | awk '/libxml2\.so\.2 /{print $NF; exit}')"
+          [ -n "$xml2" ] || xml2="$(ls /lib/x86_64-linux-gnu/libxml2.so.2* 2>/dev/null | head -1)"
+          [ -n "$xml2" ] || { echo "no system libxml2.so.2"; exit 1; }
+          ln -sf "$xml2" .link-shim/libxml2.so.16
+          "$LLVM_PREFIX/bin/ld.lld" --version
+
+      - name: Bootstrap seed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          curl -fL -o with-seed \
+            "https://github.com/$WITH_SEED_REPO/releases/download/$WITH_SEED_VERSION/$WITH_SEED_ASSET"
+          chmod +x with-seed
+          LD_LIBRARY_PATH="$PWD/.link-shim:${LD_LIBRARY_PATH:-}" ./with-seed version
+
+      - name: Build (seed -> stage1 -> stage2 -> final)
+        env:
+          WITH: ${{ github.workspace }}/with-seed
+        run: |
+          set -euo pipefail
+          export PATH="$PWD/.link-shim:$LLVM_PREFIX/bin:$PATH"
+          export LD_LIBRARY_PATH="$PWD/.link-shim:${LD_LIBRARY_PATH:-}"
+          "$WITH" build
+
+      - name: Fixpoint (stage2.emit == stage3.emit)
+        env:
+          WITH: ${{ github.workspace }}/with-seed
+        run: |
+          set -euo pipefail
+          # Drive :fixpoint with the seed, not ./out/bin/with: the freshly built
+          # tip compiler is post-str-flip and would reject this era's build.w.
+          export PATH="$PWD/.link-shim:$LLVM_PREFIX/bin:$PATH"
+          export LD_LIBRARY_PATH="$PWD/.link-shim:${LD_LIBRARY_PATH:-}"
+          "$WITH" build :fixpoint

--- a/src/Codegen.w
+++ b/src/Codegen.w
@@ -1511,6 +1511,13 @@ impl Codegen:
         self.closure_counter = thunk_id + 1
         let thunk_name = f"__fn_thunk_{thunk_id}"
         let thunk_fn = wl_add_function(self.llmod, thunk_name, thunk_fn_ty)
+        // Anonymous fat-ptr coercion thunk: referenced only by-address at its
+        // creation site (insert_value below), never by name across units. Give
+        // it internal linkage so globaldce can drop it when the coercion is
+        // dead — otherwise a dead thunk keeps its `call @callee` and breaks the
+        // link on targets without default dead-strip (linux gold, no
+        // --gc-sections). This is what lets a dead extern-fn alias DCE cleanly.
+        wl_set_linkage(thunk_fn, wl_internal_linkage())
         // Generate thunk body
         let saved_bb = wl_get_insert_block(self.builder)
         let entry = wl_append_bb(self.context, thunk_fn, "entry")

--- a/src/compiler/LlvmBridge.w
+++ b/src/compiler/LlvmBridge.w
@@ -1592,6 +1592,21 @@ pub fn wl_compile_ir_to_object(source_path: &str, output_path: &str) -> i32:
         LLVMSetModuleDataLayout(m, layout)
         LLVMDisposeTargetData(layout)
         LLVMDisposeMessage(default_triple)
+        // `with ir` emits unoptimized IR, so dead module-level bindings survive as
+        // an internal, unreferenced __with_init_const_* -> __fn_thunk_* -> `call
+        // @<extern>` chain (e.g. the migration-cruft fn-ptr aliases coercing an
+        // unused `extern fn pcre2_regcomp` into a fat pointer). Darwin ld64
+        // `-dead_strip` drops such dead atoms; linux `--gc-sections` works at
+        // section granularity and cannot strip one dead function out of a
+        // monolithic `.text`, so the dead `call` reaches the link as an undefined
+        // symbol. globaldce removes the whole dead chain here, portably — matching
+        // darwin — and touches no live code (dead internal globals are unobservable).
+        let gdce_opts = LLVMCreatePassBuilderOptions()
+        let gdce_err = LLVMRunPasses(m, to_cstr("globaldce"), tm, gdce_opts)
+        if gdce_err as i64 != 0:
+            let gmsg = LLVMGetErrorMessage(gdce_err)
+            if gmsg as i64 != 0: LLVMDisposeErrorMessage(gmsg)
+        LLVMDisposePassBuilderOptions(gdce_opts)
         var out_buf: [4096]u8 = [0 as u8; 4096]
         let out_cstr = path_to_cstr(output_path, &out_buf as *mut u8)
         var emit_err: *mut u8 = 0 as *mut u8


### PR DESCRIPTION
## Linux x86_64 self-host: fix the IR-object link wall + add bootstrap CI

Makes the compiler self-host on **linux x86_64** and adds a CI workflow that
bootstraps the tree from a published seed and verifies byte-identical fixpoint.

### The bug: `undefined symbol: pcre2_regcomp` at link time on Linux

The final compiler link fails on Linux with `undefined pcre2_regcomp`
(also `regexec`/`regfree`/`regerror`). Root cause, traced end to end:

- Dead module-level fn-ptr aliases in `lib/std/re/defs.w`
  (`let PCRE2regcomp = pcre2_regcomp`, …) coerce the thin `extern fn`
  C decls into With's **fat fn-ptr** type. Each coercion emits an anonymous
  `__fn_thunk_N` whose body is `call @pcre2_regcomp`.
- Those thunks were emitted with **external** linkage, so `globaldce` cannot
  drop them even though nothing references them.
- The regex runtime object is built through `with ir` →
  `wl_compile_ir_to_object`, the **one** object path that never runs an
  optimization pass — so `globaldce` never even ran on it.
- The dead `call @pcre2_regcomp` therefore reaches the linker. Darwin ld64
  `-dead_strip` is atom-granular and drops it (why macOS self-hosts today);
  Linux emits a monolithic `.text`, so section-granular `--gc-sections`
  cannot strip one dead function out of a live section → link fails.

### The fix (`codegen: strip dead fat-ptr coercion thunks…`)

Two changes, both root-cause:

1. Give the anonymous fat-ptr coercion thunks **internal** linkage in
   `Codegen.w` (they are referenced only by-address at their SSA creation
   site, never by name across units), so `globaldce` is allowed to drop them.
2. Run `globaldce` in `wl_compile_ir_to_object` (`LlvmBridge.w`) before emit,
   so the IR-object path gets the same dead-code elimination every
   `with_object_target` already gets via `default<O1>`.

Together, the dead pcre2 chain is stripped portably at compile time on all
targets. No source is deleted; the aliases stay, they just no longer drag a
dead extern reference into the object. macOS behavior is unchanged.

### CI: `selfhost (linux x86_64)`

New `.github/workflows/selfhost-linux.yml`: fetches the LLVM SDK, bootstraps
from the published linux seed, runs `with build` (seed → stage1 → stage2 →
final), then `with build :fixpoint` (`stage2.emit == stage3.emit`).

Verified green: https://github.com/ropoctl/with/actions/runs/31804648685
(Build ✓, Fixpoint ✓).

### Notes

- The seed is a dedicated release asset, not this tip's own stage3: `main`'s
  `build.w` reuses `tag: str` and requires a pre-flip (str=Copy) compiler to
  run, so by design the tip is never its own seed.
- The workflow aliases the SDK lld's `libxml2.so.16` soname to the system
  `libxml2.so.2` — safe because lld's ELF driver never calls into libxml2
  (its only libxml2 use is COFF/Windows manifest merging). A follow-up can
  drop the dep entirely by building the SDK with `LLVM_ENABLE_LIBXML2=OFF`.
