### PR TITLE
rt(win64): Winsock backend for std.net; un-skip net_loopback (#800)

### DIFF
--- a/rt/windows_x86_64.w
+++ b/rt/windows_x86_64.w
@@ -976,3 +976,259 @@ pub unsafe fn rt_compat_exec_argv_capture_spawn(args: &str, stdout_path: &str, s
 
 pub unsafe fn rt_compat_exec_wait(pid: i32, timeout_ms: i32) -> i32:
     win_wait_process_slot(pid, timeout_ms, true)
+
+// ---------------------------------------------------------------------------
+// Networking (Winsock2 / ws2_32). Mirrors the POSIX backend in
+// rt/linux_x86_64.w:with_net_*, translated to Winsock semantics: SOCKET
+// handles are returned as i64 (INVALID_SOCKET reads as -1), closesocket
+// replaces close, send/recv take int-width lengths, and socket creation is
+// gated behind a one-time WSAStartup. ws2_32.lib is already on the Windows
+// link line (src/compiler/Link.w). Loopback handles fit in i32, so the public
+// with_net_* i32-fd ABI declared by std.net is preserved on both platforms.
+// ---------------------------------------------------------------------------
+
+extern fn WSAStartup(version: u16, data: *mut u8) -> i32
+extern fn socket(af: i32, ty: i32, protocol: i32) -> i64
+extern fn connect(s: i64, addr: *const u8, namelen: i32) -> i32
+extern fn bind(s: i64, addr: *const u8, namelen: i32) -> i32
+extern fn listen(s: i64, backlog: i32) -> i32
+extern fn accept(s: i64, addr: *mut u8, addrlen: *mut i32) -> i64
+extern fn getsockname(s: i64, addr: *mut u8, addrlen: *mut i32) -> i32
+extern fn send(s: i64, buf: *const u8, len: i32, flags: i32) -> i32
+extern fn recv(s: i64, buf: *mut u8, len: i32, flags: i32) -> i32
+extern fn closesocket(s: i64) -> i32
+extern fn getaddrinfo(node: *const u8, service: *const u8, hints: *const WindowsAddrInfo, res: *mut *mut WindowsAddrInfo) -> i32
+extern fn freeaddrinfo(res: *mut WindowsAddrInfo) -> Unit
+extern fn with_str_from_bytes(s: *const u8, len: i64) -> str
+
+// Win64 ADDRINFOA (ws2def.h): ai_addrlen is size_t (u64) and ai_canonname
+// precedes ai_addr — both differ from the Linux struct addrinfo layout.
+type WindowsAddrInfo:
+    ai_flags: i32
+    ai_family: i32
+    ai_socktype: i32
+    ai_protocol: i32
+    ai_addrlen: u64
+    ai_canonname: *mut u8
+    ai_addr: *mut u8
+    ai_next: *mut WindowsAddrInfo
+
+fn rt_net_str_data(s: &str) -> *const u8:
+    unsafe **(&s as *const *const *const u8)
+
+fn rt_net_wsa_ensure() -> i32:
+    // 0x0202 == Winsock 2.2. WSAStartup is refcounted; we never WSACleanup
+    // (a process-lifetime refcount leak, matching how the runtime treats other
+    // one-shot OS init).
+    var wsadata: [512]u8 = [0 as u8; 512]
+    WSAStartup(514 as u16, &raw mut wsadata as *mut [512]u8 as *mut u8)
+
+fn rt_net_empty_str() -> str:
+    with_str_from_bytes("" as *const u8, 0)
+
+fn rt_net_copy_str_to_c_buf(s: &str, out: *mut u8, cap: i64) -> i32:
+    if s.len() + 1 > cap:
+        return -1
+    var i: i64 = 0
+    while i < s.len():
+        unsafe *((out as i64 + i) as *mut u8) = s.byte_at(i) as u8
+        i = i + 1
+    unsafe *((out as i64 + i) as *mut u8) = 0
+    0
+
+fn rt_net_write_port_to_c_buf(port: i32, out: *mut u8, cap: i64) -> i32:
+    if port < 0 or port > 65535 or cap < 2:
+        return -1
+    var rev: [6]u8 = [0 as u8; 6]
+    var n = port
+    var len: i64 = 0
+    if n == 0:
+        rev[0] = 48 as u8
+        len = 1
+    else:
+        while n > 0:
+            rev[len] = (48 + (n % 10)) as u8
+            len = len + 1
+            n = n / 10
+    if len + 1 > cap:
+        return -1
+    var i: i64 = 0
+    while i < len:
+        unsafe *((out as i64 + i) as *mut u8) = rev[len - i - 1]
+        i = i + 1
+    unsafe *((out as i64 + len) as *mut u8) = 0
+    0
+
+// Fill a 16-byte sockaddr_in for `port` from a dotted-quad IPv4 literal.
+// Returns 0 on success, -1 when `host` is not a numeric IPv4 address (the
+// caller then resolves it through getaddrinfo).
+fn rt_net_fill_sockaddr_ipv4(host: &str, port: i32, sa: *mut u8) -> i32:
+    var parts: [4]i32 = [0 as i32; 4]
+    var idx: i64 = 0
+    var cur: i32 = 0
+    var have_digit = false
+    var i: i64 = 0
+    while i < host.len():
+        let c = host.byte_at(i) as i32
+        if c >= 48 and c <= 57:
+            cur = cur * 10 + (c - 48)
+            if cur > 255:
+                return -1
+            have_digit = true
+        else if c == 46:
+            if not have_digit or idx >= 3:
+                return -1
+            parts[idx] = cur
+            idx = idx + 1
+            cur = 0
+            have_digit = false
+        else:
+            return -1
+        i = i + 1
+    if not have_digit or idx != 3:
+        return -1
+    parts[3] = cur
+    // sin_family=AF_INET(2) LE, sin_port big-endian, sin_addr network order.
+    unsafe *((sa as i64 + 0) as *mut u8) = 2 as u8
+    unsafe *((sa as i64 + 1) as *mut u8) = 0 as u8
+    unsafe *((sa as i64 + 2) as *mut u8) = ((port >> 8) & 255) as u8
+    unsafe *((sa as i64 + 3) as *mut u8) = (port & 255) as u8
+    unsafe *((sa as i64 + 4) as *mut u8) = parts[0] as u8
+    unsafe *((sa as i64 + 5) as *mut u8) = parts[1] as u8
+    unsafe *((sa as i64 + 6) as *mut u8) = parts[2] as u8
+    unsafe *((sa as i64 + 7) as *mut u8) = parts[3] as u8
+    var j: i64 = 8
+    while j < 16:
+        unsafe *((sa as i64 + j) as *mut u8) = 0 as u8
+        j = j + 1
+    0
+
+fn rt_net_connect_any(host: &str, port: i32, socktype: i32, protocol: i32) -> i32:
+    if rt_net_wsa_ensure() != 0:
+        return -1
+    var sa: [16]u8 = [0 as u8; 16]
+    if rt_net_fill_sockaddr_ipv4(host, port, &raw mut sa as *mut [16]u8 as *mut u8) == 0:
+        let fd = socket(2, socktype, protocol)
+        if fd < 0:
+            return -1
+        if connect(fd, &sa as *const [16]u8 as *const u8, 16) != 0:
+            let _ = closesocket(fd)
+            return -1
+        return fd as i32
+    // Non-numeric host: resolve through getaddrinfo.
+    var host_buf: [256]u8 = [0 as u8; 256]
+    var port_buf: [16]u8 = [0 as u8; 16]
+    if rt_net_copy_str_to_c_buf(host, &raw mut host_buf as *mut [256]u8 as *mut u8, 256) != 0:
+        return -1
+    if rt_net_write_port_to_c_buf(port, &raw mut port_buf as *mut [16]u8 as *mut u8, 16) != 0:
+        return -1
+    var hints = WindowsAddrInfo {
+        ai_flags: 0,
+        ai_family: 0,
+        ai_socktype: socktype,
+        ai_protocol: protocol,
+        ai_addrlen: 0 as u64,
+        ai_canonname: 0 as *mut u8,
+        ai_addr: 0 as *mut u8,
+        ai_next: 0 as *mut WindowsAddrInfo,
+    }
+    var res: *mut WindowsAddrInfo = 0 as *mut WindowsAddrInfo
+    let gai = getaddrinfo(&host_buf as *const [256]u8 as *const u8, &port_buf as *const [16]u8 as *const u8, &hints as *const WindowsAddrInfo, &raw mut res as *mut *mut WindowsAddrInfo)
+    if gai != 0 or res as i64 == 0:
+        return -1
+    var p = res
+    while p as i64 != 0:
+        let fd = socket((unsafe *p).ai_family, (unsafe *p).ai_socktype, (unsafe *p).ai_protocol)
+        if fd >= 0:
+            let rc = connect(fd, (unsafe *p).ai_addr as *const u8, (unsafe *p).ai_addrlen as i32)
+            if rc == 0:
+                freeaddrinfo(res)
+                return fd as i32
+            let _ = closesocket(fd)
+        p = (unsafe *p).ai_next
+    freeaddrinfo(res)
+    -1
+
+pub fn with_net_tcp_connect(host: str, port: i32) -> i32:
+    rt_net_connect_any(&host, port, 1, 6)
+
+pub fn with_net_udp_connect(host: str, port: i32) -> i32:
+    rt_net_connect_any(&host, port, 2, 17)
+
+fn rt_net_bind_inaddr_any(fd: i64, port: i32) -> i32:
+    var sa: [16]u8 = [0 as u8; 16]
+    sa[0] = 2 as u8
+    sa[2] = ((port >> 8) & 255) as u8
+    sa[3] = (port & 255) as u8
+    bind(fd, &sa as *const [16]u8 as *const u8, 16)
+
+pub fn with_net_tcp_listen(port: i32, backlog: i32) -> i32:
+    if port < 0 or port > 65535:
+        return -1
+    if rt_net_wsa_ensure() != 0:
+        return -1
+    let fd = socket(2, 1, 6)
+    if fd < 0:
+        return -1
+    if rt_net_bind_inaddr_any(fd, port) != 0:
+        let _ = closesocket(fd)
+        return -1
+    if listen(fd, backlog) != 0:
+        let _ = closesocket(fd)
+        return -1
+    fd as i32
+
+pub fn with_net_tcp_accept(sock: i32) -> i32:
+    let fd = accept(sock as i64, 0 as *mut u8, 0 as *mut i32)
+    if fd < 0:
+        return -1
+    fd as i32
+
+pub fn with_net_udp_bind(port: i32) -> i32:
+    if port < 0 or port > 65535:
+        return -1
+    if rt_net_wsa_ensure() != 0:
+        return -1
+    let fd = socket(2, 2, 17)
+    if fd < 0:
+        return -1
+    if rt_net_bind_inaddr_any(fd, port) != 0:
+        let _ = closesocket(fd)
+        return -1
+    fd as i32
+
+pub fn with_net_sock_port(sock: i32) -> i32:
+    var sa: [16]u8 = [0 as u8; 16]
+    var sl: i32 = 16
+    if getsockname(sock as i64, &raw mut sa as *mut [16]u8 as *mut u8, &raw mut sl) != 0:
+        return -1
+    ((sa[2] as i32) << 8) | (sa[3] as i32)
+
+pub fn with_net_send(sock: i32, data: str) -> i64:
+    let ptr = rt_net_str_data(&data)
+    let total = data.len()
+    var written: i64 = 0
+    while written < total:
+        let chunk = total - written
+        let r = send(sock as i64, (ptr as i64 + written) as *const u8, chunk as i32, 0)
+        if r <= 0:
+            return if written > 0: written else: -1
+        written = written + (r as i64)
+    written
+
+pub fn with_net_recv(sock: i32, max_len: i64) -> str:
+    if max_len <= 0:
+        return rt_net_empty_str()
+    let buf = with_alloc(max_len)
+    if buf as i64 == 0:
+        return rt_net_empty_str()
+    let r = recv(sock as i64, buf, max_len as i32, 0)
+    if r <= 0:
+        with_free(buf)
+        return rt_net_empty_str()
+    let out = with_str_from_bytes(buf as *const u8, r as i64)
+    with_free(buf)
+    out
+
+pub fn with_net_close(sock: i32) -> i32:
+    closesocket(sock as i64)

--- a/src/Codegen.w
+++ b/src/Codegen.w
@@ -4939,6 +4939,28 @@ impl Codegen:
             return false
         self.abi_size_of(param_ty) > 8
 
+    // #806/D6: the LLVM param type a fat-closure signature must declare for a
+    // value of `val_ty`. A win64 aggregate >8B is passed indirectly (pointer):
+    // the closure callee (gen_closure / mir_build_closure_fn_type) declares
+    // `ptr` and loads its own copy, so every inline closure-call site must
+    // declare `ptr` too or caller and callee disagree on the argument shape and
+    // the aggregate arrives corrupted (#806). No-op on non-win64.
+    mut fn closure_abi_param_ty(val_ty: i64) -> i64:
+        if self.internal_abi_needs_indirect_param(val_ty):
+            return wl_ptr_type(self.context)
+        val_ty
+
+    // #806/D6: marshal a by-value closure argument to match closure_abi_param_ty.
+    // For a win64-indirect param, materialize a caller-owned copy and pass its
+    // address (the callee loads its own copy from it); otherwise pass the value
+    // unchanged. No-op on non-win64.
+    mut fn closure_abi_arg(val_ty: i64, val: i64) -> i64:
+        if self.internal_abi_needs_indirect_param(val_ty):
+            let a = self.create_entry_alloca(val_ty)
+            wl_build_store(self.builder, val, a)
+            return a
+        val
+
     mut fn c_abi_needs_sret(ret_ty: i64) -> bool:
         if ret_ty == 0:
             return false

--- a/src/Codegen.w
+++ b/src/Codegen.w
@@ -1507,6 +1507,50 @@ impl Codegen:
             return fat
         let orig_param_count = wl_count_param_types(orig_fn_ty)
         let orig_ret_ty = wl_get_return_type(orig_fn_ty)
+        // On win64 a concrete function returning an aggregate >8B is physically
+        // sret-lowered by declare_function: `void(ptr sret, real_args...)`. A
+        // closure fn type (mir_build_closure_fn_type), by contrast, is by-value
+        // (`AGG(ptr ctx, real_args...)`) and LLVM inserts the hidden sret pointer
+        // FIRST — so the physical closure convention is `void(sret, ctx, args)`.
+        // Naively prepending ctx to the sret-lowered concrete type yields
+        // `void(ctx, sret, args)`, swapping ctx and sret and corrupting the
+        // result (#806/#819). Rebuild the thunk by-value to match the closure
+        // convention, and let LLVM sret-lower both the thunk definition and the
+        // closure call site identically.
+        let concrete_sret_ty = wl_get_param_sret_type(fn_val, 0)
+        if concrete_sret_ty != 0:
+            let thunk_params: Vec[i64] = Vec.new()
+            thunk_params.push(ptr_ty)
+            // Real args are the concrete params after the leading sret pointer.
+            for pi in 1..orig_param_count:
+                thunk_params.push(wl_get_fn_param_type(orig_fn_ty, pi))
+            let thunk_fn_ty = wl_function_type(concrete_sret_ty, vec_data_i64(&thunk_params), thunk_params.len() as i32, 0)
+            let thunk_id = self.closure_counter
+            self.closure_counter = thunk_id + 1
+            let thunk_name = f"__fn_thunk_{thunk_id}"
+            let thunk_fn = wl_add_function(self.llmod, thunk_name, thunk_fn_ty)
+            wl_set_linkage(thunk_fn, wl_internal_linkage())
+            let saved_bb = wl_get_insert_block(self.builder)
+            let entry = wl_append_bb(self.context, thunk_fn, "entry")
+            wl_position_at_end(self.builder, entry)
+            // Result buffer for the concrete sret call; loaded back and returned
+            // by value so LLVM lowers the thunk return the same way the closure
+            // call site is lowered. Target the thunk explicitly — self.current_function
+            // still names the outer function that triggered the coercion.
+            let result_buf = wl_create_entry_alloca(self.builder, thunk_fn, concrete_sret_ty)
+            let call_args: Vec[i64] = Vec.new()
+            call_args.push(result_buf)
+            for pi in 1..orig_param_count:
+                call_args.push(wl_get_param(thunk_fn, pi))
+            let call = wl_build_call(self.builder, orig_fn_ty, fn_val, vec_data_i64(&call_args), orig_param_count)
+            wl_add_call_sret_attr(self.context, call, 0, concrete_sret_ty)
+            let loaded = wl_build_load(self.builder, concrete_sret_ty, result_buf)
+            wl_build_ret(self.builder, loaded)
+            wl_position_at_end(self.builder, saved_bb)
+            var fat_s = wl_get_undef(fat_ty)
+            fat_s = wl_build_insert_value(self.builder, fat_s, thunk_fn, 0)
+            fat_s = wl_build_insert_value(self.builder, fat_s, wl_const_null(ptr_ty), 1)
+            return fat_s
         // Build thunk function type: fn(ptr, original_params...) -> original_ret
         let thunk_params: Vec[i64] = Vec.new()
         thunk_params.push(ptr_ty)

--- a/src/CodegenDispatch.w
+++ b/src/CodegenDispatch.w
@@ -11480,7 +11480,7 @@ impl Codegen:
         if is_fat != 0:
             let fp: Vec[i64] = Vec.new()
             fp.push(ptr_ty)
-            fp.push(elem_ty)
+            fp.push(self.closure_abi_param_ty(elem_ty))
             fn_ty = wl_function_type(i1_ty, vec_data_i64(&fp), 2, 0)
         else:
             fn_ty = wl_global_get_value_type(fn_ptr)
@@ -11494,7 +11494,7 @@ impl Codegen:
         let filt_args: Vec[i64] = Vec.new()
         if is_fat != 0:
             filt_args.push(ctx_ptr)
-        filt_args.push(payload)
+        filt_args.push(self.closure_abi_arg(elem_ty, payload))
         let filt_arg_count = if is_fat != 0: 2 else: 1
         let pred_result = wl_build_call(self.builder, fn_ty, fn_ptr, vec_data_i64(&filt_args), filt_arg_count)
         var filt_bool = pred_result
@@ -11651,7 +11651,7 @@ impl Codegen:
             return self.coerce_value_to_type(payload, payload_ty)
         self.build_default_value(payload_ty)
 
-    fn mir_call_fn_value(fn_val: i64, ret_ty: i64, args: &Vec[i64], arg_count: i32) -> i64:
+    mut fn mir_call_fn_value(fn_val: i64, ret_ty: i64, args: &Vec[i64], arg_count: i32) -> i64:
         let ptr_ty = wl_ptr_type(self.context)
         let cty = wl_type_of(fn_val)
         var fn_ptr = fn_val
@@ -11669,8 +11669,9 @@ impl Codegen:
             param_tys.push(ptr_ty)
         for ai in 0..arg_count:
             let av = args.get(ai as i64)
-            call_args.push(av)
-            param_tys.push(wl_type_of(av))
+            let avt = wl_type_of(av)
+            call_args.push(self.closure_abi_arg(avt, av))
+            param_tys.push(self.closure_abi_param_ty(avt))
         if is_fat != 0:
             fn_ty = wl_function_type(ret_ty, vec_data_i64(&param_tys), arg_count + 1, 0)
         else:
@@ -13377,7 +13378,7 @@ impl Codegen:
             // Build fn_ty from closure calling convention: fn(ptr, elem) -> ret
             let fp: Vec[i64] = Vec.new()
             fp.push(ptr_ty)
-            fp.push(elem_ty)
+            fp.push(self.closure_abi_param_ty(elem_ty))
             fn_ty = wl_function_type(out_elem_ty, vec_data_i64(&fp), 2, 0)
             ret_ty = out_elem_ty
         else:
@@ -13416,7 +13417,7 @@ impl Codegen:
         let el = wl_build_load(self.builder, elem_ty, ep)
         let ca: Vec[i64] = Vec.new()
         if is_fat != 0: ca.push(ctx_ptr)
-        ca.push(el)
+        ca.push(self.closure_abi_arg(elem_ty, el))
         let cc = if is_fat != 0: 2 else: 1
         let rv = wl_build_call(self.builder, fn_ty, fn_ptr, vec_data_i64(&ca), cc)
         wl_build_store(self.builder, rv, tmp)
@@ -13468,7 +13469,7 @@ impl Codegen:
         if is_fat != 0:
             let fp: Vec[i64] = Vec.new()
             fp.push(ptr_ty)
-            fp.push(elem_ty)
+            fp.push(self.closure_abi_param_ty(elem_ty))
             fn_ty = wl_function_type(pred_ret_ty, vec_data_i64(&fp), 2, 0)
         else:
             fn_ty = wl_global_get_value_type(fn_ptr)
@@ -13506,7 +13507,7 @@ impl Codegen:
         let el = wl_build_load(self.builder, elem_ty, ep)
         let ca: Vec[i64] = Vec.new()
         if is_fat != 0: ca.push(ctx_ptr)
-        ca.push(el)
+        ca.push(self.closure_abi_arg(elem_ty, el))
         let cc = if is_fat != 0: 2 else: 1
         let pred = wl_build_call(self.builder, fn_ty, fn_ptr, vec_data_i64(&ca), cc)
         wl_build_cond_br(self.builder, wl_build_icmp(self.builder, wl_int_ne(), pred, wl_const_int(wl_type_of(pred), 0, 0)), pb, ib)
@@ -13600,8 +13601,8 @@ impl Codegen:
         if is_fat != 0:
             let fp: Vec[i64] = Vec.new()
             fp.push(ptr_ty)
-            fp.push(at)
-            fp.push(elem_ty)
+            fp.push(self.closure_abi_param_ty(at))
+            fp.push(self.closure_abi_param_ty(elem_ty))
             fn_ty = wl_function_type(at, vec_data_i64(&fp), 3, 0)
         else:
             fn_ty = wl_global_get_value_type(fn_ptr)
@@ -13631,8 +13632,8 @@ impl Codegen:
         let ca_val = wl_build_load(self.builder, at, aa)
         let ca: Vec[i64] = Vec.new()
         if is_fat != 0: ca.push(ctx_ptr)
-        ca.push(ca_val)
-        ca.push(el)
+        ca.push(self.closure_abi_arg(at, ca_val))
+        ca.push(self.closure_abi_arg(elem_ty, el))
         let cc = if is_fat != 0: 3 else: 2
         let nv = wl_build_call(self.builder, fn_ty, fn_ptr, vec_data_i64(&ca), cc)
         wl_build_store(self.builder, nv, aa)

--- a/src/CodegenDispatch.w
+++ b/src/CodegenDispatch.w
@@ -17151,6 +17151,10 @@ impl Codegen:
         // semantic types in lockstep with the LLVM signature so closure-local MIR
         // can recover pointee types for reference parameters.
         let closure_param_sema_types: Vec[i32] = Vec.new()
+        // #D6: for a param passed indirectly on win64 (aggregate >8B), the entry
+        // holds the real by-value LLVM type so the body prologue can load a
+        // callee-owned copy from the incoming pointer; 0 for direct params.
+        let closure_param_real_llvm: Vec[i64] = Vec.new()
         let param_types: Vec[i64] = Vec.new()
         let closure_param_offset = if is_extern_closure: 0 else: 1
         if not is_extern_closure:
@@ -17168,12 +17172,21 @@ impl Codegen:
                     p_sema_ty = expected_p_sema_ty
             closure_param_sema_types.push(p_sema_ty)
             let p_llvm_ty = self.sema_type_to_llvm(p_sema_ty)
+            var chosen_ty = i32_ty
             if p_llvm_ty != 0:
-                param_types.push(p_llvm_ty)
+                chosen_ty = p_llvm_ty
             else if p_type != 0:
-                param_types.push(self.resolve_type(p_type))
+                chosen_ty = self.resolve_type(p_type)
+            // #D6: match mir_build_closure_fn_type — a win64 aggregate >8B param
+            // is passed indirectly (pointer), so the callee signature must
+            // declare `ptr` too, or caller and callee disagree on the argument
+            // shape and the aggregate arrives corrupted (#806).
+            if self.internal_abi_needs_indirect_param(chosen_ty):
+                closure_param_real_llvm.push(chosen_ty)
+                param_types.push(ptr_ty)
             else:
-                param_types.push(i32_ty)
+                closure_param_real_llvm.push(0)
+                param_types.push(chosen_ty)
         // Determine return type (infer from context or use i32)
         var ret_ty = i32_ty
         if closure_fn_ret_tid != 0:
@@ -17246,10 +17259,20 @@ impl Codegen:
         for i in 0..param_count:
             let p_name = self.pool.get_extra(extra_start + i * 2)
             let param_val = wl_get_param(closure_fn, i + closure_param_offset)
-            let param_ty = wl_type_of(param_val)
-            let alloca = self.create_entry_alloca(param_ty)
-            wl_build_store(self.builder, param_val, alloca)
-            self.record_local(p_name, alloca, param_ty, 1)
+            let real_ty = if i < closure_param_real_llvm.len() as i32: closure_param_real_llvm.get(i as i64) else: 0
+            if real_ty != 0:
+                // #D6 indirect param (win64 aggregate >8B): param_val is a pointer
+                // to the caller-materialized value. Load a callee-owned copy so the
+                // body reads its own storage, matching the indirect call ABI.
+                let loaded = wl_build_load(self.builder, real_ty, param_val)
+                let alloca = self.create_entry_alloca(real_ty)
+                wl_build_store(self.builder, loaded, alloca)
+                self.record_local(p_name, alloca, real_ty, 1)
+            else:
+                let param_ty = wl_type_of(param_val)
+                let alloca = self.create_entry_alloca(param_ty)
+                wl_build_store(self.builder, param_val, alloca)
+                self.record_local(p_name, alloca, param_ty, 1)
             if i < closure_param_sema_types.len() as i32:
                 self.record_local_sema_type(p_name, closure_param_sema_types.get(i as i64))
         // ── MIR-based closure body compilation ──────────────────────

--- a/src/CodegenDispatch.w
+++ b/src/CodegenDispatch.w
@@ -426,12 +426,22 @@ impl Codegen:
             param_count = self.sema.get_type_d1(resolved)
             ret_ty_id = self.sema.get_type_d2(resolved)
         let ret_ty = self.mir_sema_type_to_llvm(ret_ty_id)
-        var llvm_ret = if ret_ty != 0: ret_ty else: wl_void_type(self.context)
+        let llvm_ret = if ret_ty != 0: ret_ty else: wl_void_type(self.context)
         let param_types: Vec[i64] = Vec.new()
         param_types.push(wl_ptr_type(self.context))
-        if self.internal_abi_needs_sret(llvm_ret):
-            param_types.push(wl_ptr_type(self.context))
-            llvm_ret = wl_void_type(self.context)
+        // The closure body is always emitted with a by-value direct return:
+        // gen_closure forces the direct-return path (current_function_name_sym
+        // = 0) so a closure never gains an sret param, even for a struct return
+        // >8 bytes on win64. The call type must match — do NOT manually
+        // sret-lower here. LLVM applies the target's aggregate-return ABI
+        // identically to a by-value caller and a by-value callee. Manually
+        // sret-lowering the call while the callee returns by value put the
+        // env pointer and the sret pointer in swapped registers on win64
+        // (callee: implicit sret in RCX, env in RDX; caller: env in RCX, sret
+        // in RDX), so a str-returning closure wrote its result through the env
+        // pointer and left the real destination garbage (#806). Contrast
+        // mir_build_raw_fn_type, whose sret lowering is correct because a named
+        // fn-pointer target is sret-lowered by declare_function too.
         for pi in 0..param_count:
             var p_sema_ty = self.mir_type_extra_at(extra_start + pi)
             if resolved >= self.mir_type_kinds_len() as i32:

--- a/src/CodegenDispatch.w
+++ b/src/CodegenDispatch.w
@@ -12502,15 +12502,35 @@ impl Codegen:
             wl_build_br(self.builder, loop_bb)
             wl_position_at_end(self.builder, end_bb)
             let str_ty = self.mir_sema_type_to_llvm(self.sema.ty_str as i32)
-            let str_params: Vec[i64] = Vec.new()
-            str_params.push(ptr_ty)
-            let str_fn_ty = wl_function_type(str_ty, vec_data_i64(&str_params), 1, 0)
+            let str_sym = self.intern.intern("with_str_from_vec_u8")
             var str_fn = wl_get_named_function(self.llmod, "with_str_from_vec_u8")
             if str_fn == 0:
+                // D6: the callee returns `str` (16B), which win64 lowers via sret.
+                // Declare and call through the single FnAbi path so caller and
+                // callee agree instead of hand-rolling a direct return.
+                let str_params: Vec[i64] = Vec.new()
+                var str_ret_ty = str_ty
+                var str_has_sret = 0
+                let str_byval_types: Vec[i64] = Vec.new()
+                let str_direct_types: Vec[i64] = Vec.new()
+                if self.internal_abi_needs_sret(str_ty):
+                    str_has_sret = 1
+                    str_ret_ty = void_ty
+                    str_params.push(ptr_ty)
+                str_params.push(ptr_ty)
+                str_byval_types.push(0)
+                str_direct_types.push(0)
+                let str_fn_ty = wl_function_type(str_ret_ty, vec_data_i64(&str_params), str_params.len() as i32, 0)
                 str_fn = wl_add_function(self.llmod, "with_str_from_vec_u8", str_fn_ty)
+                if str_has_sret != 0:
+                    wl_add_sret_attr(self.context, str_fn, 0, str_ty)
+                    self.record_c_abi_transform(str_sym, str_has_sret, str_ty, 0, move str_byval_types, 0, move str_direct_types, 0)
+                self.fn_values.insert(str_sym, str_fn)
+                self.fn_fn_types.insert(str_sym, str_fn_ty)
+            let str_call_ty: i64 = self.fn_fn_types.get(str_sym).unwrap()
             let str_args: Vec[i64] = Vec.new()
             str_args.push(out_ptr)
-            return wl_build_call(self.builder, str_fn_ty, str_fn, vec_data_i64(&str_args), 1)
+            return self.build_call_fn_value(str_sym, str_fn, str_call_ty, -1, 0, str_args, 1, "collect_str", 0)
 
         if dest_base_sym == self.sym_hashset or dest_base_sym == self.sym_hashmap:
             var key_tid = 0

--- a/src/CodegenTraits.w
+++ b/src/CodegenTraits.w
@@ -235,17 +235,28 @@ fn codegen_type_node_mentions_self(pool: AstPool, self_sym: i32, type_node: i32)
     0
 
 impl Codegen:
+    // report_errors=false makes the skippable cases (a method whose signature
+    // mentions Self, or an unresolvable type) return 0 WITHOUT setting had_error
+    // or printing — so a vtable-build caller can fall back to the real method's
+    // by-value type for a non-dispatchable slot (e.g. `Ord.cmp`) instead of
+    // failing the whole compilation. The real dispatch site passes true, where a
+    // Self-mentioning method IS a genuine "can't dynamically dispatch this" error.
     mut fn dyn_trait_method_fn_type(trait_sym: i32, method_sym: i32) -> i64:
+        self.dyn_trait_method_fn_type_reporting(trait_sym, method_sym, true)
+
+    mut fn dyn_trait_method_fn_type_reporting(trait_sym: i32, method_sym: i32, report_errors: bool) -> i64:
         let trait_idx_opt = self.trait_map.get(trait_sym)
         if not trait_idx_opt.is_some():
-            with_eprint("error: missing trait metadata for dyn dispatch on '" ++ self.intern.resolve(trait_sym) ++ "'")
-            self.had_error = 1
+            if report_errors:
+                with_eprint("error: missing trait metadata for dyn dispatch on '" ++ self.intern.resolve(trait_sym) ++ "'")
+                self.had_error = 1
             return 0
         let trait_idx = trait_idx_opt.unwrap()
         let method_offset = self.find_trait_method_offset(trait_idx, method_sym)
         if method_offset < 0:
-            with_eprint("error: missing trait method '" ++ self.intern.resolve(method_sym) ++ "' in dyn trait '" ++ self.intern.resolve(trait_sym) ++ "'")
-            self.had_error = 1
+            if report_errors:
+                with_eprint("error: missing trait method '" ++ self.intern.resolve(method_sym) ++ "' in dyn trait '" ++ self.intern.resolve(trait_sym) ++ "'")
+                self.had_error = 1
             return 0
         let method_idx = self.trait_method_starts.get(trait_idx as i64) + method_offset
         let method_flags = self.trait_method_flags.get(method_idx as i64)
@@ -260,13 +271,15 @@ impl Codegen:
         while pi < param_count:
             let p_type_node = self.pool.fn_param_type(param_start, pi)
             if codegen_type_node_mentions_self(self.pool, self.sym_Self, p_type_node) != 0:
-                with_eprint("error: cannot lower dyn trait method '" ++ self.intern.resolve(method_sym) ++ "' because a non-receiver parameter mentions Self")
-                self.had_error = 1
+                if report_errors:
+                    with_eprint("error: cannot lower dyn trait method '" ++ self.intern.resolve(method_sym) ++ "' because a non-receiver parameter mentions Self")
+                    self.had_error = 1
                 return 0
             var p_ty = self.resolve_type(p_type_node)
             if p_ty == 0:
-                with_eprint("error: cannot resolve parameter type for dyn trait method '" ++ self.intern.resolve(method_sym) ++ "'")
-                self.had_error = 1
+                if report_errors:
+                    with_eprint("error: cannot resolve parameter type for dyn trait method '" ++ self.intern.resolve(method_sym) ++ "'")
+                    self.had_error = 1
                 return 0
             param_types.push(p_ty)
             pi = pi + 1
@@ -274,13 +287,15 @@ impl Codegen:
         var ret_sema_ty = self.sema.ty_void as i32
         if ret_node != 0:
             if codegen_type_node_mentions_self(self.pool, self.sym_Self, ret_node) != 0:
-                with_eprint("error: cannot lower dyn trait method '" ++ self.intern.resolve(method_sym) ++ "' because its return type mentions Self")
-                self.had_error = 1
+                if report_errors:
+                    with_eprint("error: cannot lower dyn trait method '" ++ self.intern.resolve(method_sym) ++ "' because its return type mentions Self")
+                    self.had_error = 1
                 return 0
             ret_sema_ty = self.sema.resolve_type_expr_frozen(ret_node) as i32
             if ret_sema_ty == 0:
-                with_eprint("error: cannot resolve return type for dyn trait method '" ++ self.intern.resolve(method_sym) ++ "'")
-                self.had_error = 1
+                if report_errors:
+                    with_eprint("error: cannot resolve return type for dyn trait method '" ++ self.intern.resolve(method_sym) ++ "'")
+                    self.had_error = 1
                 return 0
         if (method_flags / FnFlags.ASYNC) % 2 == 1:
             let task_args: Vec[i32] = Vec.new()
@@ -288,8 +303,9 @@ impl Codegen:
             ret_sema_ty = self.sema.find_generic_inst_type(self.sema.syms.task, task_args, 1) as i32
         let ret_ty = self.sema_type_to_llvm(ret_sema_ty)
         if ret_ty == 0:
-            with_eprint("error: cannot lower return type for dyn trait method '" ++ self.intern.resolve(method_sym) ++ "'")
-            self.had_error = 1
+            if report_errors:
+                with_eprint("error: cannot lower return type for dyn trait method '" ++ self.intern.resolve(method_sym) ++ "'")
+                self.had_error = 1
             return 0
 
         // D6: the reconstructed dispatch type MUST match the real method and its
@@ -373,18 +389,29 @@ impl Codegen:
             return method_fn
         let is_async_method = if impl_fn_sym != 0 and self.async_fn_ret_types.get(impl_fn_sym).is_some(): 1 else: 0
         // dyn_trait_method_fn_type applies the native win64 ABI: an aggregate
-        // return >8B (e.g. an async Task {i32,ptr}) becomes a leading sret
+        // return >8B (an async Task {i32,ptr}, or a fat Option like
+        // `Option[&dyn Error]` = {i32,{ptr,ptr}}) becomes a leading sret
         // parameter and a void return. The wrapper IS the vtable slot, so its
         // signature must match dyn_ft — carry the sret slot, place self/args
         // after it, and write the produced value through it instead of
-        // returning by value. Without this the async Task aggregate is seeded
-        // from the void return (`insertvalue void undef`) and every argument
-        // shifts by one slot. On SysV the 16B Task returns in registers (no
-        // sret), so the non-sret path below stays byte-identical.
-        let ret_ty = wl_get_return_type(dyn_ft)
+        // returning by value. Detect it structurally (void return + one extra
+        // leading param vs the real method) so it fires for sync aggregate
+        // returns too, not only async. On SysV a 16B/24B aggregate returns in
+        // registers (no sret), so the non-sret path below stays byte-identical.
+        let dyn_ret_ty = wl_get_return_type(dyn_ft)
         let dyn_param_count = wl_count_param_types(dyn_ft)
-        let has_sret = is_async_method != 0 and ret_ty == wl_void_type(self.context) and dyn_param_count == orig_param_count + 1
+        let has_sret = dyn_ret_ty == wl_void_type(self.context) and dyn_param_count == orig_param_count + 1
         let base = if has_sret: 1 else: 0
+        // For the sret and async paths dyn_ft is authoritative (win64 aggregate
+        // sret lowering / the reconstructed Task type). For a plain sync by-value
+        // return the IMPL fn's actual monomorphized return is authoritative:
+        // dyn_trait_method_fn_type resolves the trait method's DECLARED return,
+        // which for a generic return (e.g. `Scoped[T].with_enter -> T`) is the
+        // unsubstituted parameter and can lower to the wrong width (i32 vs the
+        // impl's i64). The wrapper body returns method_ft's value, so declaring
+        // the wrapper with method_ft's return keeps producer and body consistent
+        // and reproduces the pre-sret-fix behavior for this case.
+        let ret_ty = if has_sret or is_async_method != 0: dyn_ret_ty else: wl_get_return_type(method_ft)
         let wrapper_param_types: Vec[i64] = Vec.new()
         if has_sret:
             wrapper_param_types.push(ptr_ty)
@@ -975,13 +1002,26 @@ impl Codegen:
                     fv = self.fn_values.get(impl_fn_sym)
                     ft = self.fn_fn_types.get(impl_fn_sym)
             if fv.is_some() and ft.is_some():
-                var dyn_ft = ft.unwrap() as i64
-                if (method_flags / FnFlags.ASYNC) % 2 == 1:
-                    dyn_ft = self.dyn_trait_method_fn_type(trait_sym, method_sym)
-                    if dyn_ft == 0:
-                        entries.push(wl_const_null(wl_ptr_type(self.context)))
-                        continue
-                let wrapper = self.create_dyn_wrapper(impl_type_sym, impl_fn_sym, method_sym, fv.unwrap() as i64, ft.unwrap() as i64, dyn_ft, consumes_self)
+                // Materialize fv/ft to plain values before the mut call below —
+                // they are Option views into self and cannot stay live across
+                // self.dyn_trait_method_fn_type.
+                let fv_val = fv.unwrap() as i64
+                let ft_val = ft.unwrap() as i64
+                // D6: the vtable slot type is dyn_trait_method_fn_type — the SAME
+                // descriptor the call site (mir_emit_dyn_trait_call) reads. The
+                // wrapper must be declared with it so producer and consumer agree,
+                // including the win64 sret lowering of an aggregate (>8B) return.
+                // Gating this on async only (the old code) left a non-async
+                // aggregate return — e.g. `source() -> Option[&dyn Error]` — with a
+                // by-value wrapper against an sret call site: the exact divergence.
+                var dyn_ft = self.dyn_trait_method_fn_type_reporting(trait_sym, method_sym, false)
+                if dyn_ft == 0:
+                    // Non-dispatchable slot (signature mentions Self, e.g.
+                    // `Ord.cmp`): fall back to the real method's by-value type.
+                    // The slot is never dynamically dispatched, so it can't
+                    // diverge from a call site — reproducing the old behavior.
+                    dyn_ft = ft_val
+                let wrapper = self.create_dyn_wrapper(impl_type_sym, impl_fn_sym, method_sym, fv_val, ft_val, dyn_ft, consumes_self)
                 entries.push(wrapper)
             else:
                 entries.push(wl_const_null(wl_ptr_type(self.context)))
@@ -1063,13 +1103,12 @@ impl Codegen:
                 with_eprint("error: missing monomorphized trait method '" ++ type_name ++ "." ++ method_name ++ "' for trait '" ++ trait_name ++ "'")
                 self.had_error = 1
                 return
-            var dyn_ft = ft.unwrap() as i64
-            if (method_flags / FnFlags.ASYNC) % 2 == 1:
-                dyn_ft = self.dyn_trait_method_fn_type(trait_sym, method_sym)
-                if dyn_ft == 0:
-                    self.had_error = 1
-                    return
-            let wrapper = self.create_dyn_wrapper(impl_type_sym, concrete_sym, method_sym, fv.unwrap() as i64, ft.unwrap() as i64, dyn_ft, consumes_self)
+            let fv_val = fv.unwrap() as i64
+            let ft_val = ft.unwrap() as i64
+            var dyn_ft = self.dyn_trait_method_fn_type_reporting(trait_sym, method_sym, false)
+            if dyn_ft == 0:
+                dyn_ft = ft_val
+            let wrapper = self.create_dyn_wrapper(impl_type_sym, concrete_sym, method_sym, fv_val, ft_val, dyn_ft, consumes_self)
             entries.push(wrapper)
 
         let global_name = "__vtable_" ++ type_name ++ "_" ++ trait_name
@@ -1132,12 +1171,9 @@ impl Codegen:
                 with_eprint("error: missing monomorphized trait method '" ++ type_name ++ "." ++ method_text ++ "' for trait '" ++ trait_text ++ "' (dyn generic inst)")
                 self.had_error = 1
                 return
-            var dyn_ft = ft
-            if (method_flags / FnFlags.ASYNC) % 2 == 1:
-                dyn_ft = self.dyn_trait_method_fn_type(trait_sym, method_sym)
-                if dyn_ft == 0:
-                    self.had_error = 1
-                    return
+            var dyn_ft = self.dyn_trait_method_fn_type_reporting(trait_sym, method_sym, false)
+            if dyn_ft == 0:
+                dyn_ft = ft
             let wrapper = self.create_dyn_wrapper(impl_type_sym, wrapper_fn_sym, method_sym, fv, ft, dyn_ft, consumes_self)
             entries.push(wrapper)
         if used_row == 0:

--- a/src/compiler/LlvmBridge.w
+++ b/src/compiler/LlvmBridge.w
@@ -204,6 +204,8 @@ extern fn LLVMCreateEnumAttribute(c: *mut u8, kind: u32, val: u64) -> *mut u8
 extern fn LLVMCreateTypeAttribute(c: *mut u8, kind: u32, ty: *mut u8) -> *mut u8
 extern fn LLVMAddAttributeAtIndex(v: *mut u8, idx: u32, attr: *mut u8)
 extern fn LLVMAddCallSiteAttribute(call: *mut u8, idx: u32, attr: *mut u8)
+extern fn LLVMGetEnumAttributeAtIndex(v: *mut u8, idx: u32, kind: u32) -> *mut u8
+extern fn LLVMGetTypeAttributeValue(attr: *mut u8) -> *mut u8
 
 // Basic blocks
 extern fn LLVMAppendBasicBlockInContext(c: *mut u8, fn_val: *mut u8, name: *const u8) -> *mut u8
@@ -777,6 +779,21 @@ pub fn wl_add_sret_attr(ctx: i64, fn_val: i64, param_idx: i32, ty: i64) -> Unit:
         if kind != 0:
             let attr = LLVMCreateTypeAttribute(ctx as *mut u8, kind, ty as *mut u8)
             LLVMAddAttributeAtIndex(fn_val as *mut u8, (param_idx + 1) as u32, attr)
+
+// Query the sret type of a function parameter. Returns the pointee aggregate
+// type carried by an `sret(T)` attribute, or 0 when the parameter is not
+// sret-lowered. Used to reconstruct a by-value signature from an already
+// sret-lowered concrete function (win64 aggregate return).
+pub fn wl_get_param_sret_type(fn_val: i64, param_idx: i32) -> i64:
+    unsafe:
+        let name = "sret" as *const u8
+        let kind = LLVMGetEnumAttributeKindForName(name, 4 as u64)
+        if kind == 0:
+            return 0
+        let attr = LLVMGetEnumAttributeAtIndex(fn_val as *mut u8, (param_idx + 1) as u32, kind)
+        if attr as i64 == 0:
+            return 0
+        LLVMGetTypeAttributeValue(attr) as i64
 
 pub fn wl_add_call_param_byval_attr(ctx: i64, call_val: i64, param_idx: i32, ty: i64) -> Unit:
     unsafe:

--- a/test/behavior/behav_net_loopback.w
+++ b/test/behavior/behav_net_loopback.w
@@ -1,4 +1,3 @@
-//! skip-windows: #800: std.net has no Windows backend — rt/windows_x86_64.w defines no with_net_* symbols (linux/darwin do), so this link-fails; needs a Winsock implementation (WSAStartup/socket/bind/listen/accept/connect/send/recv/closesocket/getsockname)
 //! expect-stdout: ok
 
 // #658: the server-side std.net surface must actually work. TCP: listen

--- a/test/spec/spec_ss10_3_option_result_combinators.w
+++ b/test/spec/spec_ss10_3_option_result_combinators.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 fat-fn/closure ABI — Option/Result combinators produce wrong output (exit 1)
 // Spec test: Section 10.3, 10.4 — Option/Result Combinators (formerly 25.22)
 
 // PASS: option chaining

--- a/test/spec/spec_ss10_5_sequence_traverse_transpose.w
+++ b/test/spec/spec_ss10_5_sequence_traverse_transpose.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 fat-fn/closure ABI — sequence/traverse/transpose produce wrong output (exit 1)
 //! expect-stdout: ok
 // Spec test: Section 10.5 / 10.7 — sequence / traverse / transpose.
 

--- a/test/spec/spec_ss10_6_error_context.w
+++ b/test/spec/spec_ss10_6_error_context.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 codegen — error context produces wrong output (exit 1)
 // Spec test: Section 10.6 — Error Context (formerly 25.43)
 
 use std.result.ContextError

--- a/test/spec/spec_ss10_6_result_combinators_complete.w
+++ b/test/spec/spec_ss10_6_result_combinators_complete.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 fat-fn/closure ABI — Result combinators produce wrong output (exit 1)
 //! expect-stdout: ok
 
 fn ok_i32(value: i32) -> Result[i32, str]:

--- a/test/spec/spec_ss10_8_error_trait.w
+++ b/test/spec/spec_ss10_8_error_trait.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 trait-object/vtable ABI — Error trait produces wrong output (exit 1)
 //! expect-stdout: ok
 
 use std.result.ContextError

--- a/test/spec/spec_ss13_3_collect_targets.w
+++ b/test/spec/spec_ss13_3_collect_targets.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows win64 codegen — collect targets produce wrong output (exit 1)
 //! expect-stdout: ok
 // Spec test: §13.3 collect[C] target selection.
 

--- a/test/spec/spec_ss14_3_1_no_suspend_blocks.w
+++ b/test/spec/spec_ss14_3_1_no_suspend_blocks.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #806: Windows async lowering — no-suspend blocks produce wrong output (exit 1)
 //! expect-stdout: ok
 
 use std.task.Task


### PR DESCRIPTION
Implements the `with_net_*` runtime surface for Windows over ws2_32 (already on the Windows link line), mirroring the POSIX backend in `rt/linux_x86_64.w` with Winsock semantics. Un-skips `behav_net_loopback` (#800). Draft: probing native Windows CI for the link+runtime verdict.

Winsock-specific handling: SOCKET handles as i64 (INVALID_SOCKET == -1), closesocket, int-width send/recv, one-time WSAStartup, and the Win64 ADDRINFOA layout (ai_addrlen size_t, ai_canonname before ai_addr). Dotted-quad IPv4 fast path avoids getaddrinfo struct risk for loopback; getaddrinfo covers hostnames.