### PR TITLE
ci: seed all platforms from v0.15.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Bootstrap seed
         env:
           WITH_SEED_REPO: withlang-dev/with
-          WITH_SEED_VERSION: with-darwin-aarch64
+          WITH_SEED_VERSION: v0.15.1.3
           WITH_SEED_ASSET: with-darwin-aarch64
-          WITH_SEED_SHA256: 7223e03b2fd5f0153c1932f51c4be2fe1a98589cf853a535f715742af1039dc3
+          WITH_SEED_SHA256: b1eefae290630cc33d4a8ece2681c4ca1aa7b98944345a3969bfcfd5ce9fdc2e
         run: |
           set -euo pipefail
           curl -fL -o src/main \

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -43,9 +43,9 @@ jobs:
             runner: macos-latest
             sdk_host_tag: darwin-arm64
             seed_repo: withlang-dev/with
-            seed_version: with-darwin-aarch64
+            seed_version: v0.15.1.3
             seed_asset: with-darwin-aarch64
-            seed_sha256: 7223e03b2fd5f0153c1932f51c4be2fe1a98589cf853a535f715742af1039dc3
+            seed_sha256: b1eefae290630cc33d4a8ece2681c4ca1aa7b98944345a3969bfcfd5ce9fdc2e
             sdk_version: nightly-sdk-test-20260815-680aa139
             sdk_asset: with-llvm-sdk-22.1.6-darwin-aarch64.tar.gz
             sdk_sha256: 4f99fc99a933ee3cf0578336a4fbbbcaaedbbe89112cd49454ea64149c188e6d
@@ -56,9 +56,9 @@ jobs:
             runner: ubuntu-latest
             sdk_host_tag: linux-x86_64
             seed_repo: withlang-dev/with
-            seed_version: seed-linux-tip-368c81bf
+            seed_version: v0.15.1.3
             seed_asset: with-linux-x86_64
-            seed_sha256: bd3a76844f23f9ecbe23cc1a4138087bd80ece2df41db2408e59a60b180c2019
+            seed_sha256: 0556c80c0acc44545c77e1dac77ffb677fe53c4cdbefba4aa7d36eb63b27b595
             sdk_version: nightly-sdk-test-20260815-680aa139
             sdk_asset: with-llvm-sdk-22.1.6-linux-x86_64.tar.gz
             sdk_sha256: c7747403c3556ba9ca6e8f47c5db023798c7c5828c807c4a3b474f0c87db24db
@@ -192,12 +192,9 @@ jobs:
       # The unix matrix build above cannot cover Windows -- its steps use shasum,
       # tar -xzf, libclang.a and POSIX paths -- so Windows is a sibling job.
       WITH_SEED_REPO: withlang-dev/with
-      # ae12ec95 carries the rt_getenv deadlock fix (rt_mmap return buffer). Older
-      # pins self-deadlocked under `build` at the allocator's WITH_MEMORY_LIMIT_BYTES
-      # cold-read (rt_getenv -> with_alloc re-entering the non-recursive spinlock).
-      WITH_SEED_VERSION: seed-windows-x86_64-ae12ec95
+      WITH_SEED_VERSION: v0.15.1.3
       WITH_SEED_ASSET: with-windows-x86_64.exe
-      WITH_SEED_SHA256: 6d604a38fa487de416ee68729b61e56543eecc0ff6ffe1277fbcdf8f55466f80
+      WITH_SEED_SHA256: a1e0487f81e4c04292f87d2c6fc92122490ccf43faa025bb91901ec57d3bcdba
       # The Windows LLVM SDK is versioned independently of the nightly-sdk-* used
       # by darwin/linux and ships without .sha256/.manifest sidecars, so we pin the
       # archive digest directly here rather than fetching sidecar files.
@@ -301,9 +298,9 @@ jobs:
       # when Linux succeeds; otherwise these pins provision a metadata-only
       # compiler and SDK without adding Linux assets to the partial release.
       METADATA_SEED_REPO: withlang-dev/with
-      METADATA_SEED_VERSION: seed-linux-tip-368c81bf
+      METADATA_SEED_VERSION: v0.15.1.3
       METADATA_SEED_ASSET: with-linux-x86_64
-      METADATA_SEED_SHA256: bd3a76844f23f9ecbe23cc1a4138087bd80ece2df41db2408e59a60b180c2019
+      METADATA_SEED_SHA256: 0556c80c0acc44545c77e1dac77ffb677fe53c4cdbefba4aa7d36eb63b27b595
       METADATA_SDK_REPO: withlang-dev/with
       METADATA_SDK_VERSION: nightly-sdk-test-20260815-680aa139
       METADATA_SDK_ASSET: with-llvm-sdk-22.1.6-linux-x86_64.tar.gz

--- a/.github/workflows/selfhost-linux.yml
+++ b/.github/workflows/selfhost-linux.yml
@@ -14,12 +14,11 @@ jobs:
     env:
       WITH_OUT_DIR: ${{ github.workspace }}/out
       LLVM_PREFIX: ${{ github.workspace }}/.deps/llvm-22.1.6-linux-x86_64
-      # Pre-flip (+187-era) seed carrying the globaldce fix from this branch's
-      # first commit. Tip's build.w requires a str=Copy compiler to run, so the
-      # seed cannot be tip's own stage3 — by design tip is never its own seed.
-      WITH_SEED_REPO: ${{ github.repository }}
+      # Fixpoint-verified stable release seed for this platform.
+      WITH_SEED_REPO: withlang-dev/with
       WITH_SEED_ASSET: with-linux-x86_64
