### PR TITLE
compiler: serve rt_linux_aarch64.o from the embedded runtime

### DIFF
--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -27,6 +27,8 @@ extern let with_embedded_rt_core_o_start: u8
 extern let with_embedded_rt_core_o_end: u8
 extern let with_embedded_rt_darwin_aarch64_o_start: u8
 extern let with_embedded_rt_darwin_aarch64_o_end: u8
+extern let with_embedded_rt_linux_aarch64_o_start: u8
+extern let with_embedded_rt_linux_aarch64_o_end: u8
 extern let with_embedded_rt_linux_x86_64_o_start: u8
 extern let with_embedded_rt_linux_x86_64_o_end: u8
 extern let with_embedded_rt_windows_x86_64_o_start: u8
@@ -714,6 +716,8 @@ fn link_stage_embedded_runtime_object(name: &str) -> str:
         return link_stage_embedded_obj_slice(&with_embedded_rt_core_o_start as *const u8, &with_embedded_rt_core_o_end as *const u8)
     if name == "rt_darwin_aarch64.o":
         return link_stage_embedded_obj_slice(&with_embedded_rt_darwin_aarch64_o_start as *const u8, &with_embedded_rt_darwin_aarch64_o_end as *const u8)
+    if name == "rt_linux_aarch64.o":
+        return link_stage_embedded_obj_slice(&with_embedded_rt_linux_aarch64_o_start as *const u8, &with_embedded_rt_linux_aarch64_o_end as *const u8)
     if name == "rt_linux_x86_64.o":
         return link_stage_embedded_obj_slice(&with_embedded_rt_linux_x86_64_o_start as *const u8, &with_embedded_rt_linux_x86_64_o_end as *const u8)
     if name == "rt_windows_x86_64.o":


### PR DESCRIPTION
Stacked on #859.

## Problem
`Link.w` declared `with_embedded_rt_{core,darwin_aarch64,linux_x86_64,windows_x86_64}` and dispatched on them, but never `linux_aarch64` — so that one platform runtime was the only one not served from the binary. A linux-aarch64 compiler fell back to reading `rt_linux_aarch64.o` from `<bindir>/runtime/`, and with no such directory failed every link with `missing rt_linux_aarch64.o`.

That is the actual reason bootstrapping this platform in CI needs the runtime objects shipped beside the seed. This change removes the need; a follow-up drops that step from both workflows and re-pins to a seed carrying this commit.

## Fix
Declare the extern and dispatch on it, exactly as for the other three. Four lines.

Safe **only** because #859 made the symbol exist on every host. Before it, a darwin build emitted no such symbol and this extern would not have resolved — I verified that against a real darwin build rather than assuming it.

## Verification
Both hosts, build **and** fixpoint green:
- **darwin**: build exit 0 / 0 errors, fixpoint exit 0 / 0 errors — *after reseeding to a compiler carrying #859*. The reseed is required, not incidental: the embed step runs in the driver process, so an older seed emits no `linux_aarch64` symbol regardless of what the source says. This is the bootstrap ordering AGENTS.md calls for.
- **linux-aarch64**: build exit 0 / 0 errors, fixpoint exit 0 / 0 errors.

## Behaviour
A linux-aarch64 compiler alone in a directory, with no `runtime/` beside it:

```
=== dir contents (note: NO runtime/) ===
.  ..  h.w  with
=== run ===
SELF-CONTAINED: no runtime dir needed
```

Previously that same directory failed with `missing rt_linux_aarch64.o`. The platform is now self-contained like darwin, linux-x86_64 and windows.