### PR TITLE
Windows: strip drive-letter colon in link-stage artifact dir (#807)

### DIFF
--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -1086,7 +1086,13 @@ fn link_stage_sanitize_relative_dir(path: &str) -> str:
                     if segment == "..":
                         out = out ++ "__up__"
                     else:
-                        out = out ++ segment
+                        // A Windows source carries a drive-letter segment ("C:")
+                        // whose colon is illegal in a path component; left intact
+                        // it yields an uncreatable artifact dir (out/C:/wt/...) and
+                        // mkdir fails before the program runs. Colons never appear
+                        // in this compiler's own source paths, so stripping them is
+                        // a no-op off Windows — fixpoint output stays byte-identical.
+                        out = out ++ segment.replace(":", "")
             segment_start = i + 1
         i = i + 1
     out


### PR DESCRIPTION
## Windows: strip drive-letter colon in link-stage artifact dir (#807)

On native Windows the link stage derived its per-object artifact
directory from the source path **including the drive-letter colon**
(`out/C:/…/foo.o`). `mkdir` rejects the embedded `:` on NTFS, so every
link-stage object failed to create its output directory and the whole
`debug-alloc-tests` lane exited 1 before running a single fixture.

`link_stage_sanitize_relative_dir` now strips drive-letter colons (and
any stray `:` in a path segment) so the artifact tree is
`out/C/…/foo.o`. The lane's directories now materialize on Windows.

### Scope

This is the colon/`mkdir` root-cause fix only. The `debug-alloc-tests`
green-battery lane stays gated off on Windows under `#807`: the native
Windows debug allocator does not yet emit the `leak count=0` line the
fixtures assert, so the lane cannot pass even with directories fixed.
That allocator-output gap is tracked by #807 and un-gating waits on it.