### PR TITLE
codegen(win64): materialize dyn-trait fat pointers, sync + async (#806)

### DIFF
--- a/src/CodegenDispatch.w
+++ b/src/CodegenDispatch.w
@@ -6951,21 +6951,43 @@ impl Codegen:
         if param_count > 0:
             wl_get_param_types(fn_ty, vec_data_i64(&param_types))
 
+        // D6: dyn_trait_method_fn_type applies the native win64 ABI, so an
+        // aggregate return (>8B) becomes an sret parameter — matching the vtable
+        // wrapper's real `void(sret_dest, self_data, ...)` shape. Detect it: a
+        // void LLVM return with one more parameter than the MIR arg list (the
+        // extra leading slot is sret) means we must pass the destination pointer
+        // as arg 0 and let the callee write the result in place.
+        let ret_ty = wl_get_return_type(fn_ty)
+        let is_void_ret = ret_ty == wl_void_type(self.context)
+        let has_sret = is_void_ret and param_count == arg_count + 1
+
         let call_args: Vec[i64] = Vec.new()
+        var sret_dst: i64 = 0
+        if has_sret:
+            if dest_place < 0 or dest_place >= body.place_locals.len() as i32:
+                return self.mir_emit_dyn_call_error("error: dyn trait sret call has no destination", next_bb)
+            var sret_dst_ty = self.mir_dest_llvm_type(body, dest_place)
+            if sret_dst_ty == 0:
+                sret_dst_ty = wl_ptr_type(self.context)
+            sret_dst = self.mir_place_ptr(body, dest_place, true, sret_dst_ty)
+            if sret_dst == 0:
+                return self.mir_emit_dyn_call_error("error: dyn trait sret destination could not be materialized", next_bb)
+            call_args.push(sret_dst)
         call_args.push(data_ptr)
+        let sret_off = if has_sret: 1 else: 0
         var ai = 1
         while ai < arg_count:
             let op_id = body.call_arg_operands.get((arg_start + ai) as i64)
             var expected_ty: i64 = 0
-            if ai < param_types.len() as i32:
-                expected_ty = param_types.get(ai as i64)
+            let pidx = ai + sret_off
+            if pidx < param_types.len() as i32:
+                expected_ty = param_types.get(pidx as i64)
             let val = self.mir_eval_call_operand(body, op_id, expected_ty, "dyn trait method", ai - 1)
             call_args.push(val)
             ai = ai + 1
 
         let result = wl_build_call(self.builder, fn_ty, fn_ptr, vec_data_i64(&call_args), call_args.len() as i32)
-        let ret_ty = wl_get_return_type(fn_ty)
-        if ret_ty != wl_void_type(self.context):
+        if not has_sret and ret_ty != wl_void_type(self.context):
             if dest_place < 0 or dest_place >= body.place_locals.len() as i32:
                 return self.mir_emit_dyn_call_error("error: dyn trait call has no destination for non-void return", next_bb)
             var dst_ty = self.mir_dest_llvm_type(body, dest_place)
@@ -13659,6 +13681,31 @@ impl Codegen:
             wl_build_br(self.builder, self.mir_bb_values.get(next_bb as i64))
         true
 
+    // Build the dyn-trait fat pointer {data_ptr, vtable_ptr} for an argument
+    // whose declared parameter is `dyn Trait`. Extracted so the win64
+    // indirect-aggregate call paths (which pass the fat value BY ADDRESS) build
+    // the same value the direct path builds — never the concrete's own address.
+    mut fn mir_build_dyn_arg_fat_value(body: &MirBody, args_id: i32, operand_id: i32, ai: i32, dyn_trait_sym: i32) -> i64:
+        let arg_val = self.mir_eval_operand(body, operand_id, 0)
+        if self.llvm_type_is_dyn_fat_ptr(wl_type_of(arg_val)) != 0:
+            return arg_val
+        var dyn_info = self.mir_dyn_arg_info_from_operand(body, operand_id, arg_val)
+        if dyn_info.type_sym == 0:
+            let dyn_call_node = body.call_ast_node(args_id)
+            if dyn_call_node > 0 and self.pool.kind(dyn_call_node) == NodeKind.NK_CALL:
+                let dyn_ast_arg_start = self.pool.get_data1(dyn_call_node)
+                let dyn_ast_arg_count = self.pool.get_data2(dyn_call_node)
+                if ai < dyn_ast_arg_count:
+                    let dyn_arg_node = self.pool.get_extra(dyn_ast_arg_start + ai)
+                    dyn_info = self.mir_dyn_arg_info_from_ast_node(dyn_arg_node, arg_val)
+        if dyn_info.type_sym != 0:
+            if dyn_info.use_ptr != 0:
+                return self.build_dyn_trait_value_from_ptr(arg_val, dyn_info.type_sym, dyn_trait_sym)
+            return self.build_dyn_trait_value(arg_val, dyn_info.type_sym, dyn_trait_sym)
+        with_eprint(f"error: cannot lower argument {ai + 1} to dyn trait '{self.intern.resolve(dyn_trait_sym)}'")
+        self.had_error = 1
+        wl_get_undef(self.get_dyn_fat_ptr_type())
+
     mut fn mir_emit_call_term(body: &MirBody, callee_operand: i32, args_id: i32, dest_place: i32, next_bb: i32) -> bool:
         // Check for intrinsic-tagged calls (Vec/HashMap/Option builtins).
         // These have meaningless ConstKind.CK_FN syms — dispatch by intrinsic kind instead.
@@ -15096,11 +15143,34 @@ impl Codegen:
             if sema_sig_idx >= 0 and param_offset < self.sema.sig_get_param_count(sema_sig_idx):
                 expected_sema_ty = self.sema.sig_param_type(sema_sig_idx, param_offset)
 
+            // Resolve dyn-trait param early: the win64 indirect-aggregate spill
+            // paths below must build the fat pointer, not pass the concrete's
+            // own address. Computed once here and reused by the direct path.
+            var dyn_trait_sym: i32 = 0
+            if callee_fn_sym != 0:
+                dyn_trait_sym = self.get_fn_dyn_param_trait(callee_fn_sym, ai)
+            if dyn_trait_sym == 0 and callee_raw_fn_sym != 0:
+                dyn_trait_sym = self.get_raw_fn_dyn_param_trait(callee_raw_fn_sym, ai)
+
             // Byval: large struct param → alloca + store + pass pointer
             if (abi_byval_mask & ((1 as i64) << (ai as u32))) != 0:
                 var indirect_ty = expected_ty
                 if ai < abi_byval_types.len() as i32 and abi_byval_types.get(ai as i64) != 0:
                     indirect_ty = abi_byval_types.get(ai as i64)
+                // A dyn-trait param passed indirectly: the callee reads a fat
+                // pointer {data, vtable} by address, so build the fat value from
+                // the concrete and spill THAT — never pass the concrete's address.
+                if dyn_trait_sym != 0:
+                    let fatval = self.mir_build_dyn_arg_fat_value(body, args_id, operand_id, ai, dyn_trait_sym)
+                    var fat_ty = indirect_ty
+                    if fat_ty == 0:
+                        fat_ty = wl_type_of(fatval)
+                    let ftmp = self.create_entry_alloca(fat_ty)
+                    let fstored = self.enforce_coerced_type(fatval, fat_ty, "indirect dyn aggregate argument")
+                    wl_build_store(self.builder, fstored, ftmp)
+                    self.record_codegen_call_argument(body, args_id, operand_id, ai, AnalysisMarshalStrategy.TemporaryAddress, ftmp, ftmp)
+                    args.push(ftmp)
+                    continue
                 var arg_ptr = self.mir_try_place_ptr_for_ref(body, operand_id)
                 var byval_strategy = AnalysisMarshalStrategy.ExistingPointer
                 if arg_ptr == 0:
@@ -15150,6 +15220,19 @@ impl Codegen:
                     if arg_sema_ty > 0:
                         agg_ty = self.mir_sema_type_to_llvm(arg_sema_ty)
                 if self.internal_abi_needs_indirect_param(agg_ty):
+                    // A dyn-trait param passed indirectly: build the fat pointer
+                    // from the concrete and spill THAT — matching the byval path.
+                    if dyn_trait_sym != 0:
+                        let fatval = self.mir_build_dyn_arg_fat_value(body, args_id, operand_id, ai, dyn_trait_sym)
+                        var fat_ty = agg_ty
+                        if fat_ty == 0:
+                            fat_ty = wl_type_of(fatval)
+                        let ftmp = self.create_entry_alloca(fat_ty)
+                        let fstored = self.enforce_coerced_type(fatval, fat_ty, "indirect dyn aggregate argument")
+                        wl_build_store(self.builder, fstored, ftmp)
+                        self.record_codegen_call_argument(body, args_id, operand_id, ai, AnalysisMarshalStrategy.TemporaryAddress, ftmp, ftmp)
+                        args.push(ftmp)
+                        continue
                     var arg_ptr = self.mir_try_place_ptr_for_ref(body, operand_id)
                     var indirect_strategy = AnalysisMarshalStrategy.ExistingPointer
                     if arg_ptr == 0:
@@ -15174,11 +15257,7 @@ impl Codegen:
 
             // Check for dyn param BEFORE evaluating operand — coercion would
             // mangle the concrete struct into the fat-pointer shape.
-            var dyn_trait_sym: i32 = 0
-            if callee_fn_sym != 0:
-                dyn_trait_sym = self.get_fn_dyn_param_trait(callee_fn_sym, ai)
-            if dyn_trait_sym == 0 and callee_raw_fn_sym != 0:
-                dyn_trait_sym = self.get_raw_fn_dyn_param_trait(callee_raw_fn_sym, ai)
+            // (dyn_trait_sym was resolved above the byval branch.)
             var arg_val: i64 = 0
             if needs_ref:
                 // #D5 cathedral: single ref-param address policy (extracted).

--- a/src/CodegenTraits.w
+++ b/src/CodegenTraits.w
@@ -292,7 +292,27 @@ impl Codegen:
             self.had_error = 1
             return 0
 
-        wl_function_type(ret_ty, vec_data_i64(&param_types), param_types.len() as i32, 0)
+        // D6: the reconstructed dispatch type MUST match the real method and its
+        // vtable wrapper (create_dyn_wrapper copies the method's ABI-lowered param
+        // layout). Trait methods use the native (internal) With ABI, so apply the
+        // same sret / indirect-param lowering declare_function does. Without this,
+        // a win64 aggregate return (>8B, e.g. `str`) is reconstructed here by-value
+        // while the wrapper returns via sret — the exact caller/callee ABI
+        // divergence D6 forbids, producing wrong output at every dyn call site.
+        let abi_param_types: Vec[i64] = Vec.new()
+        var actual_ret_ty = ret_ty
+        if self.internal_abi_needs_sret(ret_ty):
+            actual_ret_ty = wl_void_type(self.context)
+            abi_param_types.push(ptr_ty)
+        var api = 0
+        while api < param_types.len() as i32:
+            let src_ty = param_types.get(api as i64)
+            if self.internal_abi_needs_indirect_param(src_ty):
+                abi_param_types.push(ptr_ty)
+            else:
+                abi_param_types.push(src_ty)
+            api = api + 1
+        wl_function_type(actual_ret_ty, vec_data_i64(&abi_param_types), abi_param_types.len() as i32, 0)
 
     fn find_decl_index(node: i32) -> i32:
         for i in 0..self.pool.decl_count():

--- a/src/CodegenTraits.w
+++ b/src/CodegenTraits.w
@@ -371,15 +371,30 @@ impl Codegen:
         let orig_param_count = wl_count_param_types(method_ft)
         if orig_param_count <= 0:
             return method_fn
+        let is_async_method = if impl_fn_sym != 0 and self.async_fn_ret_types.get(impl_fn_sym).is_some(): 1 else: 0
+        // dyn_trait_method_fn_type applies the native win64 ABI: an aggregate
+        // return >8B (e.g. an async Task {i32,ptr}) becomes a leading sret
+        // parameter and a void return. The wrapper IS the vtable slot, so its
+        // signature must match dyn_ft — carry the sret slot, place self/args
+        // after it, and write the produced value through it instead of
+        // returning by value. Without this the async Task aggregate is seeded
+        // from the void return (`insertvalue void undef`) and every argument
+        // shifts by one slot. On SysV the 16B Task returns in registers (no
+        // sret), so the non-sret path below stays byte-identical.
+        let ret_ty = wl_get_return_type(dyn_ft)
+        let dyn_param_count = wl_count_param_types(dyn_ft)
+        let has_sret = is_async_method != 0 and ret_ty == wl_void_type(self.context) and dyn_param_count == orig_param_count + 1
+        let base = if has_sret: 1 else: 0
         let wrapper_param_types: Vec[i64] = Vec.new()
+        if has_sret:
+            wrapper_param_types.push(ptr_ty)
         wrapper_param_types.push(ptr_ty)
         var pi = 1
         while pi < orig_param_count:
             let pval = wl_get_param(method_fn, pi)
             wrapper_param_types.push(wl_type_of(pval))
             pi = pi + 1
-        let ret_ty = wl_get_return_type(dyn_ft)
-        let wrapper_ft = wl_function_type(ret_ty, vec_data_i64(&wrapper_param_types), orig_param_count, 0)
+        let wrapper_ft = wl_function_type(ret_ty, vec_data_i64(&wrapper_param_types), orig_param_count + base, 0)
         let wrapper_fn = wl_add_function(self.llmod, wrapper_name, wrapper_ft)
         wl_set_linkage(wrapper_fn, wl_internal_linkage())
 
@@ -394,7 +409,7 @@ impl Codegen:
         let entry = wl_append_bb(self.context, wrapper_fn, "entry")
         wl_position_at_end(self.builder, entry)
 
-        let data_ptr = wl_get_param(wrapper_fn, 0)
+        let data_ptr = wl_get_param(wrapper_fn, base)
         let self_param_ty = if orig_param_count > 0: wl_type_of(wl_get_param(method_fn, 0)) else: ptr_ty
         let self_arg = if wl_get_type_kind(self_param_ty) == wl_pointer_type_kind():
             wl_build_bitcast(self.builder, data_ptr, self_param_ty)
@@ -405,15 +420,20 @@ impl Codegen:
         call_args.push(self_arg)
         pi = 1
         while pi < orig_param_count:
-            let p = wl_get_param(wrapper_fn, pi)
+            let p = wl_get_param(wrapper_fn, base + pi)
             let target_ty = wl_type_of(wl_get_param(method_fn, pi))
             call_args.push(self.coerce_value_to_type(p, target_ty))
             pi = pi + 1
 
-        let is_async_method = if impl_fn_sym != 0 and self.async_fn_ret_types.get(impl_fn_sym).is_some(): 1 else: 0
         var call_val: i64 = 0
         if is_async_method != 0:
-            call_val = self.emit_async_fn_spawn_task_value(impl_fn_sym, method_fn, method_ft, &call_args, ret_ty)
+            var async_task_ty = ret_ty
+            if has_sret:
+                let task_fields: Vec[i64] = Vec.new()
+                task_fields.push(wl_i32_type(self.context))
+                task_fields.push(ptr_ty)
+                async_task_ty = wl_struct_type(self.context, vec_data_i64(&task_fields), 2, 0)
+            call_val = self.emit_async_fn_spawn_task_value(impl_fn_sym, method_fn, method_ft, &call_args, async_task_ty)
         else:
             call_val = wl_build_call(self.builder, method_ft, method_fn, vec_data_i64(&call_args), orig_param_count)
         if consumes_self != 0:
@@ -422,10 +442,14 @@ impl Codegen:
                 let free_args: Vec[i64] = Vec.new()
                 free_args.push(data_ptr)
                 let _ = wl_build_call(self.builder, wl_global_get_value_type(free_fn), free_fn, vec_data_i64(&free_args), 1)
-        if ret_ty == wl_void_type(self.context):
+        if has_sret:
+            let _ = wl_build_store(self.builder, call_val, wl_get_param(wrapper_fn, 0))
             let _ = wl_build_ret_void(self.builder)
         else:
-            let _ = wl_build_ret(self.builder, call_val)
+            if ret_ty == wl_void_type(self.context):
+                let _ = wl_build_ret_void(self.builder)
+            else:
+                let _ = wl_build_ret(self.builder, call_val)
 
         self.current_function = saved_fn
         self.current_function_name_sym = saved_fn_name_sym

--- a/test/behavior/sealed_trait_match.w
+++ b/test/behavior/sealed_trait_match.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #802: core-language behavior fails on native Windows (needs root-cause)
 //! expect-stdout: ok
 @[sealed]
 trait Shape:    fn area(self:


### PR DESCRIPTION
Stacked on #816.

Makes win64 codegen materialize `dyn Trait` fat pointers across the indirect
ABI, fixing trait-object dispatch that previously produced wrong output on
Windows. Two parts:

1. **Sync dispatch** — the fat-pointer materialization that un-skips
   `sealed_trait_match` (non-async `match s: c: Circle => ...` dispatch).
2. **Async dispatch** — `dyn_trait_method_fn_type` applies the native win64
   ABI to vtable slots, which sret-lowers an aggregate return >8B. An async
   Task is `{i32,ptr}` (16B), so its slot becomes `void(sret, ...)`. The
   vtable wrapper (`create_dyn_wrapper`) now carries that sret slot as its
   leading parameter, reconstructs the real Task type for the coroutine
   spawn, and stores the result through the sret slot — matching the vtable
   slot and the dispatch call site (D6: one ABI, agreed at every reader).
   Previously the wrapper seeded the Task aggregate from the sret-lowered
   `void` return (`insertvalue void undef`), an LLVM verify error that
   aborted win64 codegen for any async dyn-trait program.

On SysV the 16B Task returns in registers (no sret), so the async path is
byte-identical to before — linux/mac and the sync path are untouched.

Un-skips (now passing on win64): `sealed_trait_match`,
`spec_ss11_5_dyn_async_trait_methods`, `spec_ss14_3_async_calling_is_unrestricted`.