### PR TITLE
c_import(win64): model UCRT inline wrappers; un-skip system-header c_import (#799)

### DIFF
--- a/src/CImport.w
+++ b/src/CImport.w
@@ -8431,6 +8431,29 @@ fn ci_lookup_c_function_decl_idx(session: i64, name: &str) -> i32:
         return g_ci_fn_decl_by_escaped.get(name).unwrap()
     -1
 
+// A referenced C function that ci_translate_function will NOT emit as a
+// callable. This mirrors the emission filter exactly: leading-underscore
+// internal names are skipped (line ~1660) and static functions without
+// inline have no external linkage and no translated body (line ~1706). An
+// inline wrapper body that calls such a symbol would lower to a reference
+// nothing defines (SemaCheck: "undefined variable"), so the call lowering
+// must bail and let the wrapper be cleanly omitted+recorded rather than
+// emit a ghost call. The call-site system-symbol guard misses these on
+// Windows: ci_is_system_decl only catches `__`/`_[A-Z]` (not `_[a-z]` UCRT
+// helpers like `_vfwprintf_s_l`) and ci_is_system_path is Unix-only, so
+// this decl-index-driven check is the platform-independent source of truth.
+fn ci_fn_decl_is_unemittable(session: i64, decl_idx: i32) -> bool:
+    if decl_idx < 0:
+        return false
+    let dname = with_cimport_decl_name(session, decl_idx)
+    if dname.len() == 0:
+        return false
+    if dname.byte_at(0) == 95:
+        return true
+    let storage = with_cimport_fn_storage_class(session, decl_idx)
+    let is_inline = with_cimport_fn_is_inline(session, decl_idx)
+    storage == CX_SC_STATIC and is_inline == 0
+
 fn ci_call_callee_name(session: i64, cursor: i32) -> str:
     // Walk through transparent wrappers (IMPLICIT_CAST, PAREN_EXPR,
     // and libclang's kind-100 UnexposedExpr which is what CALL_EXPR
@@ -9962,6 +9985,16 @@ impl CiStmtPool:
                 return ci_value_ir_invalid()
             var arg_ids: Vec[i32] = Vec.new()
             let callee_decl_idx = ci_lookup_c_function_decl_idx(session, callee_text)
+            // #799: an inline wrapper body must not lower a call to a C
+            // function the emitter skips (leading-underscore UCRT helpers,
+            // static-non-inline). Bail so the wrapper is omitted+recorded
+            // rather than emitting a reference nothing defines.
+            if ci_fn_decl_is_unemittable(session, callee_decl_idx):
+                if g_ci_bail_message.len() == 0:
+                    g_ci_bail_message = f"inline body calls non-emitted C function '{callee_text}'"
+                    g_ci_bail_location = with_ci_cursor_location(session, cursor)
+                    g_ci_bail_kind = kind
+                return ci_value_ir_invalid()
             let callee_param_count = if callee_decl_idx >= 0: with_cimport_fn_param_count(session, callee_decl_idx) else: 0
             var ai = first_arg
             while ai < nc:

--- a/src/CImport.w
+++ b/src/CImport.w
@@ -9985,11 +9985,16 @@ impl CiStmtPool:
                 return ci_value_ir_invalid()
             var arg_ids: Vec[i32] = Vec.new()
             let callee_decl_idx = ci_lookup_c_function_decl_idx(session, callee_text)
-            // #799: an inline wrapper body must not lower a call to a C
-            // function the emitter skips (leading-underscore UCRT helpers,
-            // static-non-inline). Bail so the wrapper is omitted+recorded
-            // rather than emitting a reference nothing defines.
-            if ci_fn_decl_is_unemittable(session, callee_decl_idx):
+            // #799: a c_import inline wrapper body must not lower a call to a
+            // C function the header-import emitter skips (leading-underscore
+            // UCRT helpers, static-non-inline). Bail so the wrapper is
+            // omitted+recorded rather than emitting a reference nothing defines.
+            // Migrate mode has its own emitter that DOES translate static and
+            // reserved-name functions from the source .c (test
+            // migrate-emit-c-reserved-symbols asserts `fn __with_checked_add`
+            // is emitted and callable), so this c_import-only filter must not
+            // gate migrate-mode calls.
+            if not ci_translate_in_migrate_mode() and ci_fn_decl_is_unemittable(session, callee_decl_idx):
                 if g_ci_bail_message.len() == 0:
                     g_ci_bail_message = f"inline body calls non-emitted C function '{callee_text}'"
                     g_ci_bail_location = with_ci_cursor_location(session, cursor)

--- a/test/behavior/behav_c_import_sdk_header.w
+++ b/test/behavior/behav_c_import_sdk_header.w
@@ -1,9 +1,3 @@
-//! skip-windows: issue #799: INCDIR wiring is done (clang now parses UCRT
-//! stdio.h — WITH_WINDOWS_*_INCDIR reach the c_import clang args), but modeling
-//! the real UCRT declarations still errors ("null requires pointer type
-//! context" + "undefined variable" on vfwprintf_s/vfwscanf_s). Deeper c_import
-//! UCRT-header modeling (task #79) remains before this can pass natively.
-//
 // §16.1: a system-header c_import resolves the target SDK without spawning
 // xcrun. On macOS this is the SDK sysroot (env SDKROOT/WITH_SDKROOT, with.toml
 // [c_import] sdk_path, or a well-known path); on native Windows the MSVC CRT +


### PR DESCRIPTION
Stacked on #831 (MSVC/UCRT include-dir wiring).

## Problem
With #831's include dirs wired, clang parses UCRT `stdio.h` on native Windows, but modeling still errored:
```
error: null requires pointer type context
error: undefined variable   (on vfwprintf_s / vfwscanf_s)
```

## Root cause (instruction-level)
UCRT ships `static __inline` wrappers (`vfwprintf_s`) whose body calls a leading-underscore internal helper (`_vfwprintf_s_l`). `ci_try_translate_fn_body` translates the wrapper body via IR lowering, but the emitter (`ci_translate_function`) skips **all** leading-underscore names and static-non-inline functions. The lowered body referenced a symbol nothing defines → `undefined variable`, and the `0` void\* arg lost pointer context → `null requires pointer type context`.

The existing call-site guard missed these on Windows: `ci_is_system_decl` matches only `__*`/`_[A-Z]*` (not `_[a-z]*` like `_vfwprintf_s_l`), and `ci_is_system_path` knows only Unix/macOS sysroots.

## Fix
`ci_fn_decl_is_unemittable(session, decl_idx)` mirrors the emission filter exactly (leading-underscore, or static-without-inline). The CALL_EXPR value lowering bails when the callee is one the emitter won't produce, so the wrapper is cleanly **omitted+recorded** (No-Silent-Fallbacks) instead of emitting a ghost call. `c_import("stdio.h")` then succeeds and modeled constants (`SEEK_SET`, `SEEK_END`) resolve. Platform-independent (decl-index driven, not path/name-regex).

## Verification (local, linux)
Faithful name-gap repro (inline wrapper calling `_my_vfwprintf_s_l`): **2 errors → clean**. Control repros calling non-underscore helpers still model (`ok`) — bail is narrow. Full linux `with build` + `:fixpoint` + `:test` battery running.

Un-skips `behav_c_import_sdk_header`; Windows CI arbitrates end-to-end.