### PR TITLE
test(windows): un-skip regex runtime tests that compile clean

### DIFF
--- a/test/behavior/behav_fstring_hole_backslashes.w
+++ b/test/behavior/behav_fstring_hole_backslashes.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal codegen crash (0xC0000005) on native Windows
 //! expect-stdout: ok
 
 // #656: f-string hole normalization must not strip source-level

--- a/test/behavior/behav_regex_capture_fstring.w
+++ b/test/behavior/behav_regex_capture_fstring.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal codegen crash (0xC0000005) on native Windows
 //! expect-stdout: ok
 
 use std.regex

--- a/test/behavior/behav_regex_language_semantics.w
+++ b/test/behavior/behav_regex_language_semantics.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: regex-literal codegen crash (0xC0000005) on native Windows
 //! expect-stdout: ok
 
 fn test_global_match_operator_progresses:

--- a/test/behavior/behav_regex_std.w
+++ b/test/behavior/behav_regex_std.w
@@ -1,4 +1,4 @@
-//! skip-windows: issue #798: regex-literal codegen crash (0xC0000005) on native Windows
+//! skip-windows: member-import `use std.regex.Captures` not registered for the §18.1 explicit-import gate on native Windows (front-end miscompile; whole-module `use std.regex` is fine)
 //! expect-stdout: ok
 
 use std.regex.Captures

--- a/test/spec/spec_ss15_8_regex_branch_captures.w
+++ b/test/spec/spec_ss15_8_regex_branch_captures.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #798: Windows regex-literal codegen crash (0xC0000005)
 //! expect-stdout: ok
 
 use std.regex


### PR DESCRIPTION
Four regex behavior/spec tests were gated `skip-windows` for #798's regex-literal codegen crash. That crash is gone — each compiles clean on native Windows x86_64 (`check` on the release compiler, no 0xC0000005). They use bare regex literals or whole-module `use std.regex`:

- `behav_regex_language_semantics`
- `behav_regex_capture_fstring`
- `behav_fstring_hole_backslashes`
- `spec_ss15_8_regex_branch_captures`

Windows CI runs them through the real harness to confirm runtime output (`expect-stdout: ok`).

`behav_regex_std` **stays skipped**, but its reason is corrected to the actual cause: on native Windows the member-symbol import `use std.regex.Captures` is not registered for the §18.1 explicit-import gate, so a `&Captures` parameter is wrongly rejected. Whole-module `use std.regex` and bare literals are unaffected, and the identical source is accepted on Linux — a platform-divergent front-end miscompile, tracked separately, not a regex codegen crash.