### PR TITLE
rt(linux-aarch64): fix posix_str_to_c_buf str data-pointer deref (unblocks aarch64 self-host)

### DIFF
--- a/rt/linux_aarch64.w
+++ b/rt/linux_aarch64.w
@@ -879,8 +879,8 @@ fn posix_str_to_c_buf(s: &str) -> *mut u8:
     if out as i64 == 0:
         return 0 as *mut u8
     if s.len() > 0:
-        let sp = &s as *const *const u8
-        with_memcpy(out, unsafe *sp, s.len())
+        let sp = unsafe **(&s as *const *const *const u8)
+        with_memcpy(out, sp, s.len())
     unsafe *((out as i64 + s.len()) as *mut u8) = 0
     out
 


### PR DESCRIPTION
## Fix linux-aarch64 subprocess spawning (posix_str_to_c_buf data-pointer deref)

`rt/linux_aarch64.w`'s `posix_str_to_c_buf` read the `str` data pointer with a
**double** dereference (`let sp = &s as *const *const u8; *sp`) — one deref short.
A `&str` param is passed as a pointer-to-str, so `*(&s)` is the *address of* the
str `{ptr,len}` struct, not the data pointer; `with_memcpy` then copied the raw
fat-pointer bytes instead of the string contents.

Every C string built through this helper came out garbage — including `argv[0]`
and the stdout/stderr/cwd paths handed to the forked child in `posix_run_argv`.
The child's `execvp`/`open` therefore failed and it `_exit(127)`'d **before**
writing anything to the capture files. That is the exact reason a cross-built
aarch64 seed runs and emits objects in-process fine, yet every fork-based
`bootstrap-*-object` target in `with build` exited **127 with empty stderr**.

The fix uses the **triple** deref `**(&s as *const *const *const u8)`, matching
the x86_64 runtime (`rt/linux_x86_64.w` `posix_str_to_c_buf`) and this same
file's own sibling `rt_str_data`, both of which were already correct. Pure source
divergence — not an ABI/codegen bug.

### Verification (native aarch64, running-code proof)

Bootstrapped a native aarch64 seed cross-built from this commit, then ran a full
native self-host on `ubuntu-24.04-arm`:

- **Build** (seed → stage1 → stage2 → final): **green** — the fork-based
  `bootstrap-*-object` targets that previously exited 127 now compile.
- **Fixpoint** (`stage2 == stage3`, byte-identical): **green** — the aarch64 seed
  self-hosts deterministically.

This is the first time a linux-aarch64 seed has ever cleared the build/fixpoint
gate.

### Known remaining aarch64 gaps (NOT introduced here; separate follow-ups)

With Build+fixpoint green, the aarch64 test battery reached execution for the
first time and surfaced 5 pre-existing platform-feature gaps, none touched by
this one-line runtime fix:

1. **emit-c on Linux/aarch64 host** (`emit-c-smoke`, `cli-selfhost-edge-tests`,
   `embedded-runtime-regression`): `emitc_host_platform_runtime_object()`
   (`build/emit_c.w:118`) has no Linux/aarch64 entry and bails with
   "unsupported host runtime object for emit-c". Needs the aarch64 host runtime
   object + host C-flags wired in.
2. **migrator variadic/stdarg on aarch64** (`c-migrator-basic-tests`
   `check-variadic-stdarg`): aarch64's `va_list` is a struct-based ABI, distinct
   from x86_64.
3. **c_import / sysinfo aarch64 ABI** (4 `behav_c_import_*` + `behav_sysinfo_contract`):
   aarch64 struct-layout/ABI handling in c_import and the sysinfo contract.

These are tracked as their own bring-up tasks; this PR is the isolated,
proven-correct enabler that gets the aarch64 seed self-hosting and fixpointing.
