### PR TITLE
test(windows): un-skip regex comptime-validation compile-error tests (#798)

### DIFF
--- a/test/compile_errors/err_regex_capture_after_branch.w
+++ b/test/compile_errors/err_regex_capture_after_branch.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_capture_else_scope.w
+++ b/test/compile_errors/err_regex_capture_else_scope.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_capture_out_of_range.w
+++ b/test/compile_errors/err_regex_capture_out_of_range.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_capture_out_of_scope.w
+++ b/test/compile_errors/err_regex_capture_out_of_scope.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_compound_no_capture.w
+++ b/test/compile_errors/err_regex_compound_no_capture.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_invalid_literal.w
+++ b/test/compile_errors/err_regex_invalid_literal.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: invalid regex literal
 
 fn main:

--- a/test/compile_errors/err_regex_neg_match_no_capture.w
+++ b/test/compile_errors/err_regex_neg_match_no_capture.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_value_no_capture.w
+++ b/test/compile_errors/err_regex_value_no_capture.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:


### PR DESCRIPTION
## Summary

Un-skips the 8 `err_regex_*` compile-error tests that were `skip-windows`-gated on #798.

The gate existed because malformed/capture-invalid regex literals were **silently accepted** on native Windows — `with check` printed `ok` and exited 0 instead of emitting the expected diagnostic. Root cause was the **win64 sret / aggregate-return ABI**, which miscompiled `pcre2_compile_8`'s by-value struct error returns so the compiler's in-process comptime validation never observed the failure.

The **#806 win64 sret ABI fixes** (landed via #819–#822, tip `2ea52e88`) corrected that. These tests are comptime (`with check`) validations exercised **in-process** by the compiler binary, so with a fresh Windows compiler they now emit the expected first diagnostic and exit non-zero.

## Verification (native Windows VM, fresh compiler at `2ea52e88`)

All 8 exit RC=1 with the correct first diagnostic:

| test | expected first diagnostic |
|---|---|
| `err_regex_invalid_literal` | `invalid regex literal: missing closing parenthesis` |
| `err_regex_compound_no_capture` | `undefined variable` |
| `err_regex_capture_out_of_range` | `undefined variable` |
| `err_regex_capture_after_branch` | `undefined variable` |
| `err_regex_value_no_capture` | `undefined variable` |
| `err_regex_capture_out_of_scope` | `undefined variable` |
| `err_regex_capture_else_scope` | `undefined variable` |
| `err_regex_neg_match_no_capture` | `undefined variable` |

## Scope

Removes only the stale `//! skip-windows: issue #798 ...` directive line from each of the 8 files; the `//! expect-check-fail:` directive and test bodies are unchanged. Standalone off `main`, independent of the other in-flight Windows stacks.