### PR TITLE
Add target kind 6 = windows_aarch64 (inert target-table plumbing)

### DIFF
--- a/src/BuildGraphKinds.w
+++ b/src/BuildGraphKinds.w
@@ -8,7 +8,7 @@ const BUILD_GRAPH_STANDARD_KIND_MAX: i32 = 23
 const BUILD_GRAPH_PROJECT_KIND_MIN: i32 = 1000
 const BUILD_GRAPH_PROJECT_KIND_MAX: i32 = 1027
 const BUILD_GRAPH_TARGET_MIN: i32 = 0
-const BUILD_GRAPH_TARGET_MAX: i32 = 5
+const BUILD_GRAPH_TARGET_MAX: i32 = 6
 
 fn build_graph_kind_is_standard(kind: i32) -> bool:
     if kind >= BUILD_GRAPH_STANDARD_KIND_MIN and kind <= 4:
@@ -103,6 +103,8 @@ pub fn build_graph_target_name(kind: i32) -> str:
         return "darwin_aarch64"
     if kind == 5:
         return "windows_x86_64"
+    if kind == 6:
+        return "windows_aarch64"
     f"unknown({kind})"
 
 pub fn build_graph_host_target_kind() -> i32:
@@ -119,6 +121,8 @@ pub fn build_graph_host_target_kind() -> i32:
         if arch == "x86_64":
             return 1
     if os == "Windows":
+        if arch == "armv8" or arch == "aarch64":
+            return 6
         if arch == "x86_64":
             return 5
     0

--- a/src/BuildGraphOps.w
+++ b/src/BuildGraphOps.w
@@ -302,7 +302,7 @@ pub fn build_graph_embed_object_files(root: &str, target: &BuildGraphTarget) -> 
     // The embed target's entry names the PLATFORM the assembly is for
     // (e.g. "linux_x86_64" for a cross-built compiler); empty = host.
     var macho_sections = build_graph_host_target_kind() == 3 or build_graph_host_target_kind() == 4
-    var coff_sections = build_graph_host_target_kind() == 5
+    var coff_sections = build_graph_host_target_kind() == 5 or build_graph_host_target_kind() == 6
     if target.entry.len() > 0:
         macho_sections = target.entry.starts_with("darwin")
         coff_sections = target.entry.starts_with("windows")

--- a/src/TargetSpec.w
+++ b/src/TargetSpec.w
@@ -1,9 +1,9 @@
 // TargetSpec — the single source of truth for the active build target.
 //
-// `--target <triple>` (§18.5) selects a target kind: the same 0-5
+// `--target <triple>` (§18.5) selects a target kind: the same 0-6
 // numbering `std.build.BuildTarget` and `driver_target_triple_kind`
 // use (0 native, 1 linux_x86_64, 2 linux_aarch64, 3 darwin_x86_64,
-// 4 darwin_aarch64, 5 windows_x86_64). The driver records the active
+// 4 darwin_aarch64, 5 windows_x86_64, 6 windows_aarch64). The driver records the active
 // kind once per compile; parse-time @[target] guards, comptime
 // sysinfo, codegen C-ABI decisions, and the link stage read the
 // resolved target from here instead of querying host sysinfo.
@@ -43,6 +43,8 @@ pub fn target_spec_host_kind() -> i32:
         if arch == "x86_64":
             return 1
     if os == "Windows":
+        if arch == "armv8" or arch == "aarch64":
+            return 6
         if arch == "x86_64":
             return 5
     0
@@ -54,7 +56,7 @@ pub fn target_spec_os() -> str:
         return "Linux"
     if kind == 3 or kind == 4:
         return "Macos"
-    if kind == 5:
+    if kind == 5 or kind == 6:
         return "Windows"
     with_sysinfo_os()
 
@@ -66,7 +68,7 @@ pub fn target_spec_arch() -> str:
     let kind = target_spec_active
     if kind == 1 or kind == 3 or kind == 5:
         return "x86_64"
-    if kind == 2 or kind == 4:
+    if kind == 2 or kind == 4 or kind == 6:
         return "aarch64"
     with_sysinfo_arch()
 
@@ -84,6 +86,8 @@ pub fn target_spec_llvm_triple() -> str:
         return "arm64-apple-macosx11.0.0"
     if kind == 5:
         return "x86_64-pc-windows-msvc"
+    if kind == 6:
+        return "aarch64-pc-windows-msvc"
     ""
 
 // Display name in the build_graph_target_name spelling.
@@ -99,6 +103,8 @@ pub fn target_spec_name() -> str:
         return "darwin_aarch64"
     if kind == 5:
         return "windows_x86_64"
+    if kind == 6:
+        return "windows_aarch64"
     "native"
 
 // The non-native targets this compiler can actually produce code and

--- a/src/compiler/DriverOptions.w
+++ b/src/compiler/DriverOptions.w
@@ -261,6 +261,8 @@ pub fn driver_target_triple_kind(triple: &str) -> i32:
         return 4
     if triple == "x86_64-pc-windows-msvc" or triple == "windows_x86_64":
         return 5
