### PR TITLE
#800: un-skip std.process command test; document net/symlink Windows gaps

### DIFF
--- a/test/behavior/behav_fs_remove_tree.w
+++ b/test/behavior/behav_fs_remove_tree.w
@@ -1,4 +1,4 @@
-//! skip-windows: issue #800: action/capability/net/process/fs OS-surface fails on native Windows
+//! skip-windows: #800: symlink() needs Developer Mode or elevation on Windows (CreateSymbolicLinkW fails ERROR_PRIVILEGE_NOT_HELD); rt_symlink already passes ALLOW_UNPRIVILEGED_CREATE, so this is an environment privilege gap, not a code bug
 use std.fs
 
 fn contains_line(text: &str, line: &str) -> bool:

--- a/test/behavior/behav_net_loopback.w
+++ b/test/behavior/behav_net_loopback.w
@@ -1,4 +1,4 @@
-//! skip-windows: issue #800: action/capability/net/process/fs OS-surface fails on native Windows
+//! skip-windows: #800: std.net has no Windows backend — rt/windows_x86_64.w defines no with_net_* symbols (linux/darwin do), so this link-fails; needs a Winsock implementation (WSAStartup/socket/bind/listen/accept/connect/send/recv/closesocket/getsockname)
 //! expect-stdout: ok
 
 // #658: the server-side std.net surface must actually work. TCP: listen

--- a/test/behavior/behav_std_process_command.w
+++ b/test/behavior/behav_std_process_command.w
@@ -1,15 +1,27 @@
-//! skip-windows: issue #800: action/capability/net/process/fs OS-surface fails on native Windows
 //! expect-stdout: ok
 
 use std.process
+use std.sysinfo
 
 fn main:
-    assert(command("/usr/bin/true").run() == 0)
+    if os() == "Windows":
+        // Use real System32 executables: `where` exits 0 when the program is
+        // found and 1 when it is not, exercising run/status/arg/PATH the same
+        // way /usr/bin/true and /bin/test do on Unix.
+        assert(command("whoami").run() == 0)
 
-    let eq = command("/bin/test").arg("with").arg("=").arg("with")
-    assert(eq.status() == 0)
+        let found = command("where").arg("cmd")
+        assert(found.status() == 0)
 
-    let ne = command("/bin/test").arg("with").arg("=").arg("shell")
-    assert(ne.status() != 0)
+        let missing = command("where").arg("with_no_such_program_xyz123")
+        assert(missing.status() != 0)
+    else:
+        assert(command("/usr/bin/true").run() == 0)
+
+        let eq = command("/bin/test").arg("with").arg("=").arg("with")
+        assert(eq.status() == 0)
+
+        let ne = command("/bin/test").arg("with").arg("=").arg("shell")
+        assert(ne.status() != 0)
 
     print("ok")


### PR DESCRIPTION
Stacked on #814.

Un-skips `behav_std_process_command` by making the test portable (it no
longer assumes a POSIX-only command surface), so `std.process` command
execution is now exercised on native Windows.

Also sharpens the justification on the two OS-surface tests that remain
genuinely blocked on Windows:

- `behav_net_loopback`: `std.net` has no Windows backend —
  `rt/windows_x86_64.w` defines no `with_net_*` symbols, so this link-fails.
  Needs a Winsock implementation (WSAStartup/socket/bind/listen/accept/
  connect/send/recv/closesocket/getsockname).
- `behav_fs_remove_tree`: `symlink()` needs Developer Mode or elevation on
  Windows (`CreateSymbolicLinkW` → `ERROR_PRIVILEGE_NOT_HELD`); an
  environment privilege gap, not a code bug.

The five action/capability tests (`behav_action_capability_filesystem`,
`behav_action_capability_process`, `behav_action_crash_diagnostic`,
`behav_action_no_deps_isolation`, `behav_capability_token_mismatch`) stay
skipped — they still fail on native Windows even with the p7 cwd fix
(tracked in #71).