-      WITH_SEED_VERSION: seed-linux-tip-368c81bf
+      WITH_SEED_VERSION: v0.15.1.3
+      WITH_SEED_SHA256: 0556c80c0acc44545c77e1dac77ffb677fe53c4cdbefba4aa7d36eb63b27b595
       WITH_SDK_REPO: withlang-dev/with
       WITH_SDK_VERSION: v0.15.1
       WITH_SDK_ASSET: with-llvm-sdk-22.1.6-linux-x86_64.tar.zst
@@ -72,6 +71,7 @@ jobs:
           set -euo pipefail
           curl -fL -o with-seed \
             "https://github.com/$WITH_SEED_REPO/releases/download/$WITH_SEED_VERSION/$WITH_SEED_ASSET"
+          printf '%s  %s\n' "$WITH_SEED_SHA256" with-seed | sha256sum -c -
           chmod +x with-seed
           LD_LIBRARY_PATH="$PWD/.link-shim:${LD_LIBRARY_PATH:-}" ./with-seed version
 
@@ -89,8 +89,8 @@ jobs:
           WITH: ${{ github.workspace }}/with-seed
         run: |
           set -euo pipefail
-          # Drive :fixpoint with the seed, not ./out/bin/with: the freshly built
-          # tip compiler is post-str-flip and would reject this era's build.w.
+          # Drive the build graph with the pinned stable seed; the graph compares
+          # the newly built stage2 and stage3 compiler outputs.
           export PATH="$PWD/.link-shim:$LLVM_PREFIX/bin:$PATH"
           export LD_LIBRARY_PATH="$PWD/.link-shim:${LD_LIBRARY_PATH:-}"
           "$WITH" build :fixpoint
@@ -106,11 +106,9 @@ jobs:
           # asserts `analyze audit:all` + `audit:storage`), CLI self-host, and
           # c-migrator suites, then records `test-green` evidence.
           #
-          # Driven with the seed for the same reason as :build/:fixpoint above:
-          # the freshly built tip compiler is post-str-flip and cannot run this
-          # era's build.w. The seed runs build.w, whose test actions invoke the
-          # already-built out/release/bin/with on the fixtures (no rebuild — the
-          # build step above populated the cache).
+          # The stable seed runs build.w, whose test actions invoke the already-
+          # built out/release/bin/with on the fixtures (no rebuild — the build
+          # step above populated the cache).
           export PATH="$PWD/.link-shim:$LLVM_PREFIX/bin:$PATH"
           export LD_LIBRARY_PATH="$PWD/.link-shim:${LD_LIBRARY_PATH:-}"
           "$WITH" build :test

--- a/.github/workflows/selfhost-windows.yml
+++ b/.github/workflows/selfhost-windows.yml
@@ -16,15 +16,10 @@ jobs:
       # Native Windows self-host: the published Windows seed compiler builds
       # stage1 -> stage2 -> stage3 and we assert stage2 == stage3 (fixpoint).
       WITH_SEED_REPO: withlang-dev/with
-      # ae12ec95 is post-c85bd53e: it carries the rt_getenv deadlock fix. The
-      # previous pin (01932a7f) predated that fix, so its build driver/workers
-      # self-deadlocked at startup on the allocator's WITH_MEMORY_LIMIT_BYTES
-      # cold-read (rt_getenv -> with_alloc re-entering the non-recursive spinlock
-      # on the same thread), producing zero output until the 120-minute timeout.
-      # The fixed rt_getenv allocates its return buffer with rt_mmap/VirtualAlloc,
-      # which takes no allocator lock.
-      WITH_SEED_VERSION: seed-windows-x86_64-ae12ec95
+      # Fixpoint-verified stable release seed for this platform.
+      WITH_SEED_VERSION: v0.15.1.3
       WITH_SEED_ASSET: with-windows-x86_64.exe
+      WITH_SEED_SHA256: a1e0487f81e4c04292f87d2c6fc92122490ccf43faa025bb91901ec57d3bcdba
       WITH_SDK_REPO: withlang-dev/with
       WITH_SDK_VERSION: v0.15.1
       WITH_SDK_ASSET: with-llvm-sdk-22.1.6-windows-x86_64.tar.zst
@@ -60,7 +55,8 @@ jobs:
           set -euo pipefail
           curl -fL -o src/main.exe \
             "https://github.com/$WITH_SEED_REPO/releases/download/$WITH_SEED_VERSION/$WITH_SEED_ASSET"
-          ./src/main.exe version || true
+          printf '%s  %s\n' "$WITH_SEED_SHA256" src/main.exe | sha256sum -c -
+          ./src/main.exe version
 
       - name: Configure native toolchain env
         run: |


### PR DESCRIPTION
## Summary

- pin macOS, Linux, and Windows CI bootstrap seeds to the corresponding `v0.15.1.3` release binaries
- pin Release workflow platform seeds and its Linux metadata fallback to the same tagged release
- add missing SHA-256 verification to Linux and Windows CI seed downloads
- remove stale comments tied to the old bridge seed tags

Seed assets are taken only from `withlang-dev/with`:

- Darwin arm64: `with-darwin-aarch64` (`b1eefae290630cc33d4a8ece2681c4ca1aa7b98944345a3969bfcfd5ce9fdc2e`)
- Linux x86_64: `with-linux-x86_64` (`0556c80c0acc44545c77e1dac77ffb677fe53c4cdbefba4aa7d36eb63b27b595`)
- Windows x86_64: `with-windows-x86_64.exe` (`a1e0487f81e4c04292f87d2c6fc92122490ccf43faa025bb91901ec57d3bcdba`)

## Verification

- each configured SHA matches the published GitHub asset digest and release `.sha256` sidecar
- no old CI/Release seed tag or digest remains
- `git diff --check`
- `act -l` parses all workflows and recognizes every job