### PR TITLE
build: teach the SDK layer the linux-aarch64 host

### DIFF
--- a/build.w
+++ b/build.w
@@ -643,6 +643,8 @@ fn package_llvm_sdk_current_host_target() -> Target:
         return target.dep("package-llvm-sdk-darwin-aarch64")
     if platform == "linux-x86_64":
         return target.dep("package-llvm-sdk-linux-x86_64")
+    if platform == "linux-aarch64":
+        return target.dep("package-llvm-sdk-linux-aarch64")
     if platform == "windows-x86_64":
         return target.dep("package-llvm-sdk-windows-x86_64")
     target.dep("package-llvm-sdk-darwin-aarch64")
@@ -1411,6 +1413,7 @@ pub fn build(ctx: BuildCtx) -> Build:
     out = out.add_target(package_current_host_target())
     out = out.add_target(package_llvm_sdk_platform_target("package-llvm-sdk-darwin-aarch64", "darwin-aarch64", sdk_default_prefix_for_platform("darwin-aarch64"), sdk_default_build_cache_for_platform("darwin-aarch64")))
     out = out.add_target(package_llvm_sdk_platform_target("package-llvm-sdk-linux-x86_64", "linux-x86_64", sdk_default_prefix_for_platform("linux-x86_64"), sdk_default_build_cache_for_platform("linux-x86_64")))
+    out = out.add_target(package_llvm_sdk_platform_target("package-llvm-sdk-linux-aarch64", "linux-aarch64", sdk_default_prefix_for_platform("linux-aarch64"), sdk_default_build_cache_for_platform("linux-aarch64")))
     out = out.add_target(package_llvm_sdk_platform_target("package-llvm-sdk-windows-x86_64", "windows-x86_64", sdk_default_prefix_for_platform("windows-x86_64"), sdk_default_build_cache_for_platform("windows-x86_64")))
     out = out.add_target(package_llvm_sdk_current_host_target())
 

--- a/build/sdk.w
+++ b/build/sdk.w
@@ -101,6 +101,8 @@ pub fn sdk_current_platform() -> str:
         return "darwin-aarch64"
     if os() == "Linux" and arch() == "x86_64":
         return "linux-x86_64"
+    if os() == "Linux" and (arch() == "armv8" or arch() == "aarch64"):
+        return "linux-aarch64"
     if os() == "Windows" and arch() == "x86_64":
         return "windows-x86_64"
     ""
@@ -110,6 +112,8 @@ pub fn sdk_host_tag_for_platform(platform: &str) -> str:
         return "darwin-arm64"
     if platform == "linux-x86_64":
         return "linux-x86_64"
+    if platform == "linux-aarch64":
+        return "linux-aarch64"
     if platform == "windows-x86_64":
         return "windows-x86_64-msvc"
     "unsupported"


### PR DESCRIPTION
## Problem
`sdk_current_platform()` had no case for linux/aarch64, so it returned `""`. `package_llvm_sdk_current_host_target()` treats an unknown platform by falling through to its `darwin-aarch64` default — so `with build :package-llvm-sdk` on an aarch64 Linux host would try to package a **Darwin** SDK rather than the host's own.

## Fix
Add the platform to `sdk_current_platform()` and `sdk_host_tag_for_platform()`. Every other SDK path — install prefix, build cache, asset name, output prefix, output cache — derives from that host tag, so those two cases are the entire change. Then register `package-llvm-sdk-linux-aarch64` and dispatch to it.

`arch()` reports `"aarch64"` on this host (verified by running it, not assumed); `"armv8"` is accepted alongside to match the existing macOS idiom.

## Verification
- The target registers and dispatches on a real linux-aarch64 host (an aarch64 Ubuntu VM).
- Not verified end-to-end: `:package-llvm-sdk-linux-aarch64` still stops on that host because the SDK prefix there lacks `bin/cmake` and `bin/ninja`, which the packaging contract requires and which the published darwin/linux-x86_64 SDKs both carry. That is a property of that particular SDK tree, not of this change — producing a conforming SDK is `with build :sdk` (full from-source ninja+cmake+LLVM). The already-published `sdk-linux-aarch64` asset is what CI consumes, so this is not on the critical path.

## Stack
First of three. The two follow-ups (selfhost CI, release CI) touch `.github/workflows/` and could not be pushed with the current token — they need `workflow` scope.