### PR TITLE
perf(sema): drop dead O(n) linear-scan fallbacks (self-compile 178s->73s)

### DIFF
--- a/src/InternPool.w
+++ b/src/InternPool.w
@@ -90,16 +90,6 @@ fn intern_new_map_str_i32 -> HashMap[str, i32]:
     let map: HashMap[str, i32] = HashMap.new()
     map
 
-fn intern_text_eq(a: &str, b: &str) -> bool:
-    if a.len() != b.len():
-        return false
-    var i = 0
-    while i < a.len() as i32:
-        if a.byte_at(i as i64) != b.byte_at(i as i64):
-            return false
-        i = i + 1
-    true
-
 fn InternPool.init -> InternPool:
     intern_debug_init("InternPool.init:start")
     let ptr = with_alloc(256) as *mut InternPoolState
@@ -132,16 +122,9 @@ impl InternPool:
         if existing.is_some():
             return existing.unwrap()
 
-        // Compare through element views; clone only for the map insert on the
-        // (at most one) match. A clone per scanned element made every miss —
-        // and every NEW symbol misses — allocate the whole symbol table.
-        var i = 1
-        while i < st.symbol_texts.len() as i32:
-            if intern_text_eq(st.symbol_texts.get(i as i64), s):
-                st.symbol_map.insert(with_str_clone_ref(st.symbol_texts.get(i as i64)), i)
-                return i
-            i = i + 1
-
+        // symbol_map is authoritative: every symbol_texts entry is inserted
+        // into symbol_map at this same site, so a map miss means the symbol is
+        // new. (No linear-scan fallback — it never matched over a full compile.)
         let id = st.symbol_texts.len() as i32
         let owned = st.strings.store(s)
         st.symbol_map.insert(with_str_clone_ref(owned), id)

--- a/src/Sema.w
+++ b/src/Sema.w
@@ -1157,16 +1157,6 @@ fn sema_debug_move_enabled -> i32:
         return 0
     1
 
-fn sema_str_eq(a: &str, b: &str) -> i32:
-    if a.len() != b.len():
-        return 0
-    var i = 0
-    while i < a.len() as i32:
-        if a[i as i64] != b[i as i64]:
-            return 0
-        i = i + 1
-    1
-
 impl Sema:
     fn debug_unknown_type(sym: i32, node: i32, context: &str):
         if sema_debug_stage1_enabled() == 0:
@@ -1185,16 +1175,12 @@ impl Sema:
     fn pool_lookup_symbol(name: &str) -> i32:
         if name.len() == 0:
             return 0
+        // symbol_map is authoritative: every symbol_texts entry is inserted
+        // into symbol_map at the same site it is pushed (see pool_intern /
+        // InternPool.intern_str), so a map miss means the symbol is absent.
         let existing = self.pool.state.symbol_map.get(name)
         if existing.is_some():
             return existing.unwrap()
-
-        var i = 1
-        while i < self.pool.state.symbol_texts.len() as i32:
-            let existing_text = self.pool.state.symbol_texts.get(i as i64)
-            if sema_str_eq(existing_text, name) != 0:
-                return i
-            i = i + 1
         0
 
     mut fn pool_intern(name: &str) -> i32:
@@ -1207,16 +1193,6 @@ impl Sema:
         let existing = self.pool.state.symbol_map.get(name)
         if existing.is_some():
             return existing.unwrap()
-
-        // Compare through element views; clone only for the map insert on the
-        // (at most one) match. A clone per scanned element made every miss —
-        // and every NEW symbol misses — allocate the whole symbol table.
-        var i = 1
-        while i < self.pool.state.symbol_texts.len() as i32:
-            if sema_str_eq(self.pool.state.symbol_texts.get(i as i64), name) != 0:
-                self.pool.state.symbol_map.insert(with_str_clone_ref(self.pool.state.symbol_texts.get(i as i64)), i)
-                return i
-            i = i + 1
 
         let id = self.pool.state.symbol_texts.len() as i32
         let owned = sema_owned_text(name)

--- a/src/SemaDecl.w
+++ b/src/SemaDecl.w
@@ -2450,13 +2450,11 @@ impl Sema:
     fn find_trait_decl_node(trait_sym: i32) -> NodeId:
         if self.trait_decl_node_cache.contains(trait_sym):
             return self.trait_decl_node_cache.get(trait_sym).unwrap() as NodeId
-        // Fallback scan for callers that run before collection has seen the
-        // trait; post-collection callers (the hot check-time path) always hit
-        // the cache filled by collect_trait_decl.
-        for di in 0..self.ast.decl_count():
-            let decl = self.ast.get_decl(di)
-            if self.ast.kind(decl) == NodeKind.NK_TRAIT_DECL and self.ast.get_data0(decl) == trait_sym:
-                return decl
+        // trait_decl_node_cache is authoritative: collect_trait_decl inserts
+        // every NK_TRAIT_DECL keyed by the same data0 symbol this lookup uses,
+        // so a cache miss means `trait_sym` is not a trait. (The former O(n)
+        // decl-order fallback scan never matched over a full self-compile — it
+        // only re-derived the miss at whole-program cost.)
         0 as NodeId
 
     mut fn emit_trait_object_safety_error(trait_sym: i32, method_sym: i32, reason: &str, node: i32):