+    if triple == "aarch64-pc-windows-msvc" or triple == "arm64-pc-windows-msvc" or triple == "windows_aarch64":
+        return 6
     -1
 
 pub type DriverTargetParseResult {

--- a/src/compiler/Frontend.w
+++ b/src/compiler/Frontend.w
@@ -161,6 +161,7 @@ fn frontend_rt_in_unit_platform_file() -> str:
     if kind == 2: return "rt/linux_aarch64.w"
     if kind == 4: return "rt/darwin_aarch64.w"
     if kind == 5: return "rt/windows_x86_64.w"
+    if kind == 6: return "rt/windows_aarch64.w"
     ""
 
 fn c_import_str_contains(text: &str, needle: &str) -> bool:
@@ -1410,7 +1411,7 @@ impl Zcu:
         if platform.len() == 0:
             self.diagnostics.emit(Diagnostic.err("rt-in-unit: no runtime platform source for target '" ++ target_spec_name() ++ "'", Span { file: 0, start: 0, end: 0 }))
             return merged_pool
-        let fiber_core = if platform == "rt/windows_x86_64.w": "rt/fiber_core_windows.w" else: "rt/fiber_core_darwin.w"
+        let fiber_core = if platform.starts_with("rt/windows"): "rt/fiber_core_windows.w" else: "rt/fiber_core_darwin.w"
         let files: Vec[str] = Vec.new()
         files.push("rt/rt_core.w")
         files.push(with_str_clone_ref(platform))

--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -652,7 +652,7 @@ fn link_stage_make_llvm_link_command(llvm_ld: &str, obj_path: &str, bin_path: &s
                 with_eprint("error: cross link needs the ELF lld driver (ld.lld) next to " ++ llvm_ld)
                 return LinkStageCommand { linker: "", args: Vec.new(), cwd: "", env: Vec.new(), inputs: Vec.new(), outputs: Vec.new(), cleanup_files: Vec.new() }
             return link_stage_make_linux_llvm_link_command(elf_ld, obj_path, bin_path, extras, link_libs, link_args)
-        if target_spec_active_kind() == 5:
+        if target_spec_active_kind() == 5 or target_spec_active_kind() == 6:
             let coff_ld = link_stage_coff_lld_for(llvm_ld)
             if coff_ld.len() == 0:
                 with_eprint("error: cross link needs the COFF lld driver (lld-link) next to " ++ llvm_ld)
@@ -1005,6 +1005,8 @@ fn link_stage_platform_runtime_object() -> str:
             return "rt_linux_aarch64.o"
         if target_spec_active_kind() == 5:
             return "rt_windows_x86_64.o"
+        if target_spec_active_kind() == 6:
+            return "rt_windows_aarch64.o"
         with_eprint("error: unsupported cross runtime platform: " ++ target_spec_name())
         return ""
     link_stage_host_platform_runtime_object()
@@ -1022,11 +1024,13 @@ fn link_stage_host_platform_runtime_object() -> str:
         return "rt_darwin_aarch64.o"
     if os == "Windows" and arch == "x86_64":
         return "rt_windows_x86_64.o"
+    if os == "Windows" and (arch == "armv8" or arch == "aarch64"):
+        return "rt_windows_aarch64.o"
     with_eprint("error: unsupported host runtime platform: " ++ os ++ "/" ++ arch)
     ""
 
 fn link_stage_make_archive(obj_path: &str) -> str:
-    if runtime_sysinfo_os() == "Windows" or target_spec_active_kind() == 5:
+    if runtime_sysinfo_os() == "Windows" or target_spec_active_kind() == 5 or target_spec_active_kind() == 6:
         return with_str_clone_ref(obj_path)
     // Wrap a .o file in a .a archive so the linker treats it as a library
     // (only pulling in symbols that aren't already defined).


### PR DESCRIPTION
First rung of the Windows-on-ARM64 (`aarch64-pc-windows-msvc`) seed effort:
introduce **target kind 6 = `windows_aarch64`** across the target-metadata
tables, without yet making it buildable.

This is deliberately **inert**. `target_spec_cross_supported` still returns
`false` for kind 6, so the target cannot be requested — kinds 0-5 are
unchanged and no existing code path is perturbed. The runtime backend
(`rt/windows_aarch64.w`), build wiring, and the embedded-runtime object
symbol land in follow-up PRs; kind 6 stays `cross_supported == false` until
then (this keeps the Link.w embedded-runtime symbol reference out of this
commit, so the seed still links — the symbol is defined alongside the
runtime object in the next PR).

## What changed
- **TargetSpec**: `os` / `arch` / `llvm_triple` / `name` / `host_kind` arms
  for kind 6 (arch `aarch64`, triple `aarch64-pc-windows-msvc`, name
  `windows_aarch64`).
- **DriverOptions**: map `aarch64-pc-windows-msvc` / `arm64-pc-windows-msvc`
  / `windows_aarch64` to kind 6.
- **BuildGraphKinds**: bump `BUILD_GRAPH_TARGET_MAX` to 6; target-name and
  host-kind arms.
- **Frontend**: rt-in-unit platform file `rt/windows_aarch64.w`; select the
  windows fiber-core for any `rt/windows*` platform.
- **Link**: cross-link COFF dispatch, platform/host runtime-object names,
  and archive gate for `windows_aarch64` (string plumbing only — no
  embedded-symbol reference).

## Verification (linux x86_64 host)
- `with build` — green
- `with build :fixpoint` — green (stage2 == stage3, byte-identical)
- `with build :dev` — stage1 links clean
- `build --target aarch64-pc-windows-msvc file.w` → `cross-target build for
  'windows_aarch64' is not implemented yet` (confirms the triple maps to
  kind 6 and is gated by `cross_supported`), while an unknown triple gets a
  distinct earlier `unsupported target triple` error.