### PR TITLE
Windows: fiber stack-overflow diagnostic via VEH; un-skip #369

### DIFF
--- a/rt/fiber_core_windows.w
+++ b/rt/fiber_core_windows.w
@@ -19,6 +19,7 @@ extern fn rt_fiber_mmap_flags() -> i32
 extern fn rt_fiber_install_signal_handlers(alt_stack: *mut u8, alt_stack_size: i64, handler: i64) -> Unit
 extern fn rt_fiber_reset_signal_handler(sig: i32) -> Unit
 extern fn rt_fiber_fault_addr(info: *const u8) -> i64
+extern fn rt_fiber_protect_guard(region: *mut u8, len: i64) -> Unit
 
 extern fn with_fiber_switch(save: *mut u8, restore: *mut u8) -> Unit
 extern fn with_fiber_prepare_initial_context(ctx: *mut u8, stack: *mut u8, stack_size: i64) -> Unit
@@ -142,6 +143,10 @@ fn store_i64_index(base: i64, index: i32, value: i64):
 fn load_i32(base: i64, offset: i64) -> i32:
     unsafe:
         *((base + offset) as *const i32)
+
+fn load_u32(base: i64, offset: i64) -> u32:
+    unsafe:
+        *((base + offset) as *const u32)
 
 fn store_i32(base: i64, offset: i64, value: i32):
     unsafe:
@@ -367,6 +372,7 @@ fn allocate_stack_region(size: i64) -> *mut u8:
     let region = rt_mmap(total)
     if region as i64 == 0 or region as i64 == MAP_FAILED:
         return 0 as *mut u8
+    rt_fiber_protect_guard(region, page_sz)
     (region as i64 + page_sz) as *mut u8
 
 fn acquire_fiber() -> i64:
@@ -459,26 +465,31 @@ fn fiber_write_i32(fd: i32, n: i32):
         let _ = rt_write(fd, (&buf as i64 + j as i64) as *const u8, 1)
         j = j - 1
 
-pub fn with_fiber_stack_overflow_handler(sig: i32, info: *const u8, ucontext: *mut u8) -> Unit:
-    let _ = ucontext
-    let fault_addr = rt_fiber_fault_addr(info)
-    if current_fiber != 0:
-        let stack = fiber_stack(current_fiber)
-        if stack as i64 != 0:
-            let page_sz = guard_page_size()
-            let guard_start = stack as i64 - page_sz
-            let guard_end = stack as i64
-            if fault_addr >= guard_start and fault_addr < guard_end:
-                let _ = rt_write(2, "fatal: fiber stack overflow (fiber #" as *const u8, 36)
-                fiber_write_i32(2, fiber_id(current_fiber))
-                let _ = rt_write(2, ")\n" as *const u8, 2)
-                rt_exit(134)
-
-    rt_fiber_reset_signal_handler(sig)
-    let _ = rt_raise(sig)
+pub fn with_fiber_veh(exception_info: *mut u8) -> i32:
+    let rec = load_i64(exception_info as i64, 0)
+    if rec == 0:
+        return 0
+    let code = load_u32(rec, 0)
+    if code != 0x80000001 as u32 and code != 0xc0000005 as u32:
+        return 0
+    if current_fiber == 0:
+        return 0
+    let stack = fiber_stack(current_fiber)
+    if stack as i64 == 0:
+        return 0
+    let fault_addr = load_i64(rec, 40)
+    let page_sz = guard_page_size()
+    let guard_start = stack as i64 - page_sz
+    let guard_end = stack as i64
+    if fault_addr >= guard_start and fault_addr < guard_end:
+        let _ = rt_write(2, "fatal: fiber stack overflow (fiber #" as *const u8, 36)
+        fiber_write_i32(2, fiber_id(current_fiber))
+        let _ = rt_write(2, ")\n" as *const u8, 2)
+        rt_exit(134)
+    0
 
 fn fiber_install_signal_handlers():
-    rt_fiber_install_signal_handlers(alt_stack_ptr(), FIBER_ALT_STACK_SIZE, with_fiber_stack_overflow_handler as i64)
+    rt_fiber_install_signal_handlers(alt_stack_ptr(), FIBER_ALT_STACK_SIZE, with_fiber_veh as i64)
 
 pub unsafe fn with_fiber_bootstrap_load(entry_out: *mut i64, arg_out: *mut i64, result_out: *mut i64) -> Unit:
     if current_fiber == 0:

--- a/rt/windows_x86_64.w
+++ b/rt/windows_x86_64.w
@@ -40,6 +40,8 @@ extern fn GetSystemInfo(info: *mut u8) -> Unit
 extern fn GlobalMemoryStatusEx(info: *mut u8) -> i32
 extern fn GetComputerNameW(buf: *mut u16, size: *mut u32) -> i32
 extern fn SystemFunction036(buf: *mut u8, len: u32) -> i32
