### PR TITLE
Probe: clean-CI verdict for #798 regex behavior Windows skips

### DIFF
--- a/test/behavior/behav_fstring_hole_backslashes.w
+++ b/test/behavior/behav_fstring_hole_backslashes.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal codegen crash (0xC0000005) on native Windows
 //! expect-stdout: ok
 
 // #656: f-string hole normalization must not strip source-level

--- a/test/behavior/behav_nonassoc_parenthesized.w
+++ b/test/behavior/behav_nonassoc_parenthesized.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal codegen crash (0xC0000005) on native Windows
 //! expect-stdout: ok
 
 fn main:

--- a/test/behavior/behav_prelude_import_gate.w
+++ b/test/behavior/behav_prelude_import_gate.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal codegen crash (0xC0000005) on native Windows
 //! expect-stdout: ok
 
 // D29 #750 scaffolding: non-§18.2 prelude-closure names resolve only through

--- a/test/behavior/behav_regex_capture_fstring.w
+++ b/test/behavior/behav_regex_capture_fstring.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal codegen crash (0xC0000005) on native Windows
 //! expect-stdout: ok
 
 use std.regex

--- a/test/behavior/behav_regex_language_semantics.w
+++ b/test/behavior/behav_regex_language_semantics.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal codegen crash (0xC0000005) on native Windows
 //! expect-stdout: ok
 
 fn test_global_match_operator_progresses:

--- a/test/behavior/behav_regex_std.w
+++ b/test/behavior/behav_regex_std.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal codegen crash (0xC0000005) on native Windows
 //! expect-stdout: ok
 
 use std.regex.Captures

--- a/test/spec/spec_ss15_8_regex_branch_captures.w
+++ b/test/spec/spec_ss15_8_regex_branch_captures.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: Windows regex-literal codegen crash (0xC0000005)
 //! expect-stdout: ok
 
 use std.regex


### PR DESCRIPTION
Draft probe. #790 (own PCRE string buffers before release) fixed the regex 0xC0000005 crash on main, so these seven regex/fstring behavior + spec tests that run a regex literal should no longer crash on native Windows. This reads the true clean-CI verdict on a main base. Green → fold into a real delivery PR (stale skips); red → CI log gives the deeper root cause and the test gets re-skipped with an accurate reason. Sibling to the #798 err_regex_* compile-errors handled on windows-798-unskip-compile-errors.