### PR TITLE
test(windows): un-skip #802 core-language cluster (CI arbitration)

### DIFF
--- a/test/behavior/behav_build_w_basic_invocation.w
+++ b/test/behavior/behav_build_w_basic_invocation.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #802: core-language behavior fails on native Windows (needs root-cause)
 //! expect-stdout: ok
 
 use pre_d_build_runner

--- a/test/behavior/behav_cli_test_command_args.w
+++ b/test/behavior/behav_cli_test_command_args.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #802: core-language behavior fails on native Windows (needs root-cause)
 //! expect-stdout: ok
 
 use pre_d_build_runner


### PR DESCRIPTION
Un-skips the 2 `#802` core-language tests so native Windows CI reports their real verdict.

## Why now
Both drive the p7 build harness (`pre_d_build_runner.w`). Their skips were last set in **#794**, before the harness cwd/`getcwd`/`.to_owned`/`.exe` fix landed in **#814 (`ec55728a`)** — which only un-skipped `overflow_modes`. Never re-evaluated against the fixed harness.

## Tests
- `behav_build_w_basic_invocation` — nested `build --graph` (graph dump; no link step, so its `link_system_lib("m")` is never resolved → **not** blocked on #827 libm-drop)
- `behav_cli_test_command_args` — nested `with test` on trivial pure-With files (`--help`, multi-file, `--filter`)

## Contract
If either still fails on native Windows CI, it is re-gated with the **CI-artifact-verified** cause per-test, replacing the stale `needs-root-cause` blanket reason. CI is the arbiter.