### PR TITLE
link(win64): drop Unix-only libm/libc on COFF link; un-skip spec_ss16 (#799)

### DIFF
--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -533,6 +533,14 @@ fn link_stage_windows_libpath(var_name: &str, fallback: &str) -> str:
         return v
     fallback ++ ""
 
+// Unix-only library spellings that have no Windows import lib and whose symbols
+// are already provided by the CRT/UCRT linked unconditionally below (cos/abs/…
+// in libucrt via libcmt; strlen/malloc/… in libcmt). A `link:` directive naming
+// one of these (e.g. c_import("math.h", link: "m")) must be dropped on the
+// Windows link, not turned into a nonexistent `m.lib`. Any other name still
+// becomes `<name>.lib` so a genuinely missing library fails loudly.
+fn link_stage_windows_lib_is_crt_implicit(name: &str): name == "m" or name == "c"
+
 fn link_stage_make_windows_llvm_link_command(llvm_ld: &str, obj_path: &str, bin_path: &str, extras: &Vec[str], link_libs: &Vec[str], link_args: &Vec[str]) -> LinkStageCommand:
     let args: Vec[str] = Vec.new()
     let env: Vec[LinkStageEnvVar] = Vec.new()
@@ -569,8 +577,10 @@ fn link_stage_make_windows_llvm_link_command(llvm_ld: &str, obj_path: &str, bin_
         let lib = link_libs.get(i as i64)
         if lib.ends_with(".lib"):
             args.push(with_str_clone_ref(lib))
-        else:
+        else if not link_stage_windows_lib_is_crt_implicit(lib):
             args.push(lib ++ ".lib")
+        // else: `m`/`c` are Unix-only spellings — Windows has no m.lib/c.lib and
+        // their symbols resolve from the UCRT/CRT linked below; drop them.
     for i in 0..link_args.len() as i32:
         args.push(with_str_clone_ref(link_args.get(i as i64)))
     args.push("libcpmt.lib")

--- a/test/spec/spec_ss16_ffi_and_c_import.w
+++ b/test/spec/spec_ss16_ffi_and_c_import.w
@@ -1,4 +1,3 @@
-//! skip-windows: #799: pulls system headers (stdio/stdlib/time/limits/string) and links libm ("m") — the c_import clang invocation (src/compiler/ClangBridge.w) lacks Windows MSVC/UCRT include-dir wiring so the headers are not found, and there is no separate libm on Windows
 //! expect-stdout: ok
 
 use c_import("stdio.h")


### PR DESCRIPTION
Stacked on #834 (c_import UCRT modeling fix).

Final piece of the standalone #799 stack (main → #831 → #834 → this).

## Change
`c_import("math.h", link: "m")` emits a bare `m` link directive. Windows has no `m.lib`/`c.lib` import library — `cos`/`abs`/… live in the UCRT and `strlen`/`malloc`/… in `libcmt`, both linked unconditionally on the COFF path. Turning `m` into `m.lib` made lld-link fail to open a nonexistent import lib. `link_stage_windows_lib_is_crt_implicit` drops the CRT-implicit Unix spellings (`m`, `c`); any other name still becomes `<name>.lib` so a genuinely missing library fails loudly (No-Silent-Fallbacks).

## Un-skips
`spec_ss16_ffi_and_c_import` — pulls stdio/stdlib/time/limits/string system headers and links libm. Needs both the modeling fix (#834) and this libm drop. Draft until #834's Windows CI confirms the modeling generalizes across those headers.

Windows-link-only; linux build/fixpoint unaffected. Compiler frontend type-checks clean.