### PR TITLE
CI: run the full green battery (build :test) on linux presubmit

### DIFF
--- a/.github/workflows/selfhost-linux.yml
+++ b/.github/workflows/selfhost-linux.yml
@@ -1,4 +1,4 @@
-name: selfhost (linux x86_64)
+name: green battery (linux x86_64)
 
 on:
   push:
@@ -6,8 +6,11 @@ on:
 
 jobs:
   selfhost-linux:
-    name: selfhost (linux x86_64)
+    name: green battery (linux x86_64)
     runs-on: ubuntu-latest
+    # The full battery (seed bootstrap + build + fixpoint + :test) is longer than
+    # the bare self-host check; give it headroom on the shared runner.
+    timeout-minutes: 180
     env:
       WITH_OUT_DIR: ${{ github.workspace }}/out
       LLVM_PREFIX: ${{ github.workspace }}/.deps/llvm-22.1.6-linux-x86_64
@@ -91,3 +94,23 @@ jobs:
           export PATH="$PWD/.link-shim:$LLVM_PREFIX/bin:$PATH"
           export LD_LIBRARY_PATH="$PWD/.link-shim:${LD_LIBRARY_PATH:-}"
           "$WITH" build :fixpoint
+
+      - name: Green battery (build :test — behavior/native/cli/deep-debug/alloc + audit:all)
+        env:
+          WITH: ${{ github.workspace }}/with-seed
+        run: |
+          set -euo pipefail
+          # The standing green battery. `:test` is a Group target that runs the
+          # behavior, native compile-error/codegen/spec/phase, comptime-diff,
+          # debug-alloc, lexer/parser/internals, deep-debug-tool (which itself
+          # asserts `analyze audit:all` + `audit:storage`), CLI self-host, and
+          # c-migrator suites, then records `test-green` evidence.
+          #
+          # Driven with the seed for the same reason as :build/:fixpoint above:
+          # the freshly built tip compiler is post-str-flip and cannot run this
+          # era's build.w. The seed runs build.w, whose test actions invoke the
+          # already-built out/release/bin/with on the fixtures (no rebuild — the
+          # build step above populated the cache).
+          export PATH="$PWD/.link-shim:$LLVM_PREFIX/bin:$PATH"
+          export LD_LIBRARY_PATH="$PWD/.link-shim:${LD_LIBRARY_PATH:-}"
+          "$WITH" build :test

