### PR TITLE
codegen(win64): indirect aggregate closure params by pointer; un-skip combinator tests (#806)

### DIFF
--- a/src/Codegen.w
+++ b/src/Codegen.w
@@ -4935,6 +4935,28 @@ impl Codegen:
             return false
         self.abi_size_of(param_ty) > 8
 
+    // #806/D6: the LLVM param type a fat-closure signature must declare for a
+    // value of `val_ty`. A win64 aggregate >8B is passed indirectly (pointer):
+    // the closure callee (gen_closure / mir_build_closure_fn_type) declares
+    // `ptr` and loads its own copy, so every inline closure-call site must
+    // declare `ptr` too or caller and callee disagree on the argument shape and
+    // the aggregate arrives corrupted (#806). No-op on non-win64.
+    mut fn closure_abi_param_ty(val_ty: i64) -> i64:
+        if self.internal_abi_needs_indirect_param(val_ty):
+            return wl_ptr_type(self.context)
+        val_ty
+
+    // #806/D6: marshal a by-value closure argument to match closure_abi_param_ty.
+    // For a win64-indirect param, materialize a caller-owned copy and pass its
+    // address (the callee loads its own copy from it); otherwise pass the value
+    // unchanged. No-op on non-win64.
+    mut fn closure_abi_arg(val_ty: i64, val: i64) -> i64:
+        if self.internal_abi_needs_indirect_param(val_ty):
+            let a = self.create_entry_alloca(val_ty)
+            wl_build_store(self.builder, val, a)
+            return a
+        val
+
     mut fn c_abi_needs_sret(ret_ty: i64) -> bool:
         if ret_ty == 0:
             return false

--- a/src/CodegenDispatch.w
+++ b/src/CodegenDispatch.w
@@ -17136,6 +17136,10 @@ impl Codegen:
         // semantic types in lockstep with the LLVM signature so closure-local MIR
         // can recover pointee types for reference parameters.
         let closure_param_sema_types: Vec[i32] = Vec.new()
+        // #D6: for a param passed indirectly on win64 (aggregate >8B), the entry
+        // holds the real by-value LLVM type so the body prologue can load a
+        // callee-owned copy from the incoming pointer; 0 for direct params.
+        let closure_param_real_llvm: Vec[i64] = Vec.new()
         let param_types: Vec[i64] = Vec.new()
         let closure_param_offset = if is_extern_closure: 0 else: 1
         if not is_extern_closure:
@@ -17153,12 +17157,21 @@ impl Codegen:
                     p_sema_ty = expected_p_sema_ty
             closure_param_sema_types.push(p_sema_ty)
             let p_llvm_ty = self.sema_type_to_llvm(p_sema_ty)
+            var chosen_ty = i32_ty
             if p_llvm_ty != 0:
-                param_types.push(p_llvm_ty)
+                chosen_ty = p_llvm_ty
             else if p_type != 0:
-                param_types.push(self.resolve_type(p_type))
+                chosen_ty = self.resolve_type(p_type)
+            // #D6: match mir_build_closure_fn_type — a win64 aggregate >8B param
+            // is passed indirectly (pointer), so the callee signature must
+            // declare `ptr` too, or caller and callee disagree on the argument
+            // shape and the aggregate arrives corrupted (#806).
+            if self.internal_abi_needs_indirect_param(chosen_ty):
+                closure_param_real_llvm.push(chosen_ty)
+                param_types.push(ptr_ty)
             else:
-                param_types.push(i32_ty)
+                closure_param_real_llvm.push(0)
+                param_types.push(chosen_ty)
         // Determine return type (infer from context or use i32)
         var ret_ty = i32_ty
         if closure_fn_ret_tid != 0:
@@ -17231,10 +17244,20 @@ impl Codegen:
         for i in 0..param_count:
             let p_name = self.pool.get_extra(extra_start + i * 2)
             let param_val = wl_get_param(closure_fn, i + closure_param_offset)
-            let param_ty = wl_type_of(param_val)
-            let alloca = self.create_entry_alloca(param_ty)
-            wl_build_store(self.builder, param_val, alloca)
-            self.record_local(p_name, alloca, param_ty, 1)
+            let real_ty = if i < closure_param_real_llvm.len() as i32: closure_param_real_llvm.get(i as i64) else: 0
+            if real_ty != 0:
+                // #D6 indirect param (win64 aggregate >8B): param_val is a pointer
+                // to the caller-materialized value. Load a callee-owned copy so the
+                // body reads its own storage, matching the indirect call ABI.
+                let loaded = wl_build_load(self.builder, real_ty, param_val)
+                let alloca = self.create_entry_alloca(real_ty)
+                wl_build_store(self.builder, loaded, alloca)
+                self.record_local(p_name, alloca, real_ty, 1)
+            else:
+                let param_ty = wl_type_of(param_val)
+                let alloca = self.create_entry_alloca(param_ty)
+                wl_build_store(self.builder, param_val, alloca)
+                self.record_local(p_name, alloca, param_ty, 1)
             if i < closure_param_sema_types.len() as i32:
                 self.record_local_sema_type(p_name, closure_param_sema_types.get(i as i64))
         // ── MIR-based closure body compilation ──────────────────────

--- a/src/CodegenDispatch.w
+++ b/src/CodegenDispatch.w
@@ -11465,7 +11465,7 @@ impl Codegen:
         if is_fat != 0:
             let fp: Vec[i64] = Vec.new()
             fp.push(ptr_ty)
-            fp.push(elem_ty)
+            fp.push(self.closure_abi_param_ty(elem_ty))
             fn_ty = wl_function_type(i1_ty, vec_data_i64(&fp), 2, 0)
         else:
             fn_ty = wl_global_get_value_type(fn_ptr)
@@ -11479,7 +11479,7 @@ impl Codegen:
         let filt_args: Vec[i64] = Vec.new()
         if is_fat != 0:
             filt_args.push(ctx_ptr)
-        filt_args.push(payload)
+        filt_args.push(self.closure_abi_arg(elem_ty, payload))
         let filt_arg_count = if is_fat != 0: 2 else: 1
         let pred_result = wl_build_call(self.builder, fn_ty, fn_ptr, vec_data_i64(&filt_args), filt_arg_count)
         var filt_bool = pred_result
@@ -11636,7 +11636,7 @@ impl Codegen:
             return self.coerce_value_to_type(payload, payload_ty)
         self.build_default_value(payload_ty)
 
-    fn mir_call_fn_value(fn_val: i64, ret_ty: i64, args: &Vec[i64], arg_count: i32) -> i64:
+    mut fn mir_call_fn_value(fn_val: i64, ret_ty: i64, args: &Vec[i64], arg_count: i32) -> i64:
         let ptr_ty = wl_ptr_type(self.context)
         let cty = wl_type_of(fn_val)
         var fn_ptr = fn_val
@@ -11654,8 +11654,9 @@ impl Codegen:
             param_tys.push(ptr_ty)
         for ai in 0..arg_count:
             let av = args.get(ai as i64)
-            call_args.push(av)
-            param_tys.push(wl_type_of(av))
+            let avt = wl_type_of(av)
+            call_args.push(self.closure_abi_arg(avt, av))
+            param_tys.push(self.closure_abi_param_ty(avt))
         if is_fat != 0:
             fn_ty = wl_function_type(ret_ty, vec_data_i64(&param_tys), arg_count + 1, 0)
         else:
@@ -13362,7 +13363,7 @@ impl Codegen:
             // Build fn_ty from closure calling convention: fn(ptr, elem) -> ret
             let fp: Vec[i64] = Vec.new()
             fp.push(ptr_ty)
-            fp.push(elem_ty)
+            fp.push(self.closure_abi_param_ty(elem_ty))
             fn_ty = wl_function_type(out_elem_ty, vec_data_i64(&fp), 2, 0)
             ret_ty = out_elem_ty
         else:
@@ -13401,7 +13402,7 @@ impl Codegen:
         let el = wl_build_load(self.builder, elem_ty, ep)
         let ca: Vec[i64] = Vec.new()
         if is_fat != 0: ca.push(ctx_ptr)
-        ca.push(el)
+        ca.push(self.closure_abi_arg(elem_ty, el))
         let cc = if is_fat != 0: 2 else: 1
         let rv = wl_build_call(self.builder, fn_ty, fn_ptr, vec_data_i64(&ca), cc)
         wl_build_store(self.builder, rv, tmp)
@@ -13453,7 +13454,7 @@ impl Codegen:
         if is_fat != 0:
             let fp: Vec[i64] = Vec.new()
             fp.push(ptr_ty)
-            fp.push(elem_ty)
+            fp.push(self.closure_abi_param_ty(elem_ty))
             fn_ty = wl_function_type(pred_ret_ty, vec_data_i64(&fp), 2, 0)
         else:
             fn_ty = wl_global_get_value_type(fn_ptr)
@@ -13491,7 +13492,7 @@ impl Codegen:
         let el = wl_build_load(self.builder, elem_ty, ep)
         let ca: Vec[i64] = Vec.new()
         if is_fat != 0: ca.push(ctx_ptr)
-        ca.push(el)
+        ca.push(self.closure_abi_arg(elem_ty, el))
         let cc = if is_fat != 0: 2 else: 1
         let pred = wl_build_call(self.builder, fn_ty, fn_ptr, vec_data_i64(&ca), cc)
         wl_build_cond_br(self.builder, wl_build_icmp(self.builder, wl_int_ne(), pred, wl_const_int(wl_type_of(pred), 0, 0)), pb, ib)
@@ -13585,8 +13586,8 @@ impl Codegen:
         if is_fat != 0:
             let fp: Vec[i64] = Vec.new()
             fp.push(ptr_ty)
-            fp.push(at)
-            fp.push(elem_ty)
+            fp.push(self.closure_abi_param_ty(at))
+            fp.push(self.closure_abi_param_ty(elem_ty))
             fn_ty = wl_function_type(at, vec_data_i64(&fp), 3, 0)
         else:
             fn_ty = wl_global_get_value_type(fn_ptr)
@@ -13616,8 +13617,8 @@ impl Codegen:
         let ca_val = wl_build_load(self.builder, at, aa)
         let ca: Vec[i64] = Vec.new()
         if is_fat != 0: ca.push(ctx_ptr)
-        ca.push(ca_val)
-        ca.push(el)
+        ca.push(self.closure_abi_arg(at, ca_val))
+        ca.push(self.closure_abi_arg(elem_ty, el))
         let cc = if is_fat != 0: 3 else: 2
         let nv = wl_build_call(self.builder, fn_ty, fn_ptr, vec_data_i64(&ca), cc)
         wl_build_store(self.builder, nv, aa)

--- a/test/spec/spec_ss10_3_option_result_combinators.w
+++ b/test/spec/spec_ss10_3_option_result_combinators.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 fat-fn/closure ABI — Option/Result combinators produce wrong output (exit 1)
 // Spec test: Section 10.3, 10.4 — Option/Result Combinators (formerly 25.22)
 
 // PASS: option chaining

--- a/test/spec/spec_ss10_6_result_combinators_complete.w
+++ b/test/spec/spec_ss10_6_result_combinators_complete.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 fat-fn/closure ABI — Result combinators produce wrong output (exit 1)
 //! expect-stdout: ok
 
 fn ok_i32(value: i32) -> Result[i32, str]:


### PR DESCRIPTION
## What

Fixes the win64 Option/Result **combinator** wrong-output class under #806
and un-skips the two affected spec tests on Windows.

`spec_ss10_3_option_result_combinators` and
`spec_ss10_6_result_combinators_complete` produced wrong output on win64
(e.g. `map_err(s => s.len())` returning `0` instead of `3`).

## Root cause (D6 — one ABI, read by both sides)

A closure **callee** built its parameter LLVM signature directly from each
parameter's by-value type. But the closure **call site**
(`mir_build_closure_fn_type`) applies `internal_abi_needs_indirect_param`,
so a win64 aggregate larger than 8 bytes — a 16-byte `str`, for instance —
is passed as a **pointer**. Caller and callee then disagreed on the
argument shape, so the aggregate arrived corrupted and the closure read
garbage.

This is the same single-ABI-source-of-truth divergence class as the
sibling dispatch-vs-vtable fix: one side re-derived the passing mode
independently of the other.

## Fix

Mirror the call-site decision in `gen_closure`:

- When a parameter is win64-indirect, declare it as `ptr` in the callee
  signature (matching the call site).
- In the body prologue, load a callee-owned copy from the incoming pointer
  into a local alloca, so the body reads its own storage.

The path is gated on `internal_abi_needs_indirect_param`, which is
win64-only, so **non-win64 targets are unchanged** (the branch is a no-op
and the direct-by-value path is taken exactly as before).

## Verification (native Windows VM)

Cross-built with the fixed stage1, run on the real Windows x86_64 VM:

| test | result |
|------|--------|
| `spec_ss10_3_option_result_combinators` | `ok` |
| `spec_ss10_6_result_combinators_complete` | `ok` |
| combinator matrix (map / map_err / and_then / or_else / filter) | all correct |

Regression — the closure/dyn tests already un-skipped by #818/#819/#820
still pass on the VM: `error_context`, `sequence_traverse_transpose`,
`no_suspend_blocks`, `error_trait` → all `ok`.

Stacked on #820.
