### PR TITLE
link(win64): resolve toolchain root from the compiler binary; un-skip #800/#802 link cluster

### DIFF
--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -896,6 +896,17 @@ fn link_stage_resolve_runtime_root() -> str:
     candidates.push(compiler_dir ++ "/runtime")
     // <compiler_dir>/../lib/ (direct FHS-style path)
     candidates.push(compiler_dir ++ "/../lib")
+    // Nested bootstrap layout: a staged/release compiler lives in
+    // out/{stage,release}/bin while its toolchain (runtime objects + the
+    // llvm_ld linker metadata) sits two levels up in out/lib and
+    // out/bootstrap-lib. argv0 is absolute for a spawned child, so these
+    // resolve independently of the child's cwd. Without them a p7-spawned
+    // child `with` (cwd = the case dir, not the repo root) never reaches the
+    // linker metadata: it self-services the runtime objects from its embedded
+    // payload but llvm_ld has no embedded fallback, so linking on Windows dies
+    // with "missing Windows LLVM linker metadata".
+    candidates.push(compiler_dir ++ "/../../lib")
+    candidates.push(compiler_dir ++ "/../../bootstrap-lib")
     for i in 0..candidates.len() as i32:
         let dir = candidates.get(i as i64)
         let probe = dir ++ "/cimport_stubs.o"

--- a/test/behavior/behav_action_capability_filesystem.w
+++ b/test/behavior/behav_action_capability_filesystem.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #800: action/capability/net/process/fs OS-surface fails on native Windows
 //! expect-stdout: ok
 
 use pre_d_build_runner

--- a/test/behavior/behav_action_capability_process.w
+++ b/test/behavior/behav_action_capability_process.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #800: action/capability/net/process/fs OS-surface fails on native Windows
 //! expect-stdout: ok
 
 use pre_d_build_runner

--- a/test/behavior/behav_action_crash_diagnostic.w
+++ b/test/behavior/behav_action_crash_diagnostic.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #800: action/capability/net/process/fs OS-surface fails on native Windows
 //! expect-stdout: ok
 
 use pre_d_build_runner

--- a/test/behavior/behav_action_no_deps_isolation.w
+++ b/test/behavior/behav_action_no_deps_isolation.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #800: action/capability/net/process/fs OS-surface fails on native Windows
 //! expect-stdout: ok
 
 use std.fs

--- a/test/behavior/behav_build_w_basic_invocation.w
+++ b/test/behavior/behav_build_w_basic_invocation.w
@@ -1,4 +1,4 @@
-//! skip-windows: issue #802: core-language behavior fails on native Windows (needs root-cause)
+//! skip-windows: issue #802: on native Windows the p7-spawned child `with build --graph` emits the repo's own build graph instead of the case's (case `demo`/`P7_BASIC` targets and the `basic build invoked` warn absent) — child project-root/stderr resolution diverges from the POSIX path. Distinct from the p7 linker-metadata gap; tracked separately.
 //! expect-stdout: ok
 
 use pre_d_build_runner

--- a/test/behavior/behav_capability_token_mismatch.w
+++ b/test/behavior/behav_capability_token_mismatch.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #800: action/capability/net/process/fs OS-surface fails on native Windows
 //! expect-stdout: ok
 
 use pre_d_build_runner

--- a/test/behavior/behav_cli_test_command_args.w
+++ b/test/behavior/behav_cli_test_command_args.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #802: core-language behavior fails on native Windows (needs root-cause)
 //! expect-stdout: ok
 
 use pre_d_build_runner


### PR DESCRIPTION
## Root cause

`link_stage_resolve_runtime_root()` probed the workspace artifact root (cwd-relative) and **one** level up from the compiler binary (`<bin>/../lib`). A spawned child `with` whose cwd is not the repo root — notably the build-harness (**p7**) child, which runs with cwd set to a generated case directory and an absolute compiler path as argv0 — never reached the real toolchain:

- `<bin>/../lib` resolves to `out/stage/lib` (**nonexistent** — the toolchain is two levels up, at `out/lib`)
- the cwd-relative candidates point at the *case dir*, not the repo

The child self-services the runtime **objects** from its embedded payload, but the `llvm_ld` linker metadata has **no embedded fallback**, so linking dies on Windows with `error: missing Windows LLVM linker metadata`. This one gap blocked every build-harness test that makes the child link on Windows.

This was confirmed from the CI artifact, not inferred: the nested p7 child capture showed the objects extracted fine and only `llvm_ld` missing.

## Fix

Add two **compiler-relative** candidates for the nested bootstrap layout where a staged/release compiler actually lives (`out/{stage,release}/bin`) relative to its toolchain (`out/lib`, `out/bootstrap-lib`, two levels up):

```
candidates.push(compiler_dir ++ "/../../lib")          // out/{stage,release}/bin/../../lib = out/lib
candidates.push(compiler_dir ++ "/../../bootstrap-lib") // = out/bootstrap-lib
```

argv0 is absolute for a spawned child, so these resolve independently of cwd and inherited env. They are **appended after** the existing candidates, so a normal repo-root invocation still resolves the workspace artifact root first and self-build output is unchanged (fixpoint unaffected).

## Un-skips

With the shared link gap closed, un-skip the six harness tests that drove a child link on Windows:

- `behav_cli_test_command_args`
- `behav_action_capability_filesystem`, `behav_action_capability_process`, `behav_action_crash_diagnostic`, `behav_action_no_deps_isolation`, `behav_capability_token_mismatch` (the #800 action/capability cluster)

`behav_build_w_basic_invocation` **stays skipped** — it fails for a distinct Windows-specific reason (the child `build --graph` emits the repo's own build graph instead of the case's), reworded and tracked separately.

## Verification

- Linux stage1 self-compile (`with build :dev`) green — compiler source compiles with the change.
- The change is append-only after the winning candidate, so the linux repo-root self-build resolves identically; fixpoint is preserved by construction.
- The decisive test is this CI run: the p7 child is `out/stage/bin/with-stage2.exe`, built in-branch by CI, so no reseed is needed. If any of the six still fails on native Windows CI, it is re-gated with the CI-artifact-verified cause per test.

Supersedes the probe-only un-skips in #847 (action/capability cluster) and the cli-test portion of #848 by fixing the shared root cause instead of just removing the gate.