--- a/build/selfhost.w
+++ b/build/selfhost.w
@@ -4283,9 +4283,12 @@ fn bs_check_migrate_macro_body_string_literal(ctx: &ActionCtx, compiler_path: &s
     let result = bs_migrate_expect_success(ctx, compiler_path, case_dir, "migrate-macro-body-string-literal", args)
     if result.rc != 0: return result.rc
     let out_text = ctx.fs().read_text(out_w)
-    rc = bs_assert_contains(ctx, out_text, "fprintf(__stderrp, c\"%s error: %d\\n\".ptr, \"compress\", __param_err)", "macro_body_string_literal")
+    // The migrator emits the target's stdio-global spelling verbatim: Darwin's
+    // headers macro-expand stderr to __stderrp, glibc's stay stderr.
+    let stderr_sym = if os() == "Macos": "__stderrp" else: "stderr"
+    rc = bs_assert_contains(ctx, out_text, "fprintf(" ++ stderr_sym ++ ", c\"%s error: %d\\n\".ptr, \"compress\", __param_err)", "macro_body_string_literal")
     if rc != 0: return rc
-    rc = bs_assert_not_contains(ctx, out_text, "fprintf(__stderrp, c\"compress\".ptr", "macro_body_string_literal")
+    rc = bs_assert_not_contains(ctx, out_text, "fprintf(" ++ stderr_sym ++ ", c\"compress\".ptr", "macro_body_string_literal")
     if rc != 0: return rc
     var check_args: Vec[str] = Vec.new()
     check_args |> push("check")

--- a/lib/std/libc.w
+++ b/lib/std/libc.w
@@ -14,6 +14,15 @@ pub extern var __stdinp: *mut c_void
 pub extern var __stdoutp: *mut c_void
 pub extern var __stderrp: *mut c_void
 
+// glibc stdio globals. These are the names produced by the Linux headers
+// (stdin/stdout/stderr are the real exported symbols; the macros expand to
+// themselves). Migrated output is target-specific, so only the target's set
+// is ever referenced — the other set stays an unreferenced extern and forces
+// no link resolution.
+pub extern var stdin: *mut c_void
+pub extern var stdout: *mut c_void
+pub extern var stderr: *mut c_void
+
 extern fn rt_libc_stdin() -> *mut c_void
 extern fn rt_libc_stdout() -> *mut c_void
 extern fn rt_libc_stderr() -> *mut c_void

--- a/rt/rt_core.w
+++ b/rt/rt_core.w
@@ -542,6 +542,17 @@ fn rt_payload_start_is_owned(ptr: *const u8) -> i32:
     if ptr as i64 == 0:
         return 0
     let payload = ptr as i64
+    // A valid owned payload starts at least RT_ALLOC_HEADER_SIZE bytes above 0
+    // (its header sits just below it). By signed-i64 comparison this also
+    // rejects non-canonical high-half addresses (which read as negative) — the
+    // slab tables and their binary searches all assume positive addresses, so a
+    // negative pointer is definitionally not owned. Rejecting here keeps the
+    // `payload - RT_ALLOC_HEADER_SIZE` below from a signed-underflow trap on
+    // garbage bytes: codegen emits discriminant-independent str-drops (see the
+    // drop-architecture note) and relies on this guard to no-op — never trap —
+    // on any non-owned slot content, blanked or not.
+    if payload < RT_ALLOC_HEADER_SIZE:
+        return 0
     let header = payload - RT_ALLOC_HEADER_SIZE
     // Binary-search the sorted slab ranges for the one with the largest start <=
     // header (ranges are non-overlapping, so at most one can contain header).

--- a/runtime/fiber_asm_linux_x86_64.s
+++ b/runtime/fiber_asm_linux_x86_64.s
@@ -47,7 +47,14 @@ with_fiber_prepare_initial_context:
 .globl with_fiber_start
 .p2align 4
 with_fiber_start:
-    subq $32, %rsp
+    // Entry rsp ≡ 8 (mod 16): prepare_initial_context sets rsp = (top & -16) - 8,
+    // a fake post-call frame. SysV requires each callee be entered at rsp ≡ 8
+    // (mod 16) so its first stack `movaps` hits a 16-aligned slot. A `call`
+    // pushes 8, so rsp must be ≡ 0 (mod 16) *before* the call. Subtract 24
+    // (≡ 8 mod 16): 8 - 8 ≡ 0, and 24 bytes still covers the three 8-byte
+    // out-slots at 0/8/16. (The old `subq $32` left rsp ≡ 8, entering the async
+    // trampoline at ≡ 0 — misaligned by 8, faulting the body's `movaps`.)
+    subq $24, %rsp
     movq %rsp, %rdi
     leaq 8(%rsp), %rsi
     leaq 16(%rsp), %rdx

--- a/runtime/fiber_asm_x86_64.s
+++ b/runtime/fiber_asm_x86_64.s
@@ -62,7 +62,13 @@ with_fiber_prepare_initial_context:
 .globl _with_fiber_start
 .p2align 4
 _with_fiber_start:
-    subq $32, %rsp
+    // Entry rsp ≡ 8 (mod 16) from prepare_initial_context's (top & -16) - 8.
+    // SysV requires callees be entered at rsp ≡ 8 so their first stack `movaps`
+    // is 16-aligned; a `call` pushes 8, so rsp must be ≡ 0 before the call.
+    // Subtract 24 (≡ 8 mod 16), not 32 (≡ 0): 32 left rsp ≡ 8, entering the
+    // async trampoline at ≡ 0 and faulting the body's `movaps`. 24 still covers
+    // the three 8-byte out-slots at 0/8/16.
+    subq $24, %rsp
     movq %rsp, %rdi
     leaq 8(%rsp), %rsi
     leaq 16(%rsp), %rdx

--- a/src/CImport.w
+++ b/src/CImport.w
@@ -6343,6 +6343,24 @@ impl CiTypePool:
                 i = i + 1
             return self.ty_fn_ptr(ret_ty, params_start, arg_count)
 
+        // Aggregate `va_list` (glibc/aarch64 `__va_list_tag[N]`) has no
+        // spellable field layout, so the bridge demotes it to `c_void` —
+        // which `check` rejects as a value type, breaking every migrated
+        // variadic function. LLVM's `llvm.va_start`/`va_end` only need
+        // correctly-sized storage, so lower it to a `[u8; N]` buffer sized
+        // to the target's actual va_list. Detection is structural: the
+        // canonical type is an array whose element record is `__va_list_tag`
+        // — target-independent, and Darwin's `char*` va_list never reaches
+        // here (it lowers through the CXT_Pointer path above).
+        let va_canon = with_ci_type_canonical(session, cxtype)
+        if va_canon >= 0 and with_ci_type_kind(session, va_canon) == CXT_ConstantArray:
+            let va_elem = with_ci_type_array_element(session, va_canon)
+            if va_elem >= 0 and ci_str_contains(with_ci_type_spelling(session, va_elem), "__va_list_tag"):
+                let va_size = with_ci_type_sizeof(session, cxtype) as i32
+                if va_size > 0:
+                    let u8_idx = self.add_string("u8")
+                    return self.ty_array(self.ty_named(u8_idx), va_size)
+
         // Typedef, elaborated, atomic, and other named wrappers.
         // Normalize builtin typedef spellings so C names like size_t do
         // not leak into generated With type positions.
@@ -15579,6 +15597,9 @@ fn ci_is_libm_fn(name: &str) -> bool:
 fn ci_libc_symbol_kind_mask(name: &str) -> i32:
     if name == "rlimit": return CI_LIBC_KIND_TYPE
     if name == "__stdinp" or name == "__stdoutp" or name == "__stderrp": return CI_LIBC_KIND_VAR
+    // glibc spells the stdio globals stdin/stdout/stderr (Darwin uses the
+    // __std*p forms above). std.libc exposes both target surfaces.
+    if name == "stdin" or name == "stdout" or name == "stderr": return CI_LIBC_KIND_VAR
     if name == "fprintf" or name == "printf" or name == "snprintf" or name == "sprintf": return CI_LIBC_KIND_FN
     if name == "vsnprintf": return CI_LIBC_KIND_FN
     if name == "fopen" or name == "fclose" or name == "fflush" or name == "fileno": return CI_LIBC_KIND_FN

--- a/src/compiler/ClangBridge.w
+++ b/src/compiler/ClangBridge.w
@@ -1240,6 +1240,11 @@ pub fn with_cimport_parse(header_code: &str) -> i64:
         nargs = nargs + 1
         args[nargs as i64] = "c\0" as *const u8
         nargs = nargs + 1
+        // libclang defaults to strict-ANSI C (unlike the clang driver's gnu
+        // dialect); _DEFAULT_SOURCE restores glibc's ordinary POSIX/BSD surface
+        // (realpath, mkstemp, ...). Inert on Darwin/Windows headers.
+        args[nargs as i64] = "-D_DEFAULT_SOURCE\0" as *const u8
+        nargs = nargs + 1
         var ip: i32 = 0
         while ip < g_cimport_include_count and nargs < 62:
             args[nargs as i64] = "-I\0" as *const u8
@@ -2322,6 +2327,11 @@ unsafe fn cimport_collect_macros_from_libclang(ms: *mut MacroSession, header_cod
     nargs = nargs + 1
     args[nargs as i64] = "c\0" as *const u8
     nargs = nargs + 1
+    // libclang defaults to strict-ANSI C (unlike the clang driver's gnu
+    // dialect); _DEFAULT_SOURCE restores glibc's ordinary POSIX/BSD surface
+    // (realpath, mkstemp, ...). Inert on Darwin/Windows headers.
+    args[nargs as i64] = "-D_DEFAULT_SOURCE\0" as *const u8
+    nargs = nargs + 1
     var ip: i32 = 0
     while ip < g_cimport_include_count and nargs < 62:
         args[nargs as i64] = "-I\0" as *const u8
@@ -2413,6 +2423,11 @@ pub fn with_cimport_collect_object_macro_types(header_code: &str, macro_names: &
         nargs = nargs + 1
         args[nargs as i64] = "c\0" as *const u8
         nargs = nargs + 1
+        // libclang defaults to strict-ANSI C (unlike the clang driver's gnu
+        // dialect); _DEFAULT_SOURCE restores glibc's ordinary POSIX/BSD surface
+        // (realpath, mkstemp, ...). Inert on Darwin/Windows headers.
+        args[nargs as i64] = "-D_DEFAULT_SOURCE\0" as *const u8
+        nargs = nargs + 1
         var ip: i32 = 0
         while ip < g_cimport_include_count and nargs < 62:
             args[nargs as i64] = "-I\0" as *const u8
@@ -2496,6 +2511,11 @@ pub fn with_cimport_parse_macro_probe(header_code: &str, macro_name: &str) -> i6
         args[nargs as i64] = "-x\0" as *const u8
         nargs = nargs + 1
         args[nargs as i64] = "c\0" as *const u8
+        nargs = nargs + 1
+        // libclang defaults to strict-ANSI C (unlike the clang driver's gnu
+        // dialect); _DEFAULT_SOURCE restores glibc's ordinary POSIX/BSD surface
+        // (realpath, mkstemp, ...). Inert on Darwin/Windows headers.
+        args[nargs as i64] = "-D_DEFAULT_SOURCE\0" as *const u8
         nargs = nargs + 1
         var ip: i32 = 0
         while ip < g_cimport_include_count and nargs < 62:

--- a/src/main.w
+++ b/src/main.w
@@ -76,6 +76,7 @@ extern fn exit(code: i32) -> Unit
 extern fn with_install_interrupt_handlers() -> Unit
 extern fn with_raise_stack_limit() -> Unit
 extern fn with_sysinfo_os() -> str
+extern fn with_sysinfo_arch() -> str
 
 enum PreludeMode: i32:
     FullMode = 0
@@ -2870,6 +2871,19 @@ fn test_parse_i32(text: &str) -> i32:
         i = i + 1
     value * sign
 
+fn test_arch_is_aarch64(arch: &str) -> bool:
+    arch == "aarch64" or arch == "armv8" or arch == "arm64"
+
+fn test_arch_is_x86_64(arch: &str) -> bool:
+    arch == "x86_64" or arch == "amd64" or arch == "x64"
+
+fn test_arch_matches(required: &str, host: &str) -> bool:
+    // Canonicalize the ISA spellings the runtime and directives may use so a
+    // `requires-arch: aarch64` gate also matches an "armv8"/"arm64" host.
+    if test_arch_is_aarch64(required): return test_arch_is_aarch64(host)
+    if test_arch_is_x86_64(required): return test_arch_is_x86_64(host)
+    required == host
+
 fn parse_test_directives_for_target(target: &str) -> TestDirectives:
     var result = empty_test_directives()
     let text = with_fs_read_file(target)
@@ -2888,6 +2902,7 @@ fn parse_test_directives_for_target(target: &str) -> TestDirectives:
     let args_prefix = "//! args: "
     let skip_prefix = "//! skip: "
     let skip_windows_prefix = "//! skip-windows: "
+    let requires_arch_prefix = "//! requires-arch: "
     let known_issue_prefix = "//! known-issue: "
     var start = 0
     var i = 0
@@ -2926,6 +2941,14 @@ fn parse_test_directives_for_target(target: &str) -> TestDirectives:
                 if with_sysinfo_os() == "Windows":
                     result.skip = true
                     result.skip_reason = line.slice(skip_windows_prefix.len(), line.len())
+                    return result
+            else if line.starts_with(requires_arch_prefix):
+                // Arch-specific test (e.g. inline asm hardcoding one ISA's
+                // registers). Runs only on the named arch; skipped elsewhere.
+                let required = line.slice(requires_arch_prefix.len(), line.len())
+                if not test_arch_matches(required, with_sysinfo_arch()):
+                    result.skip = true
+                    result.skip_reason = "requires-arch " ++ required
                     return result
             else if line == "//! skip":
                 result.skip = true

--- a/test/behavior/behav_asm_clobbers.w
+++ b/test/behavior/behav_asm_clobbers.w
@@ -1,4 +1,5 @@
 //! expect-stdout: ok
+//! requires-arch: aarch64
 // §16: an asm block's 4th section lists clobbered registers.
 fn main:
     let v: i64 = 21

--- a/test/behavior/behav_asm_multi_output.w
+++ b/test/behavior/behav_asm_multi_output.w
@@ -1,4 +1,5 @@
 //! expect-stdout: ok
+//! requires-arch: aarch64
 
 // §16.13 multiple outputs surface as a tuple. aarch64 host.
 

--- a/test/behavior/behav_asm_placeholder.w
+++ b/test/behavior/behav_asm_placeholder.w
@@ -1,4 +1,5 @@
 //! expect-stdout: ok
+//! requires-arch: aarch64
 
 // §16.13 {name} placeholder substitution. aarch64 host: x0 output, x1 input.
 

--- a/test/compile_errors/err_target_excluded_symbol_use.w
+++ b/test/compile_errors/err_target_excluded_symbol_use.w
@@ -1,8 +1,11 @@
 //! expect-error: undefined variable
+//! requires-arch: aarch64
 
 // A function guarded for a non-active architecture is excluded entirely;
-// referencing it fails loudly rather than producing wrong-target code.
-// (aarch64 host assumed.)
+// referencing it fails loudly rather than producing wrong-target code. On an
+// aarch64 host the x86_64-guarded symbol is excluded, so the reference is
+// undefined. (The mirror err_target_excluded_symbol_use_x86_64.w covers the
+// x86_64 host with an aarch64-guarded symbol.)
 
 @[target("x86_64")]
 fn only_on_x86() -> i32:

--- a/test/compile_errors/err_target_excluded_symbol_use_x86_64.w
+++ b/test/compile_errors/err_target_excluded_symbol_use_x86_64.w
@@ -1,0 +1,14 @@
+//! expect-error: undefined variable
+//! requires-arch: x86_64
+
+// Mirror of err_target_excluded_symbol_use.w for an x86_64 host: a function
+// guarded for aarch64 is excluded entirely on x86_64, so referencing it fails
+// loudly rather than producing wrong-target code.
+
+@[target("aarch64")]
+fn only_on_arm() -> i32:
+    1
+
+fn main:
+    let r = only_on_arm()
+    print("x")

--- a/test/spec/spec_ss16_13_target_guard.w
+++ b/test/spec/spec_ss16_13_target_guard.w
@@ -2,8 +2,9 @@
 
 // §16.13 architecture guards. @[target("arch")] excludes a declaration from
 // compilation on any other active target, so the same name can be defined per
-// architecture (the "declaration alternative" pattern). This test assumes an
-// aarch64 host/CI; on an x86_64 host the surviving definition returns 7.
+// architecture (the "declaration alternative" pattern). A guarded expected()
+// mirror makes the assertion hold on whichever architecture is the active host:
+// arch_value() must resolve to the definition selected for the active target.
 
 @[target("aarch64")]
 fn arch_value() -> i32:
@@ -13,8 +14,16 @@ fn arch_value() -> i32:
 fn arch_value() -> i32:
     7
 
+@[target("aarch64")]
+fn expected() -> i32:
+    42
+
+@[target("x86_64")]
+fn expected() -> i32:
+    7
+
 fn main:
-    if arch_value() == 42:
+    if arch_value() == expected():
         print("ok")
     else:
         print("bad")


### PR DESCRIPTION
The linux self-host check built and fixpoint-verified the compiler but stopped short of the test suite — the same gap surfaced when the "green battery" is asked for as the gate. This extends the linux job to run `build :test` after fixpoint, so every push/PR exercises the standing battery.

## What `:test` covers

`:test` is a Group target that runs:

- behavior tests
- native compile-error / codegen / spec / phase tests
- comptime-diff tests
- debug-alloc (drop-discipline) tests
- lexer / parser / internals tests
- deep-debug-tool tests — which themselves assert `analyze audit:all` + `audit:storage`
- CLI self-host suites (smoke, one-liner, fmt, object-symbol, build.w, project, lsp, edge, parallel)
- c-migrator tests
- issue61 / invariance / embedded-runtime / emit-c-smoke / requirements / spec-inventory checks
- `test-green` evidence recording

## Why this shape

- `:test` is a strict superset of the previous build+fixpoint work and **reuses the already-built compiler** from the build step (no rebuild), so it's one job, not a duplicate bootstrap. The job is renamed to **green battery (linux x86_64)** to reflect that it now runs the full standing battery.
- Driven with the seed for the same reason as `:build`/`:fixpoint` — the freshly built tip compiler is post-str-flip and cannot run this era's `build.w`. The seed runs `build.w`, whose test actions invoke the already-built `out/release/bin/with` on the fixtures.

Not included here (deliberately): `:move-audit` / `:drop-audit` are the ownership-isolation gates (they need `src/main` as a baseline compiler) and `:last-green` / reseed are local maintainer evidence steps — none belong in a standing presubmit. Follow-ups can extend the battery to macOS and Windows once linux is shown green.