### PR TITLE
#801: resolve embed_file on native Windows + un-skip its 3 tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,10 @@
 *.w linguist-language=With
 bootstrap/** linguist-vendored
 out/** linguist-generated
+
+# embed_file fixtures are embedded byte-for-byte and their content is asserted
+# exactly. Pin LF so a native Windows checkout (core.autocrlf=true, the default
+# on GitHub's Windows runners) does not rewrite them to CRLF, which would make
+# embed_file read "...\r\n" and break the byte-exact assertions (#801).
+test/behavior/*.txt text eol=lf
+test/behavior/**/*.txt text eol=lf

--- a/src/compiler/TrackedInputs.w
+++ b/src/compiler/TrackedInputs.w
@@ -54,9 +54,14 @@ pub fn tracked_input_merge_unique(left: Vec[str], right: &Vec[str]) -> Vec[str]:
     out
 
 fn tracked_dirname(path: &str) -> str:
+    // Separator-agnostic: a native Windows source path is '\'-separated, so a
+    // '/'-only split returns "" and the embed target resolves against the cwd
+    // instead of the source's directory (#801). Matches the '\'-aware sibling
+    // helpers below.
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path.byte_at(i as i64) == 47:
+        let b = path.byte_at(i as i64)
+        if b == 47 or b == 92:
             last_slash = i
     if last_slash < 0:
         return ""
@@ -108,7 +113,9 @@ fn tracked_normalize_path(path: &str) -> str:
     var start = 0
     for i in 0..(path.len() as i32 + 1):
         let at_end = i == path.len() as i32
-        if at_end or path.byte_at(i as i64) == 47:
+        // Split on both '/' and '\' so a '\'-separated Windows path normalizes
+        // to the same '/'-form the containment checks expect (#801).
+        if at_end or path.byte_at(i as i64) == 47 or path.byte_at(i as i64) == 92:
             if i > start:
                 // Flat decision (no inner chain ending in else-if): the seed
                 // compiler predates the #629 dangling-else fix and miscompiles

--- a/test/behavior/const_str_embed_file_const.w
+++ b/test/behavior/const_str_embed_file_const.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #801: embed_file path resolution fails on native Windows
 //! expect-stdout: ok
 
 const EMPTY: str = ""

--- a/test/behavior/embed_file_computed_path.w
+++ b/test/behavior/embed_file_computed_path.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #801: embed_file path resolution fails on native Windows
 //! expect-stdout: ok
 
 const DIR: str = "lib/embed_file_computed"

--- a/test/behavior/embed_file_relative_module.w
+++ b/test/behavior/embed_file_relative_module.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #801: embed_file path resolution fails on native Windows
 //! expect-stdout: ok
 
 use embed_file_phase8.helper


### PR DESCRIPTION
Stacked on #812 (windows-regex-fnarg-abi-798).

## What
- **Fix:** `tracked_dirname` / `tracked_normalize_path` in `src/compiler/TrackedInputs.w` split path segments on `/` only. A native-Windows source path spelled with backslashes (`with build src\app.w`) then produces an empty dirname, so `embed_file` resolves its target against the process cwd instead of the source directory and fails "could not read". Both helpers are now separator-agnostic (`/` and `\`), matching the sibling helpers `tracked_path_is_absolute` / `tracked_path_has_parent_segment`, which already treat `\` as a separator on every platform.
- **Un-skip:** `const_str_embed_file_const`, `embed_file_computed_path`, `embed_file_relative_module` were gated `skip-windows` on #801. They build and print `ok` on native Windows.

## Why the tests already pass (and the fix is still real)
The green battery feeds the compiler forward-slash-terminated source paths (`rt_list_files` joins with `/` via `win_path_join`), so the harness never hits the backslash regression — the three tests resolve correctly through it. The fix targets the remaining hand-typed-backslash CLI path, which a Windows dev *will* use; it is not exercised by a harness fixture but is verified manually on the VM.

## Verification (Windows x86_64 VM, native)
- 2×2 embed matrix (bare-filename + computed-subpath × forward-slash / backslash source path): **before** the fix, backslash cells fail `embed_file: could not read`; **after**, all four build and run `ok`.
- Real `test` subcommand (build + run + stdout check) with battery-form relative paths: all three tests pass on both the current compiler and the #801-fixed compiler, including the imported-module embed (`relative_module`).