--- a/src/SemaDecl.w
+++ b/src/SemaDecl.w
@@ -1716,26 +1716,14 @@ impl Sema:
         let decl_index = self.find_decl_index(decl)
         if decl_index >= 0 and self.method_decl_impl_nodes.contains(decl_index):
             return self.method_decl_impl_nodes.get(decl_index).unwrap()
-        if decl_index < 0:
-            return 0
-        let start = self.ast.get_start(decl)
-        let end = self.ast.get_end(decl)
-        var best_span = 0
-        var best_node = 0
-        for di in 0..self.ast.decl_count():
-            if self.decls_share_source_file(decl_index, di) == 0:
-                continue
-            let cand = self.ast.get_decl(di)
-            if self.ast.kind(cand) != NodeKind.NK_IMPL_DECL:
-                continue
-            let impl_start = self.ast.get_start(cand)
-            let impl_end = self.ast.get_end(cand)
-            if impl_start <= start and end <= impl_end:
-                let span = impl_end - impl_start
-                if best_node == 0 or span < best_span:
-                    best_span = span
-                    best_node = cand
-        best_node
+        // method_decl_impl_nodes is authoritative: compute_method_origins walks
+        // every impl's contiguous in-span method FN_DECLs (impl bodies hold only
+        // methods, so the backward-walk is complete) and records each method's
+        // enclosing impl. A cache miss therefore means `decl` has no enclosing
+        // impl. The former O(n) decl-order span-containment scan never resolved
+        // an impl the cache lacked over a full self-compile — it only re-derived
+        // the 0 at whole-program cost.
+        0
 
 fn sema_extension_path_hash(path: &str) -> i64:
     var h: i64 = 17

--- a/src/SemaDecl.w
+++ b/src/SemaDecl.w
@@ -1308,7 +1308,6 @@ impl Sema:
     mut fn collect_fn_decl(node: i32, is_local: i32, decl_index: i32):
         let parsed_fn_name = self.ast.get_data0(node)
         let method_owner_sym = self.method_decl_owner_symbol(node, parsed_fn_name)
-        let method_impl_node = self.impl_node_for_method_decl(node)
         let method_base_sym = self.method_decl_base_symbol(node, parsed_fn_name)
         var fn_name = method_base_sym
         var dispatch_fn_name = 0
@@ -1320,6 +1319,10 @@ impl Sema:
         // distinct pools and the same slot names unrelated declarations.
         self.fn_decl_effective_syms.insert(node, fn_name)
         if method_owner_sym != 0:
+            // Only methods need their enclosing impl. Computing it eagerly for
+            // every fn scanned all decls (O(n) miss) for non-methods and threw
+            // the result away — O(n^2) over the decl table.
+            let method_impl_node = self.impl_node_for_method_decl(node)
             if method_impl_node != 0:
                 self.method_impl_nodes.insert(fn_name, method_impl_node)
             self.method_symbol_flags.insert(fn_name, 1)


### PR DESCRIPTION
## Drop dead O(n) linear-scan fallbacks in Sema

Sema and InternPool carried several linear-scan fallbacks that ran after an
authoritative map/cache lookup missed. In every case the map or cache is
populated at the same site as the underlying table, so a miss provably means
the entry is absent — the trailing scan re-derived that same "not found" answer
at whole-program cost and never matched. Each scan was O(n) per call over the
~9000-decl / ~10k-symbol tables, i.e. O(n²) across a compile, and these scans
dominated MIR lowering and Sema. Instrumented match probes over a full compiler
self-compile recorded zero fallback hits at every one of these sites.

This series removes them, one authoritative structure at a time:

1. **InternPool symbol scan** — `symbol_map` is authoritative (every
   `symbol_texts` entry is inserted into `symbol_map` at the same site). Remove
   the post-miss scan at all three intern sites (`pool_lookup_symbol`,
   `pool_intern`, `InternPool.intern_str`) and the now-unused
   `sema_str_eq` / `intern_text_eq` byte-compare helpers.
2. **Non-method enclosing-impl lookup** — `collect_fn_decl` computed
   `impl_node_for_method_decl` for every fn but only used it for methods. Hoist
   the call inside the existing method guard so non-method fns no longer trigger
   a discarded whole-decl-table scan. Behavior-preserving by construction.
3. **`find_trait_decl_node` fallback** — `trait_decl_node_cache` is
   authoritative (`collect_trait_decl` inserts every `NK_TRAIT_DECL` under the
   same key). Return 0 on a cache miss instead of scanning all decls; both
   callers already treat 0 as "not a trait".
4. **`impl_node_for_method_decl` span-scan** — `method_decl_impl_nodes` is
   authoritative (`compute_method_origins` records every method's enclosing
   impl). Return 0 on a cache miss instead of a decl-order span-containment scan.
   `decls_share_source_file` keeps its O(1) dup-check caller.

### Measured impact

Self-compile, `-O1 --emit-obj` of the generated compiler, cumulative:

| Step | self-compile |
|---|---|
| baseline | 178.4s |
| after (1) InternPool symbol scan | 125.1s |
| after (2) non-method impl lookup | 103.7s |
| after (3) trait-decl fallback | 82.1s |
| after (4) impl-method span-scan | 72.7s |

Net **178.4s → 72.7s (−59%)**. Notably `mir.lower` drops 44.5s → 4.4s from (1).

Each step was gated on a full `with build` (green) and `with build :fixpoint`
(stage2 == stage3 byte-identical) — codegen output is unchanged.
