### PR TITLE
build(emit-c): support Linux/aarch64 host runtime object

### DIFF
--- a/build/emit_c.w
+++ b/build/emit_c.w
@@ -92,6 +92,8 @@ fn emitc_c_compiler(ctx: &ActionCtx) -> str:
     let sdk_clang =
         if os() == "Windows":
             ".deps/llvm-22.1.6-windows-x86_64-msvc/bin/clang++.exe"
+        else if os() == "Linux" and (arch() == "armv8" or arch() == "aarch64"):
+            ".deps/llvm-22.1.6-linux-aarch64/bin/clang++"
         else if os() == "Linux":
             ".deps/llvm-22.1.6-linux-x86_64/bin/clang++"
         else if os() == "Macos":
@@ -121,6 +123,8 @@ fn emitc_host_platform_runtime_object() -> str:
     let host_arch = arch()
     if host_os == "Linux" and host_arch == "x86_64":
         return "rt_linux_x86_64.o"
+    if host_os == "Linux" and (host_arch == "armv8" or host_arch == "aarch64"):
+        return "rt_linux_aarch64.o"
     if host_os == "Macos" and (host_arch == "armv8" or host_arch == "aarch64"):
         return "rt_darwin_aarch64.o"
     if host_os == "Windows" and host_arch == "x86_64":

--- a/build/selfhost.w
+++ b/build/selfhost.w
@@ -98,6 +98,8 @@ fn bs_host_platform_runtime_object() -> str:
     let host_arch = arch()
     if host_os == "Linux" and host_arch == "x86_64":
         return "rt_linux_x86_64.o"
+    if host_os == "Linux" and (host_arch == "armv8" or host_arch == "aarch64"):
+        return "rt_linux_aarch64.o"
     if host_os == "Macos" and (host_arch == "armv8" or host_arch == "aarch64"):
         return "rt_darwin_aarch64.o"
     if host_os == "Windows" and host_arch == "x86_64":


### PR DESCRIPTION
## emit-c on a native Linux/aarch64 host

With the linux-aarch64 seed self-hosting (Build + fixpoint green, #851), the
aarch64 test battery reached execution for the first time and surfaced that
`emit-c` had no support for a **native Linux/aarch64 host**: it bailed with
`unsupported host runtime object for emit-c`.

Both host runtime-object tables enumerated only Linux/x86_64, Macos/aarch64,
and Windows/x86_64, so a Linux/aarch64 host fell through to the empty-string
bail:

- `emitc_host_platform_runtime_object` (`build/emit_c.w`)
- `bs_host_platform_runtime_object` (`build/selfhost.w`)

This wires the `Linux/aarch64 -> rt_linux_aarch64.o` entry into both, and makes
the LLVM-SDK `clang++` fallback path arch-aware
(`.deps/llvm-22.1.6-linux-aarch64` on an aarch64 host) so a local build without
`LLVM_PREFIX` resolves the right driver. The host C-flags (`-no-pie
-fuse-ld=lld`) and the host target triple (`aarch64-unknown-linux-gnu`) already
covered aarch64 — unchanged.

Unblocks the `emit-c-smoke`, `cli-selfhost-edge-tests`, and
`embedded-runtime-regression` targets on the native aarch64 self-host battery.

Stacked on #851 (the runtime deref fix that gets the aarch64 seed self-hosting).
