### PR TITLE
Probe: clean-CI verdict for #802/#800 p7 Windows skips

### DIFF
--- a/test/behavior/behav_action_capability_filesystem.w
+++ b/test/behavior/behav_action_capability_filesystem.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #800: action/capability/net/process/fs OS-surface fails on native Windows
 //! expect-stdout: ok
 
 use pre_d_build_runner

--- a/test/behavior/behav_action_capability_process.w
+++ b/test/behavior/behav_action_capability_process.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #800: action/capability/net/process/fs OS-surface fails on native Windows
 //! expect-stdout: ok
 
 use pre_d_build_runner

--- a/test/behavior/behav_action_crash_diagnostic.w
+++ b/test/behavior/behav_action_crash_diagnostic.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #800: action/capability/net/process/fs OS-surface fails on native Windows
 //! expect-stdout: ok
 
 use pre_d_build_runner

--- a/test/behavior/behav_action_no_deps_isolation.w
+++ b/test/behavior/behav_action_no_deps_isolation.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #800: action/capability/net/process/fs OS-surface fails on native Windows
 //! expect-stdout: ok
 
 use std.fs

--- a/test/behavior/behav_build_w_basic_invocation.w
+++ b/test/behavior/behav_build_w_basic_invocation.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #802: core-language behavior fails on native Windows (needs root-cause)
 //! expect-stdout: ok
 
 use pre_d_build_runner

--- a/test/behavior/behav_capability_token_mismatch.w
+++ b/test/behavior/behav_capability_token_mismatch.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #800: action/capability/net/process/fs OS-surface fails on native Windows
 //! expect-stdout: ok
 
 use pre_d_build_runner

--- a/test/behavior/behav_cli_test_command_args.w
+++ b/test/behavior/behav_cli_test_command_args.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #802: core-language behavior fails on native Windows (needs root-cause)
 //! expect-stdout: ok
 
 use pre_d_build_runner


### PR DESCRIPTION
Draft probe (do not merge as-is). Un-skips the two #802 core-language behavior tests and five #800 action/capability tests on Windows to read the true native-Windows CI verdict on a clean main base, now that the p7 harness fixes (rt_getcwd/.exe/p7_cwd .to_owned()) are all present on main. Green tests here get folded into a real delivery PR; red ones get re-skipped with an accurate, deeper root-cause reason.