### PR TITLE
Wire Windows MSVC/UCRT include dirs into c_import (#799)

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -260,6 +260,14 @@ jobs:
           kit_ver="$(ls "$kit_root" | sort -V | tail -1)"
           echo "WITH_WINDOWS_UCRT_LIBDIR=$(cygpath -m "$kit_root/$kit_ver/ucrt/x64")" >> "$GITHUB_ENV"
           echo "WITH_WINDOWS_UM_LIBDIR=$(cygpath -m "$kit_root/$kit_ver/um/x64")" >> "$GITHUB_ENV"
+          # c_import system-header include dirs (ClangBridge.w reads
+          # WITH_WINDOWS_{MSVC,UCRT,SHARED,UM}_INCDIR).
+          echo "WITH_WINDOWS_MSVC_INCDIR=$(cygpath -m "$vs_root/VC/Tools/MSVC/$msvc_ver/include")" >> "$GITHUB_ENV"
+          kit_inc="/c/Program Files (x86)/Windows Kits/10/Include"
+          inc_ver="$(ls "$kit_inc" | sort -V | tail -1)"
+          echo "WITH_WINDOWS_UCRT_INCDIR=$(cygpath -m "$kit_inc/$inc_ver/ucrt")" >> "$GITHUB_ENV"
+          echo "WITH_WINDOWS_SHARED_INCDIR=$(cygpath -m "$kit_inc/$inc_ver/shared")" >> "$GITHUB_ENV"
+          echo "WITH_WINDOWS_UM_INCDIR=$(cygpath -m "$kit_inc/$inc_ver/um")" >> "$GITHUB_ENV"
           echo "$PWD/.deps/llvm-22.1.6-windows-x86_64-msvc/bin" >> "$GITHUB_PATH"
 
       - name: Build seed to release compiler

--- a/.github/workflows/selfhost-windows.yml
+++ b/.github/workflows/selfhost-windows.yml
@@ -102,6 +102,17 @@ jobs:
           echo "WITH_WINDOWS_UCRT_LIBDIR=$(cygpath -m "$kit_root/$kit_ver/ucrt/x64")" >> "$GITHUB_ENV"
           echo "WITH_WINDOWS_UM_LIBDIR=$(cygpath -m "$kit_root/$kit_ver/um/x64")" >> "$GITHUB_ENV"
 
+          # c_import system-header include dirs, read by ClangBridge.w via
+          # WITH_WINDOWS_{MSVC,UCRT,SHARED,UM}_INCDIR — the include-side analog
+          # of the LIBDIR wiring above. Without these, a system-header c_import
+          # (e.g. c_import("stdio.h")) cannot find MSVC/UCRT headers on Windows.
+          echo "WITH_WINDOWS_MSVC_INCDIR=$(cygpath -m "$vs_root/VC/Tools/MSVC/$msvc_ver/include")" >> "$GITHUB_ENV"
+          kit_inc="/c/Program Files (x86)/Windows Kits/10/Include"
+          inc_ver="$(ls "$kit_inc" | sort -V | tail -1)"
+          echo "WITH_WINDOWS_UCRT_INCDIR=$(cygpath -m "$kit_inc/$inc_ver/ucrt")" >> "$GITHUB_ENV"
+          echo "WITH_WINDOWS_SHARED_INCDIR=$(cygpath -m "$kit_inc/$inc_ver/shared")" >> "$GITHUB_ENV"
+          echo "WITH_WINDOWS_UM_INCDIR=$(cygpath -m "$kit_inc/$inc_ver/um")" >> "$GITHUB_ENV"
+
           # lld-link.exe on PATH for the native COFF link step.
           echo "$PWD/.deps/llvm-22.1.6-windows-x86_64-msvc/bin" >> "$GITHUB_PATH"
 
@@ -113,6 +124,8 @@ jobs:
           echo "MSVC_LIBDIR=$WITH_WINDOWS_MSVC_LIBDIR"
           echo "UCRT_LIBDIR=$WITH_WINDOWS_UCRT_LIBDIR"
           echo "UM_LIBDIR=$WITH_WINDOWS_UM_LIBDIR"
+          echo "MSVC_INCDIR=$WITH_WINDOWS_MSVC_INCDIR"
+          echo "UCRT_INCDIR=$WITH_WINDOWS_UCRT_INCDIR"
           command -v lld-link.exe && lld-link.exe --version || true
 
       - name: Build (seed -> stage1 -> stage2 -> stage3)

--- a/test/behavior/behav_c_import_sdk_header.w
+++ b/test/behavior/behav_c_import_sdk_header.w
@@ -1,4 +1,3 @@
-//! skip-windows: #799: c_import("stdio.h") needs system headers, but the c_import clang invocation (src/compiler/ClangBridge.w) wires macOS -isysroot/-resource-dir with no Windows MSVC/UCRT/UM include dirs or windows target triple, so <stdio.h> is not found on native Windows; inline-decl c_import (no system header) works and is un-skipped
 // §16.1: a system-header c_import resolves the target macOS SDK without
 // spawning xcrun (env SDKROOT/WITH_SDKROOT, with.toml [c_import] sdk_path, or
 // a well-known SDK path). A successful import with modeled constants proves


### PR DESCRIPTION
`src/compiler/ClangBridge.w` already reads `WITH_WINDOWS_{MSVC,UCRT,SHARED,UM}_INCDIR` to add system-header include dirs for `c_import` on native Windows (the include-side analog of the `WITH_WINDOWS_*_LIBDIR` link wiring), and `build/compiler.w` forwards them into the child compiler process — but the CI/release workflows never set them. So `c_import("stdio.h")` could not find the MSVC/UCRT headers and every system-header `c_import` was skip-gated on Windows.

This sets the four `*_INCDIR` vars from the same `vswhere`/Windows Kit roots the existing `LIBDIR` block already locates, in both `selfhost-windows.yml` and `nightly-release.yml`, and un-skips `behav_c_import_sdk_header` (asserts `SEEK_SET==0`, `SEEK_END==2` from `<stdio.h>` — portable UCRT constants).

On Windows `get_sdk_path()` returns 0 (no macOS `-isysroot`), so the wired `-I` dirs plus the embedded clang `-resource-dir` are the header source; the host libclang default triple is already `x86_64-pc-windows-msvc`.

The other four #799 skips stay — none is resolved by include-dir wiring:
- `behav_c_import_borrows_annotation`, `behav_c_import_borrow_param_readdir`: opendir/readdir/telldir are POSIX `<dirent.h>`, link-undefined on MSVCRT
- `behav_c_import_owning_wrapper_fopen`: hardcoded Unix `/tmp` path + `tmpfile()` privilege dependence
- `spec_ss16_ffi_and_c_import`: links libm (`m`), which has no separate Windows library