### PR TITLE
codegen(win64): closure call type matches by-value callee return (#806)

### DIFF
--- a/src/Codegen.w
+++ b/src/Codegen.w
@@ -1503,6 +1503,50 @@ impl Codegen:
             return fat
         let orig_param_count = wl_count_param_types(orig_fn_ty)
         let orig_ret_ty = wl_get_return_type(orig_fn_ty)
+        // On win64 a concrete function returning an aggregate >8B is physically
+        // sret-lowered by declare_function: `void(ptr sret, real_args...)`. A
+        // closure fn type (mir_build_closure_fn_type), by contrast, is by-value
+        // (`AGG(ptr ctx, real_args...)`) and LLVM inserts the hidden sret pointer
+        // FIRST — so the physical closure convention is `void(sret, ctx, args)`.
+        // Naively prepending ctx to the sret-lowered concrete type yields
+        // `void(ctx, sret, args)`, swapping ctx and sret and corrupting the
+        // result (#806/#819). Rebuild the thunk by-value to match the closure
+        // convention, and let LLVM sret-lower both the thunk definition and the
+        // closure call site identically.
+        let concrete_sret_ty = wl_get_param_sret_type(fn_val, 0)
+        if concrete_sret_ty != 0:
+            let thunk_params: Vec[i64] = Vec.new()
+            thunk_params.push(ptr_ty)
+            // Real args are the concrete params after the leading sret pointer.
+            for pi in 1..orig_param_count:
+                thunk_params.push(wl_get_fn_param_type(orig_fn_ty, pi))
+            let thunk_fn_ty = wl_function_type(concrete_sret_ty, vec_data_i64(&thunk_params), thunk_params.len() as i32, 0)
+            let thunk_id = self.closure_counter
+            self.closure_counter = thunk_id + 1
+            let thunk_name = f"__fn_thunk_{thunk_id}"
+            let thunk_fn = wl_add_function(self.llmod, thunk_name, thunk_fn_ty)
+            wl_set_linkage(thunk_fn, wl_internal_linkage())
+            let saved_bb = wl_get_insert_block(self.builder)
+            let entry = wl_append_bb(self.context, thunk_fn, "entry")
+            wl_position_at_end(self.builder, entry)
+            // Result buffer for the concrete sret call; loaded back and returned
+            // by value so LLVM lowers the thunk return the same way the closure
+            // call site is lowered. Target the thunk explicitly — self.current_function
+            // still names the outer function that triggered the coercion.
+            let result_buf = wl_create_entry_alloca(self.builder, thunk_fn, concrete_sret_ty)
+            let call_args: Vec[i64] = Vec.new()
+            call_args.push(result_buf)
+            for pi in 1..orig_param_count:
+                call_args.push(wl_get_param(thunk_fn, pi))
+            let call = wl_build_call(self.builder, orig_fn_ty, fn_val, vec_data_i64(&call_args), orig_param_count)
+            wl_add_call_sret_attr(self.context, call, 0, concrete_sret_ty)
+            let loaded = wl_build_load(self.builder, concrete_sret_ty, result_buf)
+            wl_build_ret(self.builder, loaded)
+            wl_position_at_end(self.builder, saved_bb)
+            var fat_s = wl_get_undef(fat_ty)
+            fat_s = wl_build_insert_value(self.builder, fat_s, thunk_fn, 0)
+            fat_s = wl_build_insert_value(self.builder, fat_s, wl_const_null(ptr_ty), 1)
+            return fat_s
         // Build thunk function type: fn(ptr, original_params...) -> original_ret
         let thunk_params: Vec[i64] = Vec.new()
         thunk_params.push(ptr_ty)

--- a/src/CodegenDispatch.w
+++ b/src/CodegenDispatch.w
@@ -426,12 +426,22 @@ impl Codegen:
             param_count = self.sema.get_type_d1(resolved)
             ret_ty_id = self.sema.get_type_d2(resolved)
         let ret_ty = self.mir_sema_type_to_llvm(ret_ty_id)
-        var llvm_ret = if ret_ty != 0: ret_ty else: wl_void_type(self.context)
+        let llvm_ret = if ret_ty != 0: ret_ty else: wl_void_type(self.context)
         let param_types: Vec[i64] = Vec.new()
         param_types.push(wl_ptr_type(self.context))
-        if self.internal_abi_needs_sret(llvm_ret):
-            param_types.push(wl_ptr_type(self.context))
-            llvm_ret = wl_void_type(self.context)
+        // The closure body is always emitted with a by-value direct return:
+        // gen_closure forces the direct-return path (current_function_name_sym
+        // = 0) so a closure never gains an sret param, even for a struct return
+        // >8 bytes on win64. The call type must match — do NOT manually
+        // sret-lower here. LLVM applies the target's aggregate-return ABI
+        // identically to a by-value caller and a by-value callee. Manually
+        // sret-lowering the call while the callee returns by value put the
+        // env pointer and the sret pointer in swapped registers on win64
+        // (callee: implicit sret in RCX, env in RDX; caller: env in RCX, sret
+        // in RDX), so a str-returning closure wrote its result through the env
+        // pointer and left the real destination garbage (#806). Contrast
+        // mir_build_raw_fn_type, whose sret lowering is correct because a named
+        // fn-pointer target is sret-lowered by declare_function too.
         for pi in 0..param_count:
             var p_sema_ty = self.mir_type_extra_at(extra_start + pi)
             if resolved >= self.mir_type_kinds_len() as i32:

--- a/src/compiler/LlvmBridge.w
+++ b/src/compiler/LlvmBridge.w
@@ -204,6 +204,8 @@ extern fn LLVMCreateEnumAttribute(c: *mut u8, kind: u32, val: u64) -> *mut u8
 extern fn LLVMCreateTypeAttribute(c: *mut u8, kind: u32, ty: *mut u8) -> *mut u8
 extern fn LLVMAddAttributeAtIndex(v: *mut u8, idx: u32, attr: *mut u8)
 extern fn LLVMAddCallSiteAttribute(call: *mut u8, idx: u32, attr: *mut u8)
+extern fn LLVMGetEnumAttributeAtIndex(v: *mut u8, idx: u32, kind: u32) -> *mut u8
+extern fn LLVMGetTypeAttributeValue(attr: *mut u8) -> *mut u8
 
 // Basic blocks
 extern fn LLVMAppendBasicBlockInContext(c: *mut u8, fn_val: *mut u8, name: *const u8) -> *mut u8
@@ -777,6 +779,21 @@ pub fn wl_add_sret_attr(ctx: i64, fn_val: i64, param_idx: i32, ty: i64) -> Unit:
         if kind != 0:
             let attr = LLVMCreateTypeAttribute(ctx as *mut u8, kind, ty as *mut u8)
             LLVMAddAttributeAtIndex(fn_val as *mut u8, (param_idx + 1) as u32, attr)
+
+// Query the sret type of a function parameter. Returns the pointee aggregate
+// type carried by an `sret(T)` attribute, or 0 when the parameter is not
+// sret-lowered. Used to reconstruct a by-value signature from an already
+// sret-lowered concrete function (win64 aggregate return).
+pub fn wl_get_param_sret_type(fn_val: i64, param_idx: i32) -> i64:
+    unsafe:
+        let name = "sret" as *const u8
+        let kind = LLVMGetEnumAttributeKindForName(name, 4 as u64)
+        if kind == 0:
+            return 0
+        let attr = LLVMGetEnumAttributeAtIndex(fn_val as *mut u8, (param_idx + 1) as u32, kind)
+        if attr as i64 == 0:
+            return 0
+        LLVMGetTypeAttributeValue(attr) as i64
 
 pub fn wl_add_call_param_byval_attr(ctx: i64, call_val: i64, param_idx: i32, ty: i64) -> Unit:
     unsafe:

--- a/test/spec/spec_ss10_5_sequence_traverse_transpose.w
+++ b/test/spec/spec_ss10_5_sequence_traverse_transpose.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 fat-fn/closure ABI — sequence/traverse/transpose produce wrong output (exit 1)
 //! expect-stdout: ok
 // Spec test: Section 10.5 / 10.7 — sequence / traverse / transpose.
 

--- a/test/spec/spec_ss10_6_error_context.w
+++ b/test/spec/spec_ss10_6_error_context.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 codegen — error context produces wrong output (exit 1)
 // Spec test: Section 10.6 — Error Context (formerly 25.43)
 
 use std.result.ContextError

--- a/test/spec/spec_ss14_3_1_no_suspend_blocks.w
+++ b/test/spec/spec_ss14_3_1_no_suspend_blocks.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows async lowering — no-suspend blocks produce wrong output (exit 1)
 //! expect-stdout: ok
 
 use std.task.Task


### PR DESCRIPTION
Stacked on #818 (`windows-806-closure-sret`).

## Codegen fix

`mir_build_closure_fn_type` built the closure **call** type with manual
win64 sret-lowering: when `internal_abi_needs_sret(ret)` was true it
pushed an sret pointer parameter and set the return to `void`, ordering
the params env-first, sret-second.

But the closure **definition** is always emitted with a by-value direct
return (`define %str @__closure(ptr %env)`) — `gen_closure` forces
`current_function_name_sym = 0`, so a closure never inherits the
enclosing function's sret verdict. LLVM then applies its own win64 sret
to the callee: sret pointer in RCX, env shifted to RDX. The caller,
however, passed env in RCX and the sret pointer in RDX. Swapped
registers: the `str` result was written through the env pointer
(garbage) and the real destination was never written, so a
`str`-returning closure (e.g. `.with_context(() => "lazy")`) yielded a
corrupt message.

Removing the manual sret-lowering makes the call type match the
always-by-value callee. Contrast `mir_build_raw_fn_type`, whose sret
lowering is correct because a named fn-pointer target is itself
sret-lowered by `declare_function`; only the closure path diverged.
Gated behind `internal_abi_needs_sret` (false off win64), so linux/mac
IR is byte-identical.

## Test un-skips

Three spec tests failed only through the corrupted str-closure path and
now match their linux baseline (cross-built, run under wine, exit 0):

- `spec_ss10_6_error_context` — `str`-returning `with_context` closure
- `spec_ss10_5_sequence_traverse_transpose` — fat-fn/closure `str` values
- `spec_ss14_3_1_no_suspend_blocks` — async closure value return

The remaining four #806 tests (`option_result_combinators`,
`result_combinators_complete`, `error_trait`, `collect_targets`) still
fail on win64 through a distinct data-flow path and stay skipped.
