### PR TITLE
codegen(win64): sret-lower collect[String] runtime call (#806)

### DIFF
--- a/src/CodegenDispatch.w
+++ b/src/CodegenDispatch.w
@@ -12487,15 +12487,35 @@ impl Codegen:
             wl_build_br(self.builder, loop_bb)
             wl_position_at_end(self.builder, end_bb)
             let str_ty = self.mir_sema_type_to_llvm(self.sema.ty_str as i32)
-            let str_params: Vec[i64] = Vec.new()
-            str_params.push(ptr_ty)
-            let str_fn_ty = wl_function_type(str_ty, vec_data_i64(&str_params), 1, 0)
+            let str_sym = self.intern.intern("with_str_from_vec_u8")
             var str_fn = wl_get_named_function(self.llmod, "with_str_from_vec_u8")
             if str_fn == 0:
+                // D6: the callee returns `str` (16B), which win64 lowers via sret.
+                // Declare and call through the single FnAbi path so caller and
+                // callee agree instead of hand-rolling a direct return.
+                let str_params: Vec[i64] = Vec.new()
+                var str_ret_ty = str_ty
+                var str_has_sret = 0
+                let str_byval_types: Vec[i64] = Vec.new()
+                let str_direct_types: Vec[i64] = Vec.new()
+                if self.internal_abi_needs_sret(str_ty):
+                    str_has_sret = 1
+                    str_ret_ty = void_ty
+                    str_params.push(ptr_ty)
+                str_params.push(ptr_ty)
+                str_byval_types.push(0)
+                str_direct_types.push(0)
+                let str_fn_ty = wl_function_type(str_ret_ty, vec_data_i64(&str_params), str_params.len() as i32, 0)
                 str_fn = wl_add_function(self.llmod, "with_str_from_vec_u8", str_fn_ty)
+                if str_has_sret != 0:
+                    wl_add_sret_attr(self.context, str_fn, 0, str_ty)
+                    self.record_c_abi_transform(str_sym, str_has_sret, str_ty, 0, move str_byval_types, 0, move str_direct_types, 0)
+                self.fn_values.insert(str_sym, str_fn)
+                self.fn_fn_types.insert(str_sym, str_fn_ty)
+            let str_call_ty: i64 = self.fn_fn_types.get(str_sym).unwrap()
             let str_args: Vec[i64] = Vec.new()
             str_args.push(out_ptr)
-            return wl_build_call(self.builder, str_fn_ty, str_fn, vec_data_i64(&str_args), 1)
+            return self.build_call_fn_value(str_sym, str_fn, str_call_ty, -1, 0, str_args, 1, "collect_str", 0)
 
         if dest_base_sym == self.sym_hashset or dest_base_sym == self.sym_hashmap:
             var key_tid = 0

--- a/test/spec/spec_ss13_3_collect_targets.w
+++ b/test/spec/spec_ss13_3_collect_targets.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 codegen — collect targets produce wrong output (exit 1)
 //! expect-stdout: ok
 // Spec test: §13.3 collect[C] target selection.
 


### PR DESCRIPTION
## Problem

`collect[String]` produced corrupt output on win64 (exit 5/1). `mir_emit_iter_collect` hand-rolled a **direct-return** signature for the `with_str_from_vec_u8` runtime call, but win64 returns a 16-byte `str` aggregate via **sret** (hidden pointer first param). This is exactly the per-path ABI divergence D6 forbids: one call site re-derived `value vs sret` locally instead of reading the single `FnAbi`/`build_call_fn_value` path.

## Fix

Route the `with_str_from_vec_u8` call through `internal_abi_needs_sret` + `record_c_abi_transform` + `build_call_fn_value` — the same single sret-aware path every other call uses. No per-path ABI decision remains.

## Verification

- **IR (before):** `call %str @with_str_from_vec_u8(ptr %v)` (direct)
- **IR (after, win64):** `call void @with_str_from_vec_u8(ptr sret(%str) %out, ptr %v)` — matches callee prologue and sibling call sites
- **IR (after, linux/SysV):** unchanged direct 16B return — no regression
- **VM (real Windows x86_64):** `ct_string.exe` → ok EXIT=0; `ct_collect_targets.exe` → ok EXIT=0 (all 6 collect targets: Vec/HashSet/HashMap/BTreeSet/BTreeMap/String)
- Un-skips `test/spec/spec_ss13_3_collect_targets.w` on Windows

Stacked on #821 (windows-806-combinator-indirect).