### PR TITLE
test(windows): un-skip regex compile-error tests

### DIFF
--- a/test/compile_errors/err_regex_capture_after_branch.w
+++ b/test/compile_errors/err_regex_capture_after_branch.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_capture_else_scope.w
+++ b/test/compile_errors/err_regex_capture_else_scope.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_capture_out_of_range.w
+++ b/test/compile_errors/err_regex_capture_out_of_range.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_capture_out_of_scope.w
+++ b/test/compile_errors/err_regex_capture_out_of_scope.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_compound_no_capture.w
+++ b/test/compile_errors/err_regex_compound_no_capture.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_invalid_literal.w
+++ b/test/compile_errors/err_regex_invalid_literal.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: invalid regex literal
 
 fn main:

--- a/test/compile_errors/err_regex_neg_match_no_capture.w
+++ b/test/compile_errors/err_regex_neg_match_no_capture.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:

--- a/test/compile_errors/err_regex_value_no_capture.w
+++ b/test/compile_errors/err_regex_value_no_capture.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal comptime validation crashes (0xC0000005) on native Windows
 //! expect-check-fail: undefined variable
 
 fn main:


### PR DESCRIPTION
The eight `err_regex_*` compile-error tests were gated `skip-windows` because comptime regex-literal validation crashed (0xC0000005) on native Windows. That crash is gone: the release compiler compiles regex literals cleanly, so these tests emit their expected diagnostics on Windows like every other platform.

Each was verified on native Windows x86_64 to produce its `expect-check-fail` diagnostic with no crash:

- `err_regex_capture_after_branch` — undefined variable
- `err_regex_capture_else_scope` — undefined variable
- `err_regex_capture_out_of_range` — undefined variable
- `err_regex_capture_out_of_scope` — undefined variable
- `err_regex_compound_no_capture` — undefined variable
- `err_regex_invalid_literal` — invalid regex literal
- `err_regex_neg_match_no_capture` — undefined variable
- `err_regex_value_no_capture` — undefined variable

Removes only the `skip-windows` headers; the `expect-check-fail` contracts and test bodies are unchanged.