### PR TITLE
Windows: fix .map/closure sret leak, un-skip 3 core-language tests (#802)

### DIFF
--- a/src/CodegenDispatch.w
+++ b/src/CodegenDispatch.w
@@ -17068,6 +17068,7 @@ impl Codegen:
         // Save current state
         let saved_fn = self.current_function
         let saved_ret = self.current_ret_type
+        let saved_fn_name_sym = self.current_function_name_sym
         let saved_bb = wl_get_insert_block(self.builder)
         let saved_allocas = self.local_allocas
         let saved_types = self.local_types
@@ -17083,6 +17084,16 @@ impl Codegen:
         // Build closure body
         self.current_function = closure_fn
         self.current_ret_type = ret_ty
+        // The synthetic closure is declared with a direct return (its LLVM
+        // signature uses ret_ty by value, never an sret param). Its TK_RETURN
+        // must therefore take the direct-return path. current_function_name_sym
+        // is keyed into extern_fn_has_sret; leaving the enclosing function's sym
+        // here makes the closure inherit that function's sret verdict (true on
+        // Windows for any struct return >8 bytes, e.g. Vec), which would store
+        // the result through param 0 and emit `ret void` in an i32 function.
+        // Sym 0 can never carry an sret entry (record_c_abi_transform ignores
+        // it), so it selects the direct path unconditionally.
+        self.current_function_name_sym = 0
         let entry = wl_append_bb(self.context, closure_fn, "entry")
         wl_position_at_end(self.builder, entry)
 
@@ -17320,6 +17331,7 @@ impl Codegen:
         // Restore state
         self.current_function = saved_fn
         self.current_ret_type = saved_ret
+        self.current_function_name_sym = saved_fn_name_sym
         wl_position_at_end(self.builder, saved_bb)
         self.local_allocas = saved_allocas
         self.local_types = saved_types

--- a/test/behavior/behav_for_borrow_iteration.w
+++ b/test/behavior/behav_for_borrow_iteration.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #802: core-language behavior fails on native Windows (needs root-cause)
 //! expect-stdout: ok
 
 fn doubled(xs: &Vec[i32]) -> Vec[i32]:

--- a/test/behavior/behav_iter_pipeline_local.w
+++ b/test/behavior/behav_iter_pipeline_local.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #802: core-language behavior fails on native Windows (needs root-cause)
 //! expect-stdout: ok
 
 fn make_iter(xs: &Vec[i32]) -> VecIter[i32]:

--- a/test/behavior/vec_map_type_change_return.w
+++ b/test/behavior/vec_map_type_change_return.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #802: core-language behavior fails on native Windows (needs root-cause)
 // Regression for #306: a type-changing Vec.map (A -> B) must unify with an
 // expected Vec[B] in return position and annotated-let position, not just when
 // let-bound without an expected type. Previously the map closure's parameter


### PR DESCRIPTION
## Windows: fix `.map`/closure sret leak, un-skip 3 core-language tests (#802)

### Root cause

`gen_closure` (the synthetic `@__closure` emitter used by `Vec.map`,
iterator `.filter`, and every closure-lowering path) saved and reset
`current_function` and `current_ret_type` around the closure body, but
never reset `current_function_name_sym`. The closure body's `TK_RETURN`
looks up `extern_fn_has_sret[current_function_name_sym]` to decide
between the direct-return path and the sret path — and with the field
left holding the *enclosing* function's symbol, the closure inherited
the enclosing function's sret verdict.

On Windows, any struct return larger than 8 bytes is sret
(`internal_abi_needs_sret`). So for `fn doubled(xs: &Vec[i32]) -> Vec[i32]:
xs.map(it * 2)`, the enclosing `@doubled` is sret, and the synthetic
`i32 @__closure(ptr %ctx, i32 %elem)` wrongly took the sret path: it
stored its result through `%ctx` (param 0) and emitted `ret void` — in a
function whose LLVM signature returns `i32`. LLVM verify rejected the
module, so every `.map`/closure program failed to compile for the
Windows target.

The bug was Windows-only because on non-Windows `internal_abi_needs_sret`
returns false, so no enclosing function ever gets an `extern_fn_has_sret`
entry to leak into the closure.

### Fix

`gen_closure` now saves `current_function_name_sym`, sets it to `0` for
the closure body, and restores it afterward. The synthetic closure is
always declared with a direct return (its LLVM signature uses `ret_ty`
by value, never an sret param), so its `TK_RETURN` must always take the
direct path. Symbol `0` can never carry an sret entry
(`record_c_abi_transform` ignores it), so it selects the direct path
unconditionally.

Verified by cross-emitting the Windows-target IR before/after: the
closure now emits `ret i32 %N` with no store through `%ctx`, and the
module passes verify. The enclosing `@doubled` is unchanged (still sret
on Windows, direct struct return on Linux), and the Linux-target IR is
unchanged.

### Tests un-skipped

Cross-built to `x86_64-pc-windows-msvc` and run under wine (all pass):

- `test/behavior/vec_map_type_change_return.w` — type-changing `Vec.map`
- `test/behavior/behav_for_borrow_iteration.w` — `xs.map(it * 2)`
- `test/behavior/behav_iter_pipeline_local.w` — `.iter().filter(...)`

The remaining `#802` skips (`sealed_trait_match`, `behav_build_w_basic_invocation`,
`behav_cli_test_command_args`) are a *different* root cause — verified
still failing under wine (`sealed_trait_match` compiles and exits 0 but
produces no output) — and stay skipped pending a separate fix.

Linux `with build` + `:fixpoint` (stage2 == stage3) pass with the change.