+extern fn VirtualProtect(addr: *mut u8, size: u64, new_protect: u32, old_protect: *mut u32) -> i32
+extern fn AddVectoredExceptionHandler(first: u32, handler: *mut u8) -> *mut u8
 extern fn GetCurrentThreadId() -> u32
 extern fn GetTempPathA(size: u32, buf: *mut u8) -> u32
 extern fn GetTempFileNameA(path: *const u8, prefix: *const u8, unique: u32, buf: *mut u8) -> u32
@@ -66,6 +68,7 @@ let FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x02000000 as u32
 let MEM_COMMIT_RESERVE: u32 = 0x3000 as u32
 let MEM_RELEASE: u32 = 0x8000 as u32
 let PAGE_READWRITE: u32 = 4 as u32
+let PAGE_GUARD: u32 = 0x100 as u32
 let WAIT_OBJECT_0: u32 = 0 as u32
 let WAIT_TIMEOUT: u32 = 258 as u32
 let INFINITE: u32 = 0xffffffff as u32
@@ -382,10 +385,17 @@ pub fn rt_fiber_fault_addr(info: *const u8) -> i64:
 pub fn rt_fiber_reset_signal_handler(sig: i32) -> Unit:
     let _ = sig
 
+// Arm the fiber stack's guard page. PAGE_GUARD raises STATUS_GUARD_PAGE_VIOLATION
+// on first touch AND auto-commits the page, so the vectored handler has real stack
+// to run its diagnostic on — the Windows analogue of POSIX sigaltstack.
+pub fn rt_fiber_protect_guard(region: *mut u8, len: i64) -> Unit:
+    var old: u32 = 0
+    let _ = VirtualProtect(region, len as u64, PAGE_READWRITE | PAGE_GUARD, &raw mut old)
+
 pub fn rt_fiber_install_signal_handlers(alt_stack: *mut u8, alt_stack_size: i64, handler: i64) -> Unit:
     let _ = alt_stack
     let _ = alt_stack_size
-    let _ = handler
+    let _ = AddVectoredExceptionHandler(1 as u32, handler as *mut u8)
 
 fn win_path_join(parent: *const u8, name: *const u8, out: *mut u8, cap: i64) -> i32:
     let parent_len = win_cstr_len(parent)

--- a/test/behavior/behav_async_stack_overflow.w
+++ b/test/behavior/behav_async_stack_overflow.w
@@ -1,4 +1,3 @@
-//! skip-windows: issue #369: Windows custom fiber stack overflow diagnostic awaits async backend migration
 //! expect-exit: 134
 //! expect-stderr: fiber stack overflow
 //! args: -O0


### PR DESCRIPTION
Implements the Windows side of the fiber stack-overflow diagnostic and un-skips `test/behavior/behav_async_stack_overflow.w`.

## Problem
The POSIX fiber core (`rt/fiber_core_darwin.w`) catches guard-page stack overflow with a SIGSEGV handler on a sigaltstack. Windows has no POSIX signals, so a guard-page fault surfaces as a Structured Exception — the existing `rt_fiber_install_signal_handlers` was a no-op stub and the guard page was never armed, so an overflowing fiber just crashed without the diagnostic. That is why #369 was `skip-windows`.

## Fix (`rt/windows_x86_64.w`, `rt/fiber_core_windows.w`)
- **Arm the guard page.** `allocate_stack_region` now calls `VirtualProtect(region, page, PAGE_READWRITE | PAGE_GUARD)`. `PAGE_GUARD` raises `STATUS_GUARD_PAGE_VIOLATION` on first touch **and** auto-commits the page, giving the handler real stack to run on — the Windows analogue of the POSIX sigaltstack.
- **Register a vectored exception handler.** `rt_fiber_install_signal_handlers` calls `AddVectoredExceptionHandler`. `with_fiber_veh` reads `EXCEPTION_POINTERS`, matches `STATUS_GUARD_PAGE_VIOLATION` / access-violation against the current fiber's guard region, prints `fatal: fiber stack overflow (fiber #N)` and exits 134 — matching the POSIX diagnostic text and the unified panic-exit convention (#59).

## Verification
Windows CI builds stage1→stage3 from source (the stage compilers embed this runtime) and runs `build :test` with the test un-skipped: `behav_async_stack_overflow.w` recurses on a 16 KiB fiber stack and asserts `expect-exit: 134` / `expect-stderr: fiber stack overflow`.

Closes #369.