### PR TITLE
CI: run the full green battery on macOS presubmit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,9 @@ on:
 
 jobs:
   selfhost-macos:
-    name: selfhost (macOS)
+    name: green battery (macOS arm64)
     runs-on: macos-latest
+    timeout-minutes: 180
     env:
       WITH_OUT_DIR: ${{ github.workspace }}/out
       WITH: ${{ github.workspace }}/src/main
@@ -94,3 +95,6 @@ jobs:
 
       - name: Fixpoint
         run: ./out/release/bin/with build :fixpoint
+
+      - name: Green battery (build :test)
+        run: src/main build :test


### PR DESCRIPTION
## Summary

- rename the macOS self-host check to the macOS green battery
- run the complete build :test gate after byte-identical fixpoint
- give the expanded job the same 180-minute ceiling as Linux

#791 is merged; this branch is rebased directly onto that merge and contains only the macOS workflow change.

## Verification

Run locally on Darwin arm64 against the exact pinned v0.15.1 seed and With-owned LLVM 22.1.6 SDK:

- ./src/main build — passed
- ./out/release/bin/with build :fixpoint — passed, byte-identical
- ./src/main build :test — passed the complete battery and recorded test-green evidence

The behavior lane passed all 943 files; native compile-error, codegen, spec, phase, comptime-diff, debug allocator, internals, lexer/parser, deep-debug/audit, CLI self-host, migrator, invariance, embedded-runtime, emit-C, requirements, and spec-inventory lanes all passed.