### PR TITLE
codegen(win64): fix indirect-closure spurious sret arg; un-skip 3 #806 tests

### DIFF
--- a/src/CodegenDispatch.w
+++ b/src/CodegenDispatch.w
@@ -15116,7 +15116,15 @@ impl Codegen:
                 let dst_sema_ty_for_sret = body.local_type_ids.get(dst_local_for_sret as i64)
                 let dst_llvm_ty_for_sret = self.mir_sema_type_to_llvm(dst_sema_ty_for_sret)
                 if self.internal_abi_needs_sret(dst_llvm_ty_for_sret):
-                    if param_count > arg_count and wl_get_return_type(call_ft) == wl_void_type(self.context):
+                    // An indirect closure/fn-pointer call already consumes param 0
+                    // for the environment pointer, so only a param count that
+                    // exceeds args + the env slot leaves room for a real sret
+                    // slot in call_ft. Without this the env slot is mistaken for
+                    // an sret slot, and a Never-returning closure (`void(env)`,
+                    // no sret) gets a spurious sret arg appended → arg-count
+                    // mismatch against its own type on win64.
+                    let indirect_env_slots = if is_indirect: 1 else: 0
+                    if param_count > arg_count + indirect_env_slots and wl_get_return_type(call_ft) == wl_void_type(self.context):
                         let first_param_ty = if param_count > 0: param_types.get(0) else: 0
                         if first_param_ty != 0 and wl_get_type_kind(first_param_ty) == wl_pointer_type_kind():
                             abi_has_sret = 1

--- a/test/spec/spec_ss03_9_box_dyn_coercion.w
+++ b/test/spec/spec_ss03_9_box_dyn_coercion.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 trait-object/vtable ABI — Box[dyn] coercion produces wrong output (exit 1)
 use std.box.Box
 trait BoxDynLogger:
     fn message(self: &Self) -> str

--- a/test/spec/spec_ss03_9_implicit_trait_object_coercion.w
+++ b/test/spec/spec_ss03_9_implicit_trait_object_coercion.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 trait-object/vtable ABI — implicit coercion produces wrong output (exit 1)
 // Spec test: Section 3.9 — Implicit Trait Object Coercion.
 
 trait Greet:

--- a/test/spec/spec_ss11_3_object_safety.w
+++ b/test/spec/spec_ss11_3_object_safety.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 trait-object/vtable ABI — object safety produces wrong output (exit 1)
 // Spec test: Section 11.3 - Object Safety.
 
 use std.box.Box


### PR DESCRIPTION
Stacked on #817 (`windows-codegen-806`).

## Codegen fix

The generic sret path in `mir_emit_call_term` appended an sret argument
whenever the destination local needed win64 sret and `call_ft` had one
more param than the call had args. For an indirect closure/fn-pointer
call, `call_ft` already reserves param 0 for the environment pointer, so
that extra param is the env slot — not an sret slot.

A `Never`-returning closure (`() => unreachable(...)`) lowers to
`void(env)` (Never collapses to void, no sret param). The old guard
counted the env slot as sret room and appended a spurious sret arg,
emitting `call void %fn(env, sret)`: two args against a one-param type.
LLVM verify rejected it ("Incorrect number of arguments") and win64
codegen aborted for any program with such a closure.

Now the sret slot is only added when `param_count` exceeds args **plus**
the env slot. Gated behind `internal_abi_needs_sret` (false off win64),
so linux/mac IR is byte-identical.

## Test un-skips

With the win64 closure/vtable sret ABI consistent, three pure
trait-object spec tests produce correct output on Windows and are
un-skipped: `Box[dyn]` coercion, implicit trait-object coercion, and
object safety (cross-built, run under wine, exit 0 matching the linux
baseline).

The other seven #806 skips still fail at runtime on win64 — they exercise
fat-fn/closure **value** returns (a `str`-returning closure corrupts its
sret result), a distinct data-flow bug that stays skipped until fixed.