### PR TITLE
CI: build darwin-x86_64 LLVM SDK (PR-triggered)

### DIFF
--- a/.github/workflows/sdk-darwin-x86_64.yml
+++ b/.github/workflows/sdk-darwin-x86_64.yml
@@ -11,6 +11,9 @@ name: sdk-llvm darwin-x86_64
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/sdk-darwin-x86_64.yml'
 
 concurrency:
   group: sdk-darwin-x86_64-${{ github.ref }}


### PR DESCRIPTION
Adds a `pull_request` trigger to the darwin-x86_64 static-LLVM-SDK workflow so opening/updating this PR starts the build on withlang-dev's runners. Path-filtered to the workflow file, so it won't run on unrelated PRs. `workflow_dispatch` retained. This PR's own change to the workflow file triggers the build. Publishes `sdk-darwin-x86_64` (with-llvm-sdk-22.1.6-darwin-x86_64.tar.gz) on withlang-dev.