### PR TITLE
Un-skip #798 regex comptime-crash compile-error tests on Windows

### DIFF
--- a/test/compile_errors/err_regex_capture_after_branch.w
+++ b/test/compile_errors/err_regex_capture_after_branch.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_capture_else_scope.w
+++ b/test/compile_errors/err_regex_capture_else_scope.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_capture_out_of_range.w
+++ b/test/compile_errors/err_regex_capture_out_of_range.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_capture_out_of_scope.w
+++ b/test/compile_errors/err_regex_capture_out_of_scope.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_compound_no_capture.w
+++ b/test/compile_errors/err_regex_compound_no_capture.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_invalid_literal.w
+++ b/test/compile_errors/err_regex_invalid_literal.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: invalid regex literal
 
 fn main:

--- a/test/compile_errors/err_regex_neg_match_no_capture.w
+++ b/test/compile_errors/err_regex_neg_match_no_capture.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_value_no_capture.w
+++ b/test/compile_errors/err_regex_value_no_capture.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:


### PR DESCRIPTION
The 0xC0000005 access violation in SemaCheck's in-process regex compilation (#798) was fixed by #790 (own PCRE string buffers before release). These 8 `test/compile_errors/err_regex_*.w` tests verify regex-literal comptime capture-group diagnostics.

Verified natively on Windows x86_64 with a fresh cross-built compiler: all 8 tests emit their exact expected `expect-check-fail` diagnostics (7× undefined-variable, 1× invalid-regex-literal: missing closing parenthesis) with zero access violations.

Tests un-skipped:
- err_regex_capture_out_of_range
- err_regex_value_no_capture
- err_regex_capture_after_branch
- err_regex_capture_else_scope
- err_regex_invalid_literal
- err_regex_compound_no_capture
- err_regex_capture_out_of_scope
- err_regex_neg_match_no_capture

The 7 runtime regex behavior/spec tests under #798 remain skipped pending separate CI runtime arbitration.