### PR TITLE
Runtime backend + build wiring for windows_aarch64 (kind 6 buildable)

### DIFF
--- a/build.w
+++ b/build.w
@@ -309,6 +309,65 @@ fn run_cross_windows_llvm_link_metadata_action(ctx: ActionCtx) -> i32:
         return 1
     0
 
+// ── Cross-target (windows_aarch64) helpers ──────────────────────────
+
+fn cross_windows_aarch64_dir() -> str:
+    "out/lib/cross/windows_aarch64"
+
+fn cross_windows_aarch64_triple() -> str:
+    "aarch64-pc-windows-msvc"
+
+fn cross_windows_aarch64_llvm_prefix() -> str:
+    ".deps/llvm-" ++ compiler_llvm_version() ++ "-windows-aarch64-msvc"
+
+fn cross_windows_aarch64_object_target_named(name: &str, source: &str, obj_name: &str, opt: &str) -> Target:
+    var target = with_object_target(name, release_compiler_bin("with"), source, cross_windows_aarch64_dir() ++ "/" ++ obj_name, opt, "build")
+    target = target.arg("--target=" ++ cross_windows_aarch64_triple())
+    target
+
+fn cross_windows_aarch64_object_target(name: &str, source: &str, opt: &str) -> Target:
+    let base = comp_path_basename(source)
+    let stem = if base.ends_with(".w"): base.slice(0, base.len() - 2) else: base
+    cross_windows_aarch64_object_target_named(name, source, stem ++ ".o", opt)
+
+// Generate cross/windows_aarch64/llvm_ld.rsp — arm64 sibling of
+// run_cross_windows_llvm_link_metadata_action; identical .lib selection
+// against the windows-aarch64 SDK prefix.
+fn run_cross_windows_aarch64_llvm_link_metadata_action(ctx: ActionCtx) -> i32:
+    let fs = ctx.fs()
+    let output_path = ctx.output()
+    let lib_dir = cross_windows_aarch64_llvm_prefix() ++ "/lib"
+    let libclang = lib_dir ++ "/libclang.lib"
+    if not fs.host_exists(libclang):
+        ctx.diagnostics().error("cross-windows-aarch64-llvm-link-metadata: missing " ++ libclang ++ "; extract the with-llvm-sdk-" ++ compiler_llvm_version() ++ "-windows-aarch64 release asset into .deps/")
+        return 1
+    let lib_files = fs.host_list_files(lib_dir)
+    if lib_files.len() == 0:
+        ctx.diagnostics().error("cross-windows-aarch64-llvm-link-metadata: could not list: " ++ lib_dir)
+        return 1
+    var clang_archives: Vec[str] = Vec.new()
+    var llvm_archives: Vec[str] = Vec.new()
+    for i in 0..lib_files.len() as i32:
+        let path = lib_files.get(i as i64)
+        let name = comp_path_basename(path)
+        if name.ends_with(".lib"):
+            if (name.starts_with("clang") or name.starts_with("libclang")) and path != libclang:
+                clang_archives.push(build_owned_text(path))
+            else:
+                if name.starts_with("LLVM") and name != "LLVM-C.lib":
+                    llvm_archives.push(build_owned_text(path))
+    var ld_rsp = comp_rsp_path(libclang) ++ "\n"
+    let sorted_clang = comp_sort_strings(clang_archives)
+    for i in 0..sorted_clang.len() as i32:
+        ld_rsp = ld_rsp ++ comp_rsp_path(sorted_clang.get(i as i64)) ++ "\n"
+    let sorted_llvm = comp_sort_strings(llvm_archives)
+    for i in 0..sorted_llvm.len() as i32:
+        ld_rsp = ld_rsp ++ comp_rsp_path(sorted_llvm.get(i as i64)) ++ "\n"
+    if fs.write_text(output_path, ld_rsp) != 0:
+        ctx.diagnostics().error("cross-windows-aarch64-llvm-link-metadata: could not write: " ++ output_path)
+        return 1
+    0
+
 fn empty_file_target(name: &str, output: &str) -> Target:
     var target = target_new(.Action, build_owned_text(name), "").output(build_owned_text(output))
     target.action = run_write_empty_file_action
@@ -421,6 +480,9 @@ type HostRuntimeSpec:
     second_opposite_bootstrap_platform_blob: str
     second_opposite_platform_blob: str
     second_opposite_platform_symbol: str
+    third_opposite_bootstrap_platform_blob: str
+    third_opposite_platform_blob: str
+    third_opposite_platform_symbol: str
     fiber_core_source: str
     fiber_asm_source: str
 
@@ -453,6 +515,8 @@ fn release_platform_asset_bin() -> str:
         return "out/release/with-linux-x86_64"
     if host_os == "Windows" and host_arch == "x86_64":
         return "out/release/with-windows-x86_64.exe"
+    if host_os == "Windows" and (host_arch == "armv8" or host_arch == "aarch64"):
+        return "out/release/with-windows-aarch64.exe"
     release_compiler_bin("with")
 
 // The platform asset target only exists when the asset is a distinct copy of
@@ -481,6 +545,9 @@ fn host_runtime_spec() -> HostRuntimeSpec:
             second_opposite_bootstrap_platform_blob: "out/bootstrap-lib/empty_rt_linux_x86_64.bin",
             second_opposite_platform_blob: "out/lib/empty_rt_linux_x86_64.bin",
             second_opposite_platform_symbol: "rt_linux_x86_64_o",
+            third_opposite_bootstrap_platform_blob: "out/bootstrap-lib/empty_rt_windows_aarch64.bin",
+            third_opposite_platform_blob: "out/lib/empty_rt_windows_aarch64.bin",
+            third_opposite_platform_symbol: "rt_windows_aarch64_o",
             fiber_core_source: "rt/fiber_core_darwin.w",
             fiber_asm_source: "runtime/fiber_asm_linux_aarch64.s",
         }
@@ -498,6 +565,9 @@ fn host_runtime_spec() -> HostRuntimeSpec:
             second_opposite_bootstrap_platform_blob: "out/bootstrap-lib/empty_rt_windows_x86_64.bin",
             second_opposite_platform_blob: "out/lib/empty_rt_windows_x86_64.bin",
             second_opposite_platform_symbol: "rt_windows_x86_64_o",
+            third_opposite_bootstrap_platform_blob: "out/bootstrap-lib/empty_rt_windows_aarch64.bin",
+            third_opposite_platform_blob: "out/lib/empty_rt_windows_aarch64.bin",
+            third_opposite_platform_symbol: "rt_windows_aarch64_o",
             fiber_core_source: "rt/fiber_core_darwin.w",
             fiber_asm_source: "runtime/fiber_asm_linux_x86_64.s",
         }
@@ -515,8 +585,31 @@ fn host_runtime_spec() -> HostRuntimeSpec:
             second_opposite_bootstrap_platform_blob: "out/bootstrap-lib/empty_rt_linux_x86_64.bin",
             second_opposite_platform_blob: "out/lib/empty_rt_linux_x86_64.bin",
             second_opposite_platform_symbol: "rt_linux_x86_64_o",
+            third_opposite_bootstrap_platform_blob: "out/bootstrap-lib/empty_rt_windows_aarch64.bin",
+            third_opposite_platform_blob: "out/lib/empty_rt_windows_aarch64.bin",
+            third_opposite_platform_symbol: "rt_windows_aarch64_o",
             fiber_core_source: "rt/fiber_core_windows.w",
             fiber_asm_source: "runtime/fiber_asm_windows_x86_64.s",
+        }
+    if os() == "Windows" and (arch() == "armv8" or arch() == "aarch64"):
+        return HostRuntimeSpec {
+            platform_source: "rt/windows_aarch64.w",
+            compat_source: "rt/compat_runtime.w",
+            bootstrap_platform_object: "out/bootstrap-lib/rt_windows_aarch64.o",
+            platform_object: "out/lib/rt_windows_aarch64.o",
+            platform_install_object: "rt_windows_aarch64.o",
+            platform_symbol: "rt_windows_aarch64_o",
+            opposite_bootstrap_platform_blob: "out/bootstrap-lib/empty_rt_darwin_aarch64.bin",
+            opposite_platform_blob: "out/lib/empty_rt_darwin_aarch64.bin",
+            opposite_platform_symbol: "rt_darwin_aarch64_o",
+            second_opposite_bootstrap_platform_blob: "out/bootstrap-lib/empty_rt_linux_x86_64.bin",
+            second_opposite_platform_blob: "out/lib/empty_rt_linux_x86_64.bin",
+            second_opposite_platform_symbol: "rt_linux_x86_64_o",
+            third_opposite_bootstrap_platform_blob: "out/bootstrap-lib/empty_rt_windows_x86_64.bin",
+            third_opposite_platform_blob: "out/lib/empty_rt_windows_x86_64.bin",
+            third_opposite_platform_symbol: "rt_windows_x86_64_o",
+            fiber_core_source: "rt/fiber_core_windows.w",
+            fiber_asm_source: "runtime/fiber_asm_windows_aarch64.s",
         }
     HostRuntimeSpec {
         platform_source: "rt/darwin_aarch64.w",
@@ -531,6 +624,9 @@ fn host_runtime_spec() -> HostRuntimeSpec:
         second_opposite_bootstrap_platform_blob: "out/bootstrap-lib/empty_rt_windows_x86_64.bin",
         second_opposite_platform_blob: "out/lib/empty_rt_windows_x86_64.bin",
         second_opposite_platform_symbol: "rt_windows_x86_64_o",
+        third_opposite_bootstrap_platform_blob: "out/bootstrap-lib/empty_rt_windows_aarch64.bin",
+        third_opposite_platform_blob: "out/lib/empty_rt_windows_aarch64.bin",
+        third_opposite_platform_symbol: "rt_windows_aarch64_o",
         fiber_core_source: "rt/fiber_core_darwin.w",
         fiber_asm_source: "runtime/fiber_asm_aarch64.s",
     }
@@ -542,6 +638,8 @@ fn release_asset_for_host() -> str:
         return "with-darwin-aarch64"
     if os() == "Windows" and arch() == "x86_64":
         return "with-windows-x86_64.exe"
+    if os() == "Windows" and (arch() == "armv8" or arch() == "aarch64"):
+        return "with-windows-aarch64.exe"
     "with-darwin-aarch64"
 
 // "with-darwin-aarch64" -> "darwin-aarch64"
@@ -561,6 +659,8 @@ fn supported_release_platform_tag() -> str:
         return "darwin-aarch64"
     if os() == "Windows" and arch() == "x86_64":
         return "windows-x86_64"
+    if os() == "Windows" and (arch() == "armv8" or arch() == "aarch64"):
+        return "windows-aarch64"
     ""
 
 // ".deps/llvm-<ver>-<host>" -> "llvm-<ver>-<host>"
@@ -580,6 +680,8 @@ fn release_package_asset_for_platform(platform: &str) -> str:
         return "with-linux-x86_64"
     if platform == "windows_x86_64" or platform == "windows-x86_64":
         return "with-windows-x86_64.exe"
+    if platform == "windows_aarch64" or platform == "windows-aarch64":
+        return "with-windows-aarch64.exe"
     "with-unsupported"
 
 fn package_platform_target(name: &str, platform: &str, ctx: &BuildCtx) -> Target:
@@ -614,6 +716,8 @@ fn package_current_host_target() -> Target:
         return target.dep("package-linux-x86_64")
     if platform == "windows-x86_64":
         return target.dep("package-windows-x86_64")
+    if platform == "windows-aarch64":
+        return target.dep("package-windows-aarch64")
     target.dep("package-darwin-aarch64")
 
 fn package_llvm_sdk_platform_target(name: &str, platform: &str, prefix: &str, build_cache: &str) -> Target:
@@ -647,6 +751,8 @@ fn package_llvm_sdk_current_host_target() -> Target:
         return target.dep("package-llvm-sdk-linux-aarch64")
     if platform == "windows-x86_64":
         return target.dep("package-llvm-sdk-windows-x86_64")
+    if platform == "windows-aarch64":
+        return target.dep("package-llvm-sdk-windows-aarch64")
     target.dep("package-llvm-sdk-darwin-aarch64")
 
 fn sdk_source_target(name: &str, url: &str, sha256: &str, archive: &str, source_root: &str, source_dir: &str, marker: &str) -> Target:
@@ -737,7 +843,7 @@ fn sdk_llvm_target(ctx: &BuildCtx) -> Target:
     let bootstrap_prefix = sdk_bootstrap_prefix_arg(ctx, platform)
     let output_prefix = sdk_output_prefix_arg(ctx, platform)
     let build_root = sdk_build_root_arg(ctx, platform)
-    var target = target_new(.Action, "sdk-llvm", "").output(if platform == "windows-x86_64": output_prefix ++ "/lib/libclang.lib" else: output_prefix ++ "/lib/libclang.a")
+    var target = target_new(.Action, "sdk-llvm", "").output(if platform == "windows-x86_64" or platform == "windows-aarch64": output_prefix ++ "/lib/libclang.lib" else: output_prefix ++ "/lib/libclang.a")
     target.action = run_sdk_llvm_action
     target = target.arg(bootstrap_prefix)
     target = target.arg(output_prefix)
@@ -1410,11 +1516,13 @@ pub fn build(ctx: BuildCtx) -> Build:
     out = out.add_target(package_platform_target("package-darwin-aarch64", "darwin-aarch64", ctx))
     out = out.add_target(package_platform_target("package-linux-x86_64", "linux-x86_64", ctx))
     out = out.add_target(package_platform_target("package-windows-x86_64", "windows-x86_64", ctx))
+    out = out.add_target(package_platform_target("package-windows-aarch64", "windows-aarch64", ctx))
     out = out.add_target(package_current_host_target())
     out = out.add_target(package_llvm_sdk_platform_target("package-llvm-sdk-darwin-aarch64", "darwin-aarch64", sdk_default_prefix_for_platform("darwin-aarch64"), sdk_default_build_cache_for_platform("darwin-aarch64")))
     out = out.add_target(package_llvm_sdk_platform_target("package-llvm-sdk-linux-x86_64", "linux-x86_64", sdk_default_prefix_for_platform("linux-x86_64"), sdk_default_build_cache_for_platform("linux-x86_64")))
     out = out.add_target(package_llvm_sdk_platform_target("package-llvm-sdk-linux-aarch64", "linux-aarch64", sdk_default_prefix_for_platform("linux-aarch64"), sdk_default_build_cache_for_platform("linux-aarch64")))
     out = out.add_target(package_llvm_sdk_platform_target("package-llvm-sdk-windows-x86_64", "windows-x86_64", sdk_default_prefix_for_platform("windows-x86_64"), sdk_default_build_cache_for_platform("windows-x86_64")))
+    out = out.add_target(package_llvm_sdk_platform_target("package-llvm-sdk-windows-aarch64", "windows-aarch64", sdk_default_prefix_for_platform("windows-aarch64"), sdk_default_build_cache_for_platform("windows-aarch64")))
     out = out.add_target(package_llvm_sdk_current_host_target())
 
     out = out.add_target(sdk_source_target("sdk-ninja-source", sdk_ninja_source_url(), sdk_ninja_source_sha256(), sdk_ninja_archive(), sdk_source_root(), sdk_ninja_source_dir(), sdk_ninja_source_marker()))
@@ -1489,6 +1597,7 @@ pub fn build(ctx: BuildCtx) -> Build:
     out = out.add_target(with_object_target("bootstrap-rt-platform-object", "seed", host_runtime.platform_source, host_runtime.bootstrap_platform_object, "-O1", ""))
     out = out.add_target(empty_file_target("bootstrap-empty-opposite-runtime-blob", host_runtime.opposite_bootstrap_platform_blob))
     out = out.add_target(empty_file_target("bootstrap-empty-second-opposite-runtime-blob", host_runtime.second_opposite_bootstrap_platform_blob))
+    out = out.add_target(empty_file_target("bootstrap-empty-third-opposite-runtime-blob", host_runtime.third_opposite_bootstrap_platform_blob))
     out = out.add_target(with_object_target("bootstrap-cimport-stubs-object", "seed", "rt/cimport_stubs.w", "out/bootstrap-lib/cimport_stubs.o", "-O1", ""))
     out = out.add_target(with_object_target("bootstrap-compat-runtime-object", "seed", "out/gen/compat_runtime.w", "out/bootstrap-lib/compat_runtime.o", "-O1", "compat-runtime-source"))
     out = out.add_target(with_object_target("bootstrap-panic-runtime-object", "seed", "rt/panic_runtime.w", "out/bootstrap-lib/panic_runtime.o", "-O1", ""))
@@ -1530,6 +1639,8 @@ pub fn build(ctx: BuildCtx) -> Build:
     bootstrap_embedded_objects = bootstrap_embedded_objects.arg(build_owned_text(host_runtime.opposite_platform_symbol))
     bootstrap_embedded_objects = bootstrap_embedded_objects.input(host_runtime.second_opposite_bootstrap_platform_blob)
     bootstrap_embedded_objects = bootstrap_embedded_objects.arg(build_owned_text(host_runtime.second_opposite_platform_symbol))
+    bootstrap_embedded_objects = bootstrap_embedded_objects.input(host_runtime.third_opposite_bootstrap_platform_blob)
+    bootstrap_embedded_objects = bootstrap_embedded_objects.arg(build_owned_text(host_runtime.third_opposite_platform_symbol))
     // Every consumed object's producer, declared (#680 edge audit).
     bootstrap_embedded_objects = bootstrap_embedded_objects.dep("bootstrap-cimport-stubs-object")
     bootstrap_embedded_objects = bootstrap_embedded_objects.dep("bootstrap-compat-runtime-object")
@@ -1544,6 +1655,7 @@ pub fn build(ctx: BuildCtx) -> Build:
     bootstrap_embedded_objects = bootstrap_embedded_objects.dep("bootstrap-rt-platform-object")
     bootstrap_embedded_objects = bootstrap_embedded_objects.dep("bootstrap-empty-opposite-runtime-blob")
     bootstrap_embedded_objects = bootstrap_embedded_objects.dep("bootstrap-empty-second-opposite-runtime-blob")
+    bootstrap_embedded_objects = bootstrap_embedded_objects.dep("bootstrap-empty-third-opposite-runtime-blob")
     out = out.add_target(bootstrap_embedded_objects)
     var bootstrap_embedded_objects_obj = target_new(.CompileAsmObject, "bootstrap-embedded-objects-object", "out/bootstrap-lib/embedded_objects.s").output("out/bootstrap-lib/embedded_objects.o")
     bootstrap_embedded_objects_obj = bootstrap_embedded_objects_obj.dep("bootstrap-embedded-objects-asm")
@@ -1555,6 +1667,7 @@ pub fn build(ctx: BuildCtx) -> Build:
     bootstrap_runtime = bootstrap_runtime.dep("bootstrap-rt-platform-object")
     bootstrap_runtime = bootstrap_runtime.dep("bootstrap-empty-opposite-runtime-blob")
     bootstrap_runtime = bootstrap_runtime.dep("bootstrap-empty-second-opposite-runtime-blob")
+    bootstrap_runtime = bootstrap_runtime.dep("bootstrap-empty-third-opposite-runtime-blob")
     bootstrap_runtime = bootstrap_runtime.dep("bootstrap-cimport-stubs-object")
     bootstrap_runtime = bootstrap_runtime.dep("bootstrap-compat-runtime-object")
     bootstrap_runtime = bootstrap_runtime.dep("bootstrap-panic-runtime-object")
@@ -1750,6 +1863,7 @@ pub fn build(ctx: BuildCtx) -> Build:
     out = out.add_target(with_object_target("rt-platform-object", stage_compiler_bin("with-stage2"), host_runtime.platform_source, host_runtime.platform_object, "-O1", "stage2"))
     out = out.add_target(empty_file_target("empty-opposite-runtime-blob", host_runtime.opposite_platform_blob))
     out = out.add_target(empty_file_target("empty-second-opposite-runtime-blob", host_runtime.second_opposite_platform_blob))
+    out = out.add_target(empty_file_target("empty-third-opposite-runtime-blob", host_runtime.third_opposite_platform_blob))
     out = out.add_target(with_object_target("cimport-stubs-object", stage_compiler_bin("with-stage2"), "rt/cimport_stubs.w", "out/lib/cimport_stubs.o", "-O1", "stage2"))
     var compat_runtime_obj = with_object_target("compat-runtime-object", stage_compiler_bin("with-stage2"), "out/gen/compat_runtime.w", "out/lib/compat_runtime.o", "-O1", "stage2")
     compat_runtime_obj = compat_runtime_obj.dep("compat-runtime-source")
@@ -1796,6 +1910,8 @@ pub fn build(ctx: BuildCtx) -> Build:
     embedded_objects = embedded_objects.arg(host_runtime.opposite_platform_symbol)
     embedded_objects = embedded_objects.input(host_runtime.second_opposite_platform_blob)
     embedded_objects = embedded_objects.arg(host_runtime.second_opposite_platform_symbol)
+    embedded_objects = embedded_objects.input(host_runtime.third_opposite_platform_blob)
+    embedded_objects = embedded_objects.arg(host_runtime.third_opposite_platform_symbol)
     // Every consumed object's producer, declared (#680 edge audit).
     embedded_objects = embedded_objects.dep("cimport-stubs-object")
     embedded_objects = embedded_objects.dep("compat-runtime-object")
@@ -1810,6 +1926,7 @@ pub fn build(ctx: BuildCtx) -> Build:
     embedded_objects = embedded_objects.dep("rt-platform-object")
     embedded_objects = embedded_objects.dep("empty-opposite-runtime-blob")
     embedded_objects = embedded_objects.dep("empty-second-opposite-runtime-blob")
+    embedded_objects = embedded_objects.dep("empty-third-opposite-runtime-blob")
     out = out.add_target(embedded_objects)
 
     var embedded_objects_obj = target_new(.CompileAsmObject, "embedded-objects-object", "out/lib/embedded_objects.s").output("out/lib/embedded_objects.o")
@@ -1820,6 +1937,7 @@ pub fn build(ctx: BuildCtx) -> Build:
     runtime = runtime.dep("embedded-objects-object")
     runtime = runtime.dep("empty-opposite-runtime-blob")
     runtime = runtime.dep("empty-second-opposite-runtime-blob")
+    runtime = runtime.dep("empty-third-opposite-runtime-blob")
     out = out.add_target(runtime)
 
     // ── Cross-target runtime (linux) ────────────────────────────────
@@ -1917,6 +2035,92 @@ pub fn build(ctx: BuildCtx) -> Build:
     cross_rt_windows = cross_rt_windows.dep("cross-win-clang-bridge-object")
     cross_rt_windows = cross_rt_windows.dep("cross-win-llvm-link-metadata")
     out = out.add_target(cross_rt_windows)
+
+    // ── Cross-target runtime (windows_aarch64) ──────────────────────
+    // `with build :cross-rt-windows-aarch64` builds the full windows_aarch64
+    // runtime + compiler link inputs into out/lib/cross/windows_aarch64/
+    // (COFF/ARM64 objects, aarch64-pc-windows-msvc triple) so a
+    // `--target aarch64-pc-windows-msvc` link resolves entirely from that
+    // directory (§18.5). Mirrors the windows_x86_64 cross-rt set; fiber
+    // core is the windows variant, fiber asm the arm64 windows variant.
+    out = out.add_target(cross_windows_aarch64_object_target("cross-winarm-rt-core-object", "rt/rt_core.w", "-O2"))
+    out = out.add_target(cross_windows_aarch64_object_target_named("cross-winarm-rt-platform-object", "rt/windows_aarch64.w", "rt_windows_aarch64.o", "-O2"))
+    out = out.add_target(cross_windows_aarch64_object_target("cross-winarm-cimport-stubs-object", "rt/cimport_stubs.w", "-O1"))
+    var cross_winarm_compat = cross_windows_aarch64_object_target_named("cross-winarm-compat-runtime-object", "out/gen/compat_runtime.w", "compat_runtime.o", "-O1")
+    cross_winarm_compat = cross_winarm_compat.dep("compat-runtime-source")
+    out = out.add_target(cross_winarm_compat)
+    out = out.add_target(cross_windows_aarch64_object_target("cross-winarm-panic-runtime-object", "rt/panic_runtime.w", "-O1"))
+    out = out.add_target(cross_windows_aarch64_object_target("cross-winarm-fiber-stubs-object", "rt/fiber_stubs.w", "-O1"))
+    out = out.add_target(cross_windows_aarch64_object_target("cross-winarm-channel-runtime-object", "rt/channel_runtime.w", "-O1"))
+    out = out.add_target(cross_windows_aarch64_object_target("cross-winarm-fiber-runtime-object", "rt/fiber_runtime.w", "-O1"))
+    out = out.add_target(cross_windows_aarch64_object_target_named("cross-winarm-fiber-core-object", "rt/fiber_core_windows.w", "fiber.o", "-O1"))
+    out = out.add_target(cross_windows_aarch64_object_target_named("cross-winarm-llvm-bridge-object", "src/compiler/LlvmBridge.w", "llvm_bridge.o", "-O1"))
+    out = out.add_target(cross_windows_aarch64_object_target_named("cross-winarm-clang-bridge-object", "src/compiler/ClangBridge.w", "clang_bridge.o", "-O1"))
+
+    var cross_winarm_regex_ir = with_ir_target_overflow("cross-winarm-regex-runtime-ir", release_compiler_bin("with"), "rt/regex_runtime.w", "out/tmp/cross_winarm_regex_runtime.ll", "build", "wrap")
+    cross_winarm_regex_ir = cross_winarm_regex_ir.arg("--target=" ++ cross_windows_aarch64_triple())
+    out = out.add_target(cross_winarm_regex_ir)
+    var cross_winarm_regex = target_new(.CompileLlvmIrObject, "cross-winarm-regex-runtime-object", "out/tmp/cross_winarm_regex_runtime.ll").output(cross_windows_aarch64_dir() ++ "/regex_runtime.o")
+    cross_winarm_regex = cross_winarm_regex.dep("cross-winarm-regex-runtime-ir")
+    out = out.add_target(cross_winarm_regex)
+
+    var cross_winarm_fiber_asm = target_new(.CompileAsmObject, "cross-winarm-fiber-asm-object", "runtime/fiber_asm_windows_aarch64.s").output(cross_windows_aarch64_dir() ++ "/fiber_asm.o")
+    cross_winarm_fiber_asm = cross_winarm_fiber_asm.arg("triple=" ++ cross_windows_aarch64_triple())
+    out = out.add_target(cross_winarm_fiber_asm)
+
+    var cross_winarm_embedded = target_new(.EmbedObjectFiles, "cross-winarm-embedded-objects-asm", "windows_aarch64").output(cross_windows_aarch64_dir() ++ "/embedded_objects.s")
+    cross_winarm_embedded = cross_winarm_embedded.input(cross_windows_aarch64_dir() ++ "/cimport_stubs.o")
+    cross_winarm_embedded = cross_winarm_embedded.arg("cimport_stubs_o")
+    cross_winarm_embedded = cross_winarm_embedded.input(cross_windows_aarch64_dir() ++ "/compat_runtime.o")
+    cross_winarm_embedded = cross_winarm_embedded.arg("compat_runtime_o")
+    cross_winarm_embedded = cross_winarm_embedded.input(cross_windows_aarch64_dir() ++ "/panic_runtime.o")
+    cross_winarm_embedded = cross_winarm_embedded.arg("panic_runtime_o")
+    cross_winarm_embedded = cross_winarm_embedded.input(cross_windows_aarch64_dir() ++ "/regex_runtime.o")
+    cross_winarm_embedded = cross_winarm_embedded.arg("regex_runtime_o")
+    cross_winarm_embedded = cross_winarm_embedded.input(cross_windows_aarch64_dir() ++ "/fiber_stubs.o")
+    cross_winarm_embedded = cross_winarm_embedded.arg("fiber_stubs_o")
+    cross_winarm_embedded = cross_winarm_embedded.input(cross_windows_aarch64_dir() ++ "/channel_runtime.o")
+    cross_winarm_embedded = cross_winarm_embedded.arg("channel_runtime_o")
+    cross_winarm_embedded = cross_winarm_embedded.input(cross_windows_aarch64_dir() ++ "/fiber_runtime.o")
+    cross_winarm_embedded = cross_winarm_embedded.arg("fiber_runtime_o")
+    cross_winarm_embedded = cross_winarm_embedded.input(cross_windows_aarch64_dir() ++ "/fiber.o")
+    cross_winarm_embedded = cross_winarm_embedded.arg("fiber_o")
+    cross_winarm_embedded = cross_winarm_embedded.input(cross_windows_aarch64_dir() ++ "/fiber_asm.o")
+    cross_winarm_embedded = cross_winarm_embedded.arg("fiber_asm_o")
+    cross_winarm_embedded = cross_winarm_embedded.input(cross_windows_aarch64_dir() ++ "/rt_core.o")
+    cross_winarm_embedded = cross_winarm_embedded.arg("rt_core_o")
+    cross_winarm_embedded = cross_winarm_embedded.input(cross_windows_aarch64_dir() ++ "/rt_windows_aarch64.o")
+    cross_winarm_embedded = cross_winarm_embedded.arg("rt_windows_aarch64_o")
+    cross_winarm_embedded = cross_winarm_embedded.dep("cross-winarm-cimport-stubs-object")
+    cross_winarm_embedded = cross_winarm_embedded.dep("cross-winarm-compat-runtime-object")
+    cross_winarm_embedded = cross_winarm_embedded.dep("cross-winarm-panic-runtime-object")
+    cross_winarm_embedded = cross_winarm_embedded.dep("cross-winarm-regex-runtime-object")
+    cross_winarm_embedded = cross_winarm_embedded.dep("cross-winarm-fiber-stubs-object")
+    cross_winarm_embedded = cross_winarm_embedded.dep("cross-winarm-channel-runtime-object")
+    cross_winarm_embedded = cross_winarm_embedded.dep("cross-winarm-fiber-runtime-object")
+    cross_winarm_embedded = cross_winarm_embedded.dep("cross-winarm-fiber-core-object")
+    cross_winarm_embedded = cross_winarm_embedded.dep("cross-winarm-fiber-asm-object")
+    cross_winarm_embedded = cross_winarm_embedded.dep("cross-winarm-rt-core-object")
+    cross_winarm_embedded = cross_winarm_embedded.dep("cross-winarm-rt-platform-object")
+    out = out.add_target(cross_winarm_embedded)
+
+    var cross_winarm_embedded_obj = target_new(.CompileAsmObject, "cross-winarm-embedded-objects-object", cross_windows_aarch64_dir() ++ "/embedded_objects.s").output(cross_windows_aarch64_dir() ++ "/embedded_objects.o")
+    cross_winarm_embedded_obj = cross_winarm_embedded_obj.arg("triple=" ++ cross_windows_aarch64_triple())
+    cross_winarm_embedded_obj = cross_winarm_embedded_obj.dep("cross-winarm-embedded-objects-asm")
+    out = out.add_target(cross_winarm_embedded_obj)
+
+    var cross_winarm_ld_rsp = target_new(.Action, "cross-winarm-llvm-link-metadata", "").output(cross_windows_aarch64_dir() ++ "/llvm_ld.rsp")
+    cross_winarm_ld_rsp.action = run_cross_windows_aarch64_llvm_link_metadata_action
+    cross_winarm_ld_rsp = cross_winarm_ld_rsp.write_scope(cross_windows_aarch64_dir())
+    cross_winarm_ld_rsp = cross_winarm_ld_rsp.write_scope("out/command/cross-winarm-llvm-link-metadata")
+    out = out.add_target(cross_winarm_ld_rsp)
+
+    var cross_rt_windows_aarch64 = target_new(.Group, "cross-rt-windows-aarch64", "")
+    cross_rt_windows_aarch64 = cross_rt_windows_aarch64.dep("cross-winarm-embedded-objects-object")
+    cross_rt_windows_aarch64 = cross_rt_windows_aarch64.dep("cross-winarm-llvm-bridge-object")
+    cross_rt_windows_aarch64 = cross_rt_windows_aarch64.dep("cross-winarm-clang-bridge-object")
+    cross_rt_windows_aarch64 = cross_rt_windows_aarch64.dep("cross-winarm-llvm-link-metadata")
+    out = out.add_target(cross_rt_windows_aarch64)
 
     // The compiler links to an UNSTAMPED intermediate whose inputs (out/gen/main.w
     // + src) are commit-independent, so it caches across commits (#650). A cheap

--- a/build/emit_c.w
+++ b/build/emit_c.w
@@ -133,7 +133,10 @@ fn emitc_push_host_c_flags(argv: Vec[str]) -> Vec[str]:
         argv |> push("-fuse-ld=lld")
     if os() == "Windows":
         argv |> push("-target")
-        argv |> push("x86_64-pc-windows-msvc")
+        if arch() == "armv8" or arch() == "aarch64":
+            argv |> push("aarch64-pc-windows-msvc")
+        else:
+            argv |> push("x86_64-pc-windows-msvc")
         argv |> push("-fms-runtime-lib=static")
         argv |> push("-D_CRT_SECURE_NO_WARNINGS")
         argv |> push("-fuse-ld=lld")
@@ -143,20 +146,26 @@ fn emitc_push_host_c_flags(argv: Vec[str]) -> Vec[str]:
         argv |> push("-Wl,/libpath:" ++ emitc_windows_msvc_libdir())
     argv
 
+// Windows SDK/CRT lib-arch subdir for the host: arm64 or x64. The
+// hardcoded fallbacks below embed this; env overrides (set by the
+// runner / cross SDK) take precedence and are used verbatim.
+fn emitc_windows_lib_arch():
+    if arch() == "armv8" or arch() == "aarch64": "arm64" else: "x64"
+
 fn emitc_windows_um_libdir():
     let dir = env("WITH_WINDOWS_UM_LIBDIR")
     if dir.len() > 0: return dir
-    "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/um/x64"
+    "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/um/" ++ emitc_windows_lib_arch()
 
 fn emitc_windows_ucrt_libdir():
     let dir = env("WITH_WINDOWS_UCRT_LIBDIR")
     if dir.len() > 0: return dir
-    "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/ucrt/x64"
+    "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/ucrt/" ++ emitc_windows_lib_arch()
 
 fn emitc_windows_msvc_libdir():
     let dir = env("WITH_WINDOWS_MSVC_LIBDIR")
     if dir.len() > 0: return dir
-    "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.29.30133/lib/x64"
+    "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.29.30133/lib/" ++ emitc_windows_lib_arch()
 
 // Windows import-library paths. Honour the explicit libdir env override
 // (set by the runner / cross-build SDK) before the baked-in VS2019/Windows-Kit
@@ -165,17 +174,17 @@ fn emitc_windows_msvc_libdir():
 fn emitc_windows_sdk_um_lib(name: &str) -> str:
     let dir = env("WITH_WINDOWS_UM_LIBDIR")
     if dir.len() > 0: return dir ++ "/" ++ name
-    "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/um/x64/" ++ name
+    "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/um/" ++ emitc_windows_lib_arch() ++ "/" ++ name
 
 fn emitc_windows_sdk_ucrt_lib(name: &str) -> str:
     let dir = env("WITH_WINDOWS_UCRT_LIBDIR")
     if dir.len() > 0: return dir ++ "/" ++ name
-    "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/ucrt/x64/" ++ name
+    "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/ucrt/" ++ emitc_windows_lib_arch() ++ "/" ++ name
 
 fn emitc_windows_msvc_lib(name: &str) -> str:
     let dir = env("WITH_WINDOWS_MSVC_LIBDIR")
     if dir.len() > 0: return dir ++ "/" ++ name
-    "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.29.30133/lib/x64/" ++ name
+    "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.29.30133/lib/" ++ emitc_windows_lib_arch() ++ "/" ++ name
 
 fn emitc_push_system_libs(argv: Vec[str]) -> Vec[str]:
     if os() == "Windows":

--- a/build/sdk.w
+++ b/build/sdk.w
@@ -105,6 +105,8 @@ pub fn sdk_current_platform() -> str:
         return "linux-aarch64"
     if os() == "Windows" and arch() == "x86_64":
         return "windows-x86_64"
+    if os() == "Windows" and (arch() == "armv8" or arch() == "aarch64"):
+        return "windows-aarch64"
     ""
 
 pub fn sdk_host_tag_for_platform(platform: &str) -> str:
@@ -272,12 +274,13 @@ fn sdk_validate_cache(ctx: &ActionCtx, platform: &str, cache_path: &str) -> i32:
     let cache = fs.read_text(cache_path)
     let cc = sdk_cache_line(cache, "CMAKE_C_COMPILER:")
     let cxx = sdk_cache_line(cache, "CMAKE_CXX_COMPILER:")
-    if platform == "windows-x86_64":
+    if platform == "windows-x86_64" or platform == "windows-aarch64":
         if not cc.contains("clang-cl") or not cxx.contains("clang-cl"):
             return sdk_fail(ctx, "refusing to package SDK not built with clang-cl; CMAKE_C_COMPILER=" ++ cc ++ " CMAKE_CXX_COMPILER=" ++ cxx)
-        let masm = sdk_cache_line(cache, "CMAKE_ASM_MASM_COMPILER:")
-        if not masm.contains("llvm-ml64"):
-            return sdk_fail(ctx, "refusing to package SDK not built with llvm-ml64; CMAKE_ASM_MASM_COMPILER=" ++ masm)
+        if platform == "windows-x86_64":
+            let masm = sdk_cache_line(cache, "CMAKE_ASM_MASM_COMPILER:")
+            if not masm.contains("llvm-ml64"):
+                return sdk_fail(ctx, "refusing to package SDK not built with llvm-ml64; CMAKE_ASM_MASM_COMPILER=" ++ masm)
         return 0
     if not cc.contains("clang") or cc.contains("/usr/bin/cc") or cc.contains("/usr/bin/gcc"):
         return sdk_fail(ctx, "refusing to package SDK not built with clang; CMAKE_C_COMPILER=" ++ cc)

--- a/rt/windows_aarch64.w
+++ b/rt/windows_aarch64.w
@@ -1,0 +1,1255 @@
+// rt/windows_aarch64.w -- Windows ARM64 runtime backend.
+//
+// Near-verbatim sibling of rt/windows_x86_64.w: the Win32 externs are
+// ABI-identical across x64 and arm64, and the SYSTEM_INFO /
+// MEMORYSTATUSEX field offsets used below are architecture-independent.
+// The only backend-specific value is rt_sysinfo_arch (aarch64).
+
+use std.builtins.c_void
+
+extern fn GetLastError() -> i32
+extern fn GetStdHandle(kind: i32) -> i64
+extern fn ReadFile(handle: i64, buf: *mut u8, len: u32, read_out: *mut u32, overlapped: *mut u8) -> i32
+extern fn WriteFile(handle: i64, buf: *const u8, len: u32, written_out: *mut u32, overlapped: *mut u8) -> i32
+extern fn CreateFileW(path: *const u16, access: u32, share: u32, security: *mut u8, creation: u32, flags: u32, template_file: i64) -> i64
+extern fn CloseHandle(handle: i64) -> i32
+extern fn SetFilePointerEx(handle: i64, distance: i64, new_pos: *mut i64, method: u32) -> i32
+extern fn GetCurrentDirectoryW(size: u32, buf: *mut u16) -> u32
+extern fn SetCurrentDirectoryW(path: *const u16) -> i32
+extern fn VirtualAlloc(addr: *mut u8, size: u64, alloc_type: u32, protect: u32) -> *mut u8
+extern fn VirtualFree(addr: *mut u8, size: u64, free_type: u32) -> i32
+extern fn ExitProcess(code: i32) -> Never
+extern fn QueryPerformanceCounter(value: *mut i64) -> i32
+extern fn QueryPerformanceFrequency(value: *mut i64) -> i32
+extern fn GetSystemTimeAsFileTime(filetime: *mut i64) -> Unit
+extern fn Sleep(ms: u32) -> Unit
+extern fn GetCurrentProcessId() -> i32
+extern fn OpenProcess(access: u32, inherit: i32, pid: i32) -> i64
+extern fn TerminateProcess(handle: i64, code: u32) -> i32
+extern fn CreateThread(attrs: *mut u8, stack_size: u64, start: *mut u8, arg: *mut u8, flags: u32, tid: *mut u32) -> i64
+extern fn WaitForSingleObject(handle: i64, ms: u32) -> u32
+extern fn GetExitCodeProcess(handle: i64, code: *mut u32) -> i32
+extern fn CreateProcessW(app: *const u16, cmd: *mut u16, proc_attrs: *mut u8, thread_attrs: *mut u8, inherit_handles: i32, flags: u32, env: *mut u8, cwd: *const u16, startup: *mut u8, proc_info: *mut u8) -> i32
+extern fn GetEnvironmentVariableW(name: *const u16, buf: *mut u16, size: u32) -> u32
+extern fn SetEnvironmentVariableW(name: *const u16, value: *const u16) -> i32
+extern fn GetFileAttributesW(path: *const u16) -> u32
+extern fn SetFileAttributesW(path: *const u16, attrs: u32) -> i32
+extern fn GetFileAttributesExW(path: *const u16, info_level: i32, out: *mut u8) -> i32
+extern fn CreateDirectoryW(path: *const u16, security: *mut u8) -> i32
+extern fn DeleteFileW(path: *const u16) -> i32
+extern fn RemoveDirectoryW(path: *const u16) -> i32
+extern fn MoveFileExW(old_path: *const u16, new_path: *const u16, flags: u32) -> i32
+extern fn FindFirstFileW(pattern: *const u16, data: *mut u8) -> i64
+extern fn FindNextFileW(handle: i64, data: *mut u8) -> i32
+extern fn FindClose(handle: i64) -> i32
+extern fn CreateSymbolicLinkW(link_path: *const u16, target: *const u16, flags: u32) -> i8
+extern fn GetSystemInfo(info: *mut u8) -> Unit
+extern fn GlobalMemoryStatusEx(info: *mut u8) -> i32
+extern fn GetComputerNameW(buf: *mut u16, size: *mut u32) -> i32
+extern fn SystemFunction036(buf: *mut u8, len: u32) -> i32
+extern fn VirtualProtect(addr: *mut u8, size: u64, new_protect: u32, old_protect: *mut u32) -> i32
+extern fn AddVectoredExceptionHandler(first: u32, handler: *mut u8) -> *mut u8
+extern fn GetCurrentThreadId() -> u32
+extern fn GetTempPathA(size: u32, buf: *mut u8) -> u32
+extern fn GetTempFileNameA(path: *const u8, prefix: *const u8, unique: u32, buf: *mut u8) -> u32
+extern fn GetFullPathNameA(path: *const u8, size: u32, buf: *mut u8, file_part: *mut *mut u8) -> u32
+extern fn with_str_from_cstr(s: *const u8) -> str
+extern fn with_alloc(size: i64) -> *mut u8
+extern fn with_free(ptr: *mut u8) -> Unit
+extern fn with_memcpy(dst: *mut u8, src: *const u8, len: i64) -> Unit
+
+let INVALID_HANDLE_VALUE: i64 = -1
+let STD_INPUT_HANDLE: i32 = -10
+let STD_OUTPUT_HANDLE: i32 = -11
+let STD_ERROR_HANDLE: i32 = -12
+let GENERIC_READ: u32 = 0x80000000 as u32
+let GENERIC_WRITE: u32 = 0x40000000 as u32
+let FILE_SHARE_ALL: u32 = 7 as u32
+let CREATE_ALWAYS: u32 = 2 as u32
+let OPEN_EXISTING: u32 = 3 as u32
+let OPEN_ALWAYS: u32 = 4 as u32
+let FILE_ATTRIBUTE_READONLY: u32 = 1 as u32
+let FILE_ATTRIBUTE_DIRECTORY: u32 = 16 as u32
+let FILE_ATTRIBUTE_NORMAL: u32 = 128 as u32
+let FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x02000000 as u32
+let MEM_COMMIT_RESERVE: u32 = 0x3000 as u32
+let MEM_RELEASE: u32 = 0x8000 as u32
+let PAGE_READWRITE: u32 = 4 as u32
+let PAGE_GUARD: u32 = 0x100 as u32
+let WAIT_OBJECT_0: u32 = 0 as u32
+let WAIT_TIMEOUT: u32 = 258 as u32
+let INFINITE: u32 = 0xffffffff as u32
+let PROCESS_TERMINATE: u32 = 1 as u32
+let PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000 as u32
+let SYNCHRONIZE: u32 = 0x00100000 as u32
+let MOVEFILE_REPLACE_EXISTING: u32 = 1 as u32
+let CAPTURE_TIMEOUT_RC: i32 = 124
+
+type RtStatBuf:
+    size: i64
+    is_dir: i32
+    is_file: i32
+    modified_ns: i64
+
+type RtSysInfo:
+    cpu_cores: i32
+    memory_total: i64
+    page_size: i64
+
+var rt_argc: i32 = 0
+var rt_argv_raw: i64 = 0
+var rt_handles: [256]i64 = [0 as i64; 256]
+var qpc_freq: i64 = 0
+var process_handles: [256]i64 = [0 as i64; 256]
+var process_ids: [256]i32 = [0 as i32; 256]
+var process_next_slot: i32 = 1
+
+fn win_error() -> i32:
+    let err = GetLastError()
+    if err == 0: 1 else: err
+
+fn win_neg_error() -> i32:
+    -win_error()
+
+fn win_strlen16(s: *const u16) -> i64:
+    var len: i64 = 0
+    while unsafe *((s as i64 + len * 2) as *const u16) != 0:
+        len = len + 1
+    len
+
+fn win_cstr_len(s: *const u8) -> i64:
+    if s as i64 == 0:
+        return 0
+    var len: i64 = 0
+    while unsafe *((s as i64 + len) as *const u8) != 0:
+        len = len + 1
+    len
+
+fn win_utf8_to_utf16_buf(src: *const u8, dst: *mut u16, cap: i64) -> i32:
+    if src as i64 == 0 or cap <= 0:
+        return -1
+    var i: i64 = 0
+    while i < cap - 1:
+        let ch = unsafe *((src as i64 + i) as *const u8)
+        if ch == 0:
+            break
+        unsafe *((dst as i64 + i * 2) as *mut u16) = ch as u16
+        i = i + 1
+    unsafe *((dst as i64 + i * 2) as *mut u16) = 0 as u16
+    0
+
+fn win_str_data(s: &str) -> *const u8:
+    unsafe **(&s as *const *const *const u8)
+
+fn win_str_to_utf16_buf(src: &str, dst: *mut u16, cap: i64) -> i32:
+    if cap <= 0:
+        return -1
+    let data = win_str_data(src)
+    var i: i64 = 0
+    while i < src.len() and i < cap - 1:
+        unsafe *((dst as i64 + i * 2) as *mut u16) = (unsafe *((data as i64 + i) as *const u8)) as u16
+        i = i + 1
+    unsafe *((dst as i64 + i * 2) as *mut u16) = 0 as u16
+    0
+
+fn win_utf16_to_utf8_buf(src: *const u16, dst: *mut u8, cap: i64) -> i32:
+    var i: i64 = 0
+    while i < cap - 1:
+        let ch = unsafe *((src as i64 + i * 2) as *const u16)
+        if ch == 0:
+            break
+        unsafe *((dst as i64 + i) as *mut u8) = if ch < 128: ch as u8 else: 63 as u8
+        i = i + 1
+    unsafe *((dst as i64 + i) as *mut u8) = 0
+    i as i32
+
+fn win_handle_for_fd(fd: i32) -> i64:
+    if fd == 0:
+        return GetStdHandle(STD_INPUT_HANDLE)
+    if fd == 1:
+        return GetStdHandle(STD_OUTPUT_HANDLE)
+    if fd == 2:
+        return GetStdHandle(STD_ERROR_HANDLE)
+    if fd < 0 or fd >= 256:
+        return 0
+    rt_handles[fd]
+
+fn win_alloc_fd(handle: i64) -> i32:
+    if handle == 0 or handle == INVALID_HANDLE_VALUE:
+        return win_neg_error()
+    for i in 3..256:
+        if rt_handles[i] == 0:
+            rt_handles[i] = handle
+            return i
+    let _ = CloseHandle(handle)
+    -24
+
+pub fn rt_store_args(argc_val: i32, argv_val: *const *const u8) -> Unit:
+    rt_argc = argc_val
+    rt_argv_raw = argv_val as i64
+
+pub fn rt_args() -> (*const *const u8, i32):
+    (rt_argv_raw as *const *const u8, rt_argc)
+
+pub fn rt_write(fd: i32, buf: *const u8, len: i64) -> i64:
+    let handle = win_handle_for_fd(fd)
+    if handle == 0 or handle == INVALID_HANDLE_VALUE:
+        return -6
+    var written: u32 = 0 as u32
+    if WriteFile(handle, buf, len as u32, &raw mut written, 0 as *mut u8) == 0:
+        return -(win_error() as i64)
+    written as i64
+
+pub fn rt_read(fd: i32, buf: *mut u8, len: i64) -> i64:
+    let handle = win_handle_for_fd(fd)
+    if handle == 0 or handle == INVALID_HANDLE_VALUE:
+        return -6
+    var got: u32 = 0 as u32
+    if ReadFile(handle, buf, len as u32, &raw mut got, 0 as *mut u8) == 0:
+        return -(win_error() as i64)
+    got as i64
+
+pub fn rt_open(path: *const u8, flags: i32, mode: i32) -> i32:
+    let _ = mode
+    var wpath: [4096]u16 = [0 as u16; 4096]
+    if win_utf8_to_utf16_buf(path, &raw mut wpath as *mut [4096]u16 as *mut u16, 4096) != 0:
+        return -1
+    let access = if (flags & 3) == 0: GENERIC_READ else if (flags & 3) == 1: GENERIC_WRITE else: GENERIC_READ | GENERIC_WRITE
+    let creation = if (flags & 0x200) != 0:
+        if (flags & 0x400) != 0: CREATE_ALWAYS else: OPEN_ALWAYS
+    else:
+        OPEN_EXISTING
+    let h = CreateFileW(&wpath as *const [4096]u16 as *const u16, access, FILE_SHARE_ALL, 0 as *mut u8, creation, FILE_ATTRIBUTE_NORMAL, 0)
+    win_alloc_fd(h)
+
+pub fn rt_close(fd: i32) -> i32:
+    if fd >= 0 and fd <= 2:
+        return 0
+    if fd < 0 or fd >= 256:
+        return -6
+    let h = rt_handles[fd]
+    rt_handles[fd] = 0
+    if h == 0:
+        return -6
+    if CloseHandle(h) == 0:
+        return win_neg_error()
+    0
+
+pub fn rt_seek(fd: i32, offset: i64, whence: i32) -> i64:
+    let h = win_handle_for_fd(fd)
+    if h == 0 or h == INVALID_HANDLE_VALUE:
+        return -6
+    var pos: i64 = 0
+    if SetFilePointerEx(h, offset, &raw mut pos, whence as u32) == 0:
+        return -(win_error() as i64)
+    pos
+
+fn win_filetime_to_ns(low: u32, high: u32) -> i64:
+    let ticks = ((high as u64) << 32) | low as u64
+    let unix_100ns = ticks - 116444736000000000 as u64
+    (unix_100ns * 100) as i64
+
+pub fn rt_stat(path: *const u8, out_raw: *mut u8) -> i32:
+    let out = out_raw as *mut RtStatBuf
+    var wpath: [4096]u16 = [0 as u16; 4096]
+    if win_utf8_to_utf16_buf(path, &raw mut wpath as *mut [4096]u16 as *mut u16, 4096) != 0:
+        return -1
+    var info: [64]u8 = [0 as u8; 64]
+    if GetFileAttributesExW(&wpath as *const [4096]u16 as *const u16, 0, &raw mut info as *mut [64]u8 as *mut u8) == 0:
+        return win_neg_error()
+    let base = &info as i64
+    let attrs = unsafe *(base as *const u32)
+    let write_low = unsafe *((base + 20) as *const u32)
+    let write_high = unsafe *((base + 24) as *const u32)
+    let size_high = unsafe *((base + 28) as *const u32)
+    let size_low = unsafe *((base + 32) as *const u32)
+    (unsafe *out).size = (((size_high as u64) << 32) | size_low as u64) as i64
+    (unsafe *out).is_dir = if (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0: 1 else: 0
+    (unsafe *out).is_file = if (attrs & FILE_ATTRIBUTE_DIRECTORY) == 0: 1 else: 0
+    (unsafe *out).modified_ns = win_filetime_to_ns(write_low, write_high)
+    0
+
+pub fn rt_file_mode(path: *const u8) -> i32:
+    var wpath: [4096]u16 = [0 as u16; 4096]
+    if win_utf8_to_utf16_buf(path, &raw mut wpath as *mut [4096]u16 as *mut u16, 4096) != 0:
+        return -1
+    let attrs = GetFileAttributesW(&wpath as *const [4096]u16 as *const u16)
+    if attrs == 0xffffffff as u32:
+        return win_neg_error()
+    if (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0:
+        return 0o040755
+    0o100644
+
+pub fn rt_chmod(path: *const u8, mode: i32) -> i32:
+    var wpath: [4096]u16 = [0 as u16; 4096]
+    if win_utf8_to_utf16_buf(path, &raw mut wpath as *mut [4096]u16 as *mut u16, 4096) != 0:
+        return -1
+    var attrs = GetFileAttributesW(&wpath as *const [4096]u16 as *const u16)
+    if attrs == 0xffffffff as u32:
+        return win_neg_error()
+    if (mode & 0o200) != 0:
+        attrs = attrs & ~FILE_ATTRIBUTE_READONLY
+    else:
+        attrs = attrs | FILE_ATTRIBUTE_READONLY
+    if SetFileAttributesW(&wpath as *const [4096]u16 as *const u16, attrs) == 0:
+        return win_neg_error()
+    0
+
+pub fn rt_getcwd(buf: *mut u8, size: i64) -> i32:
+    var wbuf: [4096]u16 = [0 as u16; 4096]
+    let n = GetCurrentDirectoryW(4096 as u32, &raw mut wbuf as *mut [4096]u16 as *mut u16)
+    if n == 0:
+        return win_neg_error()
+    let _ = win_utf16_to_utf8_buf(&wbuf as *const [4096]u16 as *const u16, buf, size)
+    0
+
+pub fn rt_mmap(size: i64) -> *mut u8:
+    VirtualAlloc(0 as *mut u8, size as u64, MEM_COMMIT_RESERVE, PAGE_READWRITE)
+
+pub fn rt_munmap(ptr: *mut u8, size: i64) -> Unit:
+    let _ = size
+    let _free = VirtualFree(ptr, 0, MEM_RELEASE)
+
+pub fn rt_exit(code: i32) -> Never:
+    ExitProcess(code)
+
+pub fn rt_clock_ns() -> i64:
+    if qpc_freq == 0:
+        let _ = QueryPerformanceFrequency(&raw mut qpc_freq)
+    var now: i64 = 0
+    let _ = QueryPerformanceCounter(&raw mut now)
+    if qpc_freq <= 0:
+        return 0
+    let seconds = now / qpc_freq
+    let remainder = now % qpc_freq
+    seconds * 1000000000 + (remainder * 1000000000) / qpc_freq
+
+pub fn rt_wall_clock_sec() -> i64:
+    // FILETIME: 100ns intervals since 1601-01-01; rebase to the Unix epoch.
+    var ft: i64 = 0
+    GetSystemTimeAsFileTime(&raw mut ft)
+    (ft - 116444736000000000) / 10000000
+
+pub fn rt_nanosleep(ns: i64) -> i32:
+    let ms = if ns <= 0: 0 else: ((ns + 999999) / 1000000) as u32
+    Sleep(ms)
+    0
+
+pub fn rt_getpid() -> i32:
+    GetCurrentProcessId()
+
+pub fn rt_kill(pid: i32, sig: i32) -> i32:
+    let access = SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE
+    let h = OpenProcess(access, 0, pid)
+    if h == 0:
+        return win_neg_error()
+    if sig != 0:
+        let _ = TerminateProcess(h, (128 + sig) as u32)
+    let _close = CloseHandle(h)
+    0
+
+pub fn rt_raise(sig: i32) -> i32:
+    ExitProcess(128 + sig)
+
+pub fn rt_thread_spawn(start_routine: *mut u8, arg: *mut u8) -> i64:
+    var tid: u32 = 0 as u32
+    let h = CreateThread(0 as *mut u8, 0, start_routine, arg, 0, &raw mut tid)
+    if h == 0:
+        return -(win_error() as i64)
+    h
+
+pub fn rt_thread_join(handle: i64) -> i32:
+    let r = WaitForSingleObject(handle, INFINITE)
+    let _ = CloseHandle(handle)
+    if r != WAIT_OBJECT_0:
+        return win_neg_error()
+    0
+
+pub fn rt_fill_random(buf: *mut u8, len: u64) -> Unit:
+    if SystemFunction036(buf, len as u32) == 0:
+        ExitProcess(1)
+
+pub fn rt_libc_stdin() -> *mut c_void:
+    0 as *mut c_void
+
+pub fn rt_libc_stdout() -> *mut c_void:
+    0 as *mut c_void
+
+pub fn rt_libc_stderr() -> *mut c_void:
+    0 as *mut c_void
+
+pub fn rt_fiber_page_size() -> i64:
+    4096
+
+pub fn rt_fiber_mmap_flags() -> i32:
+    0
+
+pub fn rt_fiber_fault_addr(info: *const u8) -> i64:
+    let _ = info
+    0
+
+pub fn rt_fiber_reset_signal_handler(sig: i32) -> Unit:
+    let _ = sig
+
+// Arm the fiber stack's guard page. PAGE_GUARD raises STATUS_GUARD_PAGE_VIOLATION
+// on first touch AND auto-commits the page, so the vectored handler has real stack
+// to run its diagnostic on — the Windows analogue of POSIX sigaltstack.
+pub fn rt_fiber_protect_guard(region: *mut u8, len: i64) -> Unit:
+    var old: u32 = 0
+    let _ = VirtualProtect(region, len as u64, PAGE_READWRITE | PAGE_GUARD, &raw mut old)
+
+pub fn rt_fiber_install_signal_handlers(alt_stack: *mut u8, alt_stack_size: i64, handler: i64) -> Unit:
+    let _ = alt_stack
+    let _ = alt_stack_size
+    let _ = AddVectoredExceptionHandler(1 as u32, handler as *mut u8)
+
+fn win_path_join(parent: *const u8, name: *const u8, out: *mut u8, cap: i64) -> i32:
+    let parent_len = win_cstr_len(parent)
+    let name_len = win_cstr_len(name)
+    var need_slash = true
+    if parent_len > 0:
+        let last = unsafe *((parent as i64 + parent_len - 1) as *const u8)
+        if last == 47 or last == 92:
+            need_slash = false
+    let slash_len: i64 = if need_slash: 1 else: 0
+    if parent_len + slash_len + name_len + 1 > cap:
+        return -36
+    var i: i64 = 0
+    while i < parent_len:
+        unsafe *((out as i64 + i) as *mut u8) = unsafe *((parent as i64 + i) as *const u8)
+        i = i + 1
+    if need_slash:
+        unsafe *((out as i64 + i) as *mut u8) = 47
+        i = i + 1
+    var j: i64 = 0
+    while j < name_len:
+        unsafe *((out as i64 + i + j) as *mut u8) = unsafe *((name as i64 + j) as *const u8)
+        j = j + 1
+    unsafe *((out as i64 + i + j) as *mut u8) = 0
+    0
+
+fn win_is_dot_or_dotdot(name: *const u8) -> bool:
+    let first = unsafe *((name as i64) as *const u8)
+    if first != 46:
+        return false
+    let second = unsafe *((name as i64 + 1) as *const u8)
+    if second == 0:
+        return true
+    if second != 46:
+        return false
+    (unsafe *((name as i64 + 2) as *const u8)) == 0
+
+fn win_find_name(data: *mut u8, out: *mut u8, cap: i64) -> i32:
+    let name_w = (data as i64 + 44) as *const u16
+    win_utf16_to_utf8_buf(name_w, out, cap)
+
+fn win_is_dir(path: *const u8) -> bool:
+    var wpath: [4096]u16 = [0 as u16; 4096]
+    if win_utf8_to_utf16_buf(path, &raw mut wpath as *mut [4096]u16 as *mut u16, 4096) != 0:
+        return false
+    let attrs = GetFileAttributesW(&wpath as *const [4096]u16 as *const u16)
+    attrs != 0xffffffff as u32 and (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0
+
+pub fn rt_mkdir(path: *const u8, mode: i32) -> i32:
+    let _ = mode
+    var wpath: [4096]u16 = [0 as u16; 4096]
+    if win_utf8_to_utf16_buf(path, &raw mut wpath as *mut [4096]u16 as *mut u16, 4096) != 0:
+        return -1
+    if CreateDirectoryW(&wpath as *const [4096]u16 as *const u16, 0 as *mut u8) == 0:
+        return win_neg_error()
+    0
+
+pub fn rt_unlink(path: *const u8) -> i32:
+    var wpath: [4096]u16 = [0 as u16; 4096]
+    if win_utf8_to_utf16_buf(path, &raw mut wpath as *mut [4096]u16 as *mut u16, 4096) != 0:
+        return -1
+    if DeleteFileW(&wpath as *const [4096]u16 as *const u16) == 0:
+        return win_neg_error()
+    0
+
+pub fn rt_rmdir(path: *const u8) -> i32:
+    var wpath: [4096]u16 = [0 as u16; 4096]
+    if win_utf8_to_utf16_buf(path, &raw mut wpath as *mut [4096]u16 as *mut u16, 4096) != 0:
+        return -1
+    if RemoveDirectoryW(&wpath as *const [4096]u16 as *const u16) == 0:
+        return win_neg_error()
+    0
+
+pub fn rt_rename(old_path: *const u8, new_path: *const u8) -> i32:
+    var oldw: [4096]u16 = [0 as u16; 4096]
+    var neww: [4096]u16 = [0 as u16; 4096]
+    if win_utf8_to_utf16_buf(old_path, &raw mut oldw as *mut [4096]u16 as *mut u16, 4096) != 0:
+        return -1
+    if win_utf8_to_utf16_buf(new_path, &raw mut neww as *mut [4096]u16 as *mut u16, 4096) != 0:
+        return -1
+    if MoveFileExW(&oldw as *const [4096]u16 as *const u16, &neww as *const [4096]u16 as *const u16, MOVEFILE_REPLACE_EXISTING) == 0:
+        return win_neg_error()
+    0
+
+fn win_remove_tree_impl(path: *const u8) -> i32:
+    if not win_is_dir(path):
+        return rt_unlink(path)
+    var pattern8: [4096]u8 = [0 as u8; 4096]
+    let join_rc = win_path_join(path, "*" as *const u8, &raw mut pattern8 as *mut [4096]u8 as *mut u8, 4096)
+    if join_rc != 0:
+        return join_rc
+    var pattern: [4096]u16 = [0 as u16; 4096]
+    let _ = win_utf8_to_utf16_buf(&pattern8 as *const [4096]u8 as *const u8, &raw mut pattern as *mut [4096]u16 as *mut u16, 4096)
+    var data: [600]u8 = [0 as u8; 600]
+    let h = FindFirstFileW(&pattern as *const [4096]u16 as *const u16, &raw mut data as *mut [600]u8 as *mut u8)
+    if h != INVALID_HANDLE_VALUE:
+        while true:
+            var name: [512]u8 = [0 as u8; 512]
+            let _name_len = win_find_name(&raw mut data as *mut [600]u8 as *mut u8, &raw mut name as *mut [512]u8 as *mut u8, 512)
+            if not win_is_dot_or_dotdot(&name as *const [512]u8 as *const u8):
+                var child: [4096]u8 = [0 as u8; 4096]
+                let child_join = win_path_join(path, &name as *const [512]u8 as *const u8, &raw mut child as *mut [4096]u8 as *mut u8, 4096)
+                if child_join == 0:
+                    let rc = win_remove_tree_impl(&child as *const [4096]u8 as *const u8)
+                    if rc != 0:
+                        let _close = FindClose(h)
+                        return rc
+            if FindNextFileW(h, &raw mut data as *mut [600]u8 as *mut u8) == 0:
+                break
+        let _close = FindClose(h)
+    rt_rmdir(path)
+
+pub fn rt_remove_tree(path: *const u8) -> i32:
+    win_remove_tree_impl(path)
+
+fn win_copy_file(src: *const u8, dst: *const u8) -> i32:
+    let in_fd = rt_open(src, 0, 0)
+    if in_fd < 0:
+        return in_fd
+    let out_fd = rt_open(dst, 1 | 0x200 | 0x400, 0o644)
+    if out_fd < 0:
+        let _ = rt_close(in_fd)
+        return out_fd
+    let buf = with_alloc(65536)
+    if buf as i64 == 0:
+        let _ = rt_close(in_fd)
+        let _ = rt_close(out_fd)
+        return -12
+    while true:
+        let n = rt_read(in_fd, buf, 65536)
+        if n < 0:
+            with_free(buf)
+            let _ = rt_close(in_fd)
+            let _ = rt_close(out_fd)
+            return n as i32
+        if n == 0:
+            break
+        var off: i64 = 0
+        while off < n:
+            let w = rt_write(out_fd, (buf as i64 + off) as *const u8, n - off)
+            if w <= 0:
+                with_free(buf)
+                let _ = rt_close(in_fd)
+                let _ = rt_close(out_fd)
+                return if w < 0: w as i32 else: -5
+            off = off + w
+    with_free(buf)
+    let cin = rt_close(in_fd)
+    let cout = rt_close(out_fd)
+    if cin != 0: cin else: cout
+
+pub fn rt_copy_tree(src: *const u8, dst: *const u8) -> i32:
+    if not win_is_dir(src):
+        return win_copy_file(src, dst)
+    let mkdir_rc = rt_mkdir(dst, 0o755)
+    if mkdir_rc != 0 and not win_is_dir(dst):
+        return mkdir_rc
+    var pattern8: [4096]u8 = [0 as u8; 4096]
+    if win_path_join(src, "*" as *const u8, &raw mut pattern8 as *mut [4096]u8 as *mut u8, 4096) != 0:
+        return -36
+    var pattern: [4096]u16 = [0 as u16; 4096]
+    let _ = win_utf8_to_utf16_buf(&pattern8 as *const [4096]u8 as *const u8, &raw mut pattern as *mut [4096]u16 as *mut u16, 4096)
+    var data: [600]u8 = [0 as u8; 600]
+    let h = FindFirstFileW(&pattern as *const [4096]u16 as *const u16, &raw mut data as *mut [600]u8 as *mut u8)
+    if h == INVALID_HANDLE_VALUE:
+        return 0
+    while true:
+        var name: [512]u8 = [0 as u8; 512]
+        let _name_len = win_find_name(&raw mut data as *mut [600]u8 as *mut u8, &raw mut name as *mut [512]u8 as *mut u8, 512)
+        if not win_is_dot_or_dotdot(&name as *const [512]u8 as *const u8):
+            var child_src: [4096]u8 = [0 as u8; 4096]
+            var child_dst: [4096]u8 = [0 as u8; 4096]
+            let sj = win_path_join(src, &name as *const [512]u8 as *const u8, &raw mut child_src as *mut [4096]u8 as *mut u8, 4096)
+            let dj = win_path_join(dst, &name as *const [512]u8 as *const u8, &raw mut child_dst as *mut [4096]u8 as *mut u8, 4096)
+            if sj == 0 and dj == 0:
+                let rc = rt_copy_tree(&child_src as *const [4096]u8 as *const u8, &child_dst as *const [4096]u8 as *const u8)
+                if rc != 0:
+                    let _close = FindClose(h)
+                    return rc
+        if FindNextFileW(h, &raw mut data as *mut [600]u8 as *mut u8) == 0:
+            break
+    let _close2 = FindClose(h)
+    0
+
+pub fn rt_symlink(target: *const u8, link_path: *const u8) -> i32:
+    var targetw: [4096]u16 = [0 as u16; 4096]
+    var linkw: [4096]u16 = [0 as u16; 4096]
+    let _ = win_utf8_to_utf16_buf(target, &raw mut targetw as *mut [4096]u16 as *mut u16, 4096)
+    let _ = win_utf8_to_utf16_buf(link_path, &raw mut linkw as *mut [4096]u16 as *mut u16, 4096)
+    let flags = if win_is_dir(target): 1 as u32 else: 0 as u32
+    if CreateSymbolicLinkW(&linkw as *const [4096]u16 as *const u16, &targetw as *const [4096]u16 as *const u16, flags | (2 as u32)) == 0:
+        return win_neg_error()
+    0
+
+pub fn rt_readlink(path: *const u8) -> str:
+    let _ = path
+    win_empty_str()
+
+fn win_empty_str() -> str:
+    with_str_from_cstr(c"".ptr)
+
+fn win_list_append(out: str, path: *const u8) -> str:
+    let path_text = with_str_from_cstr(path)
+    out ++ path_text ++ "\n"
+
+fn win_list_files_walk(path: *const u8, out: str) -> str:
+    if not win_is_dir(path):
+        return win_list_append(out, path)
+    var result = out
+    var pattern8: [4096]u8 = [0 as u8; 4096]
+    if win_path_join(path, "*" as *const u8, &raw mut pattern8 as *mut [4096]u8 as *mut u8, 4096) != 0:
+        return result
+    var pattern: [4096]u16 = [0 as u16; 4096]
+    let _ = win_utf8_to_utf16_buf(&pattern8 as *const [4096]u8 as *const u8, &raw mut pattern as *mut [4096]u16 as *mut u16, 4096)
+    var data: [600]u8 = [0 as u8; 600]
+    let h = FindFirstFileW(&pattern as *const [4096]u16 as *const u16, &raw mut data as *mut [600]u8 as *mut u8)
+    if h == INVALID_HANDLE_VALUE:
+        return result
+    while true:
+        var name: [512]u8 = [0 as u8; 512]
+        let _name_len = win_find_name(&raw mut data as *mut [600]u8 as *mut u8, &raw mut name as *mut [512]u8 as *mut u8, 512)
+        if not win_is_dot_or_dotdot(&name as *const [512]u8 as *const u8):
+            var child: [4096]u8 = [0 as u8; 4096]
+            if win_path_join(path, &name as *const [512]u8 as *const u8, &raw mut child as *mut [4096]u8 as *mut u8, 4096) == 0:
+                result = win_list_files_walk(&child as *const [4096]u8 as *const u8, result)
+        if FindNextFileW(h, &raw mut data as *mut [600]u8 as *mut u8) == 0:
+            break
+    let _close = FindClose(h)
+    result
+
+pub fn rt_list_files(path: *const u8) -> str:
+    win_list_files_walk(path, win_empty_str())
+
+pub fn rt_access(path: *const u8, mode: i32) -> i32:
+    let _ = mode
+    var wpath: [4096]u16 = [0 as u16; 4096]
+    if win_utf8_to_utf16_buf(path, &raw mut wpath as *mut [4096]u16 as *mut u16, 4096) != 0:
+        return -1
+    let attrs = GetFileAttributesW(&wpath as *const [4096]u16 as *const u16)
+    if attrs == 0xffffffff as u32:
+        return win_neg_error()
+    0
+
+pub fn rt_sysinfo(out_raw: *mut u8) -> i32:
+    let out = out_raw as *mut RtSysInfo
+    var info: [64]u8 = [0 as u8; 64]
+    GetSystemInfo(&raw mut info as *mut [64]u8 as *mut u8)
+    // SYSTEM_INFO (x64): dwPageSize @4, dwNumberOfProcessors @32.
+    // (@8 is lpMinimumApplicationAddress, @36 is the obsolete dwProcessorType
+    // which reads ~8664 on x64 — reading it as the core count oversubscribed
+    // the build worker pool 16-wide on small runners.)
+    let page_size = unsafe *((&info as i64 + 4) as *const u32)
+    let processors = unsafe *((&info as i64 + 32) as *const u32)
+    var mem: [64]u8 = [0 as u8; 64]
+    unsafe *((&raw mut mem) as *mut [64]u8 as *mut u32) = 64 as u32
+    var total: i64 = 0
+    if GlobalMemoryStatusEx(&raw mut mem as *mut [64]u8 as *mut u8) != 0:
+        total = unsafe *((&mem as i64 + 8) as *const u64) as i64
+    (unsafe *out).cpu_cores = if processors > 0: processors as i32 else: 1
+    (unsafe *out).page_size = if page_size > 0: page_size as i64 else: 4096
+    (unsafe *out).memory_total = total
+    0
+
+pub fn rt_sysinfo_os() -> str:
+    with_str_from_cstr(c"Windows".ptr)
+
+pub fn rt_sysinfo_arch() -> str:
+    with_str_from_cstr(c"aarch64".ptr)
+
+pub fn rt_getenv(name: *const u8) -> *const u8:
+    var wname: [1024]u16 = [0 as u16; 1024]
+    var wvalue: [16384]u16 = [0 as u16; 16384]
+    if win_utf8_to_utf16_buf(name, &raw mut wname as *mut [1024]u16 as *mut u16, 1024) != 0:
+        return 0 as *const u8
+    let n = GetEnvironmentVariableW(&wname as *const [1024]u16 as *const u16, &raw mut wvalue as *mut [16384]u16 as *mut u16, 16384 as u32)
+    if n == 0:
+        return 0 as *const u8
+    // Each returned value gets its own allocation so retained `env()`/
+    // `with_getenv_str` results never alias. Linux/darwin satisfy this for
+    // free because libc `getenv` hands out stable per-variable `environ`
+    // pointers; Windows `GetEnvironmentVariableW` copies into a caller buffer,
+    // so a single shared static buffer would make every retained result alias
+    // the last read. The converter writes one byte per UTF-16 code unit, so the
+    // returned unit count `n` is the exact UTF-8 length; the buffer covers
+    // value + NUL (rt_mmap pages are zero-filled, so byte `n` is already NUL).
+    //
+    // The buffer MUST come from rt_mmap, not with_alloc: rt_getenv is called
+    // from inside the allocator lock. The allocator's own config checks
+    // (dbg_on/alloc_system_on/rt_alloc_effective_limit_unlocked reading
+    // WITH_MEMORY_LIMIT_BYTES) run in rt_alloc_unlocked while rt_alloc_lock_word
+    // is held; a with_alloc here would re-enter rt_allocator_lock() on the same
+    // thread and deadlock on the non-recursive spinlock. Linux/darwin never hit
+    // this because their rt_getenv returns environ pointers and allocates
+    // nothing. rt_mmap (VirtualAlloc) is thread-safe and takes no allocator
+    // lock, mirroring dbg_ledger_init's raw-page pattern. This is an owned,
+    // non-aliasing, process-lifetime region — the same lifetime model as
+    // `environ` — so "non-allocating rt_getenv" (rt_core.w) holds on Windows too.
+    let buf = rt_mmap(n as i64 + 1)
+    if buf as i64 == 0:
+        return 0 as *const u8
+    let _ = win_utf16_to_utf8_buf(&wvalue as *const [16384]u16 as *const u16, buf, n as i64 + 1)
+    buf as *const u8
+
+pub fn gethostname(name: *mut u8, len: u64) -> i32:
+    var wname: [256]u16 = [0 as u16; 256]
+    var n: u32 = 256 as u32
+    if GetComputerNameW(&raw mut wname as *mut [256]u16 as *mut u16, &raw mut n) == 0:
+        return -1
+    let _ = win_utf16_to_utf8_buf(&wname as *const [256]u16 as *const u16, name, len as i64)
+    0
+
+pub fn pthread_self() -> i64:
+    GetCurrentThreadId() as i64
+
+pub fn mkstemp(template_path: *mut u8) -> i32:
+    if template_path as i64 == 0:
+        return -1
+    var dir: [1024]u8 = [0 as u8; 1024]
+    var name: [1024]u8 = [0 as u8; 1024]
+    let prefix: [5]u8 = [119 as u8, 105 as u8, 116 as u8, 104 as u8, 0 as u8]
+    let n = GetTempPathA(1024 as u32, &raw mut dir as *mut [1024]u8 as *mut u8)
+    if n == 0 or n >= 1024:
+        return -1
+    if GetTempFileNameA(&dir as *const [1024]u8 as *const u8, &prefix as *const [5]u8 as *const u8, 0 as u32, &raw mut name as *mut [1024]u8 as *mut u8) == 0:
+        return -1
+    var i: i64 = 0
+    while i < 1023:
+        let ch = name[i]
+        unsafe *((template_path as i64 + i) as *mut u8) = ch
+        if ch == 0:
+            break
+        i = i + 1
+    unsafe *((template_path as i64 + i) as *mut u8) = 0
+    rt_open(&name as *const [1024]u8 as *const u8, 2, 384)
+
+pub fn realpath(path: *const u8, resolved_path: *mut u8) -> *mut u8:
+    if path as i64 == 0 or resolved_path as i64 == 0:
+        return 0 as *mut u8
+    let n = GetFullPathNameA(path, 4096 as u32, resolved_path, 0 as *mut *mut u8)
+    if n == 0 or n >= 4096:
+        return 0 as *mut u8
+    resolved_path
+
+fn win_setenv(name: &str, value: &str) -> i32:
+    var wname: [1024]u16 = [0 as u16; 1024]
+    var wvalue: [8192]u16 = [0 as u16; 8192]
+    let value_len = value.len()
+    if win_str_to_utf16_buf(name, &raw mut wname as *mut [1024]u16 as *mut u16, 1024) != 0:
+        return -1
+    if win_str_to_utf16_buf(value, &raw mut wvalue as *mut [8192]u16 as *mut u16, 8192) != 0:
+        return -1
+    let value_ptr = if value_len == 0: 0 as *const u16 else: &wvalue as *const [8192]u16 as *const u16
+    if SetEnvironmentVariableW(&wname as *const [1024]u16 as *const u16, value_ptr) == 0:
+        return win_neg_error()
+    0
+
+fn win_process_alloc(handle: i64, pid: i32) -> i32:
+    for tries in 0..255:
+        let slot = process_next_slot
+        process_next_slot = process_next_slot + 1
+        if process_next_slot >= 256:
+            process_next_slot = 1
+        if process_handles[slot] == 0:
+            process_handles[slot] = handle
+            process_ids[slot] = pid
+            return slot
+    -1
+
+fn win_wait_process_slot(slot: i32, timeout_ms: i32, consume: bool) -> i32:
+    if slot <= 0 or slot >= 256:
+        return -1
+    let h = process_handles[slot]
+    if h == 0:
+        return -1
+    let wait_ms = if timeout_ms > 0: timeout_ms as u32 else: INFINITE
+    let wr = WaitForSingleObject(h, wait_ms)
+    if wr == WAIT_TIMEOUT:
+        let _term = TerminateProcess(h, CAPTURE_TIMEOUT_RC as u32)
+        let _wait = WaitForSingleObject(h, INFINITE)
+        if consume:
+            let _close = CloseHandle(h)
+            process_handles[slot] = 0
+            process_ids[slot] = 0
+        return CAPTURE_TIMEOUT_RC
+    if wr != WAIT_OBJECT_0:
+        return win_neg_error()
+    var code: u32 = 1 as u32
+    let _ = GetExitCodeProcess(h, &raw mut code)
+    if consume:
+        let _close = CloseHandle(h)
+        process_handles[slot] = 0
+        process_ids[slot] = 0
+    code as i32
+
+fn win_append_utf16(dst: *mut u16, pos: i64, cap: i64, src: *const u16) -> i64:
+    var out_pos = pos
+    var i: i64 = 0
+    while out_pos < cap - 1:
+        let ch = unsafe *((src as i64 + i * 2) as *const u16)
+        if ch == 0:
+            break
+        unsafe *((dst as i64 + out_pos * 2) as *mut u16) = ch
+        out_pos = out_pos + 1
+        i = i + 1
+    out_pos
+
+fn win_build_command_line(blob: *const u8, len: i64, out: *mut u16, cap: i64) -> i32:
+    var pos: i64 = 0
+    var offset: i64 = 0
+    while offset < len and pos < cap - 4:
+        if pos > 0:
+            unsafe *((out as i64 + pos * 2) as *mut u16) = 32 as u16
+            pos = pos + 1
+        unsafe *((out as i64 + pos * 2) as *mut u16) = 34 as u16
+        pos = pos + 1
+        var slash_count: i64 = 0
+        while offset < len:
+            let ch = unsafe *((blob as i64 + offset) as *const u8)
+            if ch == 0:
+                break
+            if ch == 92:
+                slash_count = slash_count + 1
+                offset = offset + 1
+                continue
+            if ch == 34:
+                while slash_count > 0:
+                    if pos >= cap - 5:
+                        return -1
+                    unsafe *((out as i64 + pos * 2) as *mut u16) = 92 as u16
+                    pos = pos + 1
+                    unsafe *((out as i64 + pos * 2) as *mut u16) = 92 as u16
+                    pos = pos + 1
+                    slash_count = slash_count - 1
+                if pos >= cap - 5:
+                    return -1
+                unsafe *((out as i64 + pos * 2) as *mut u16) = 92 as u16
+                pos = pos + 1
+                unsafe *((out as i64 + pos * 2) as *mut u16) = 34 as u16
+                pos = pos + 1
+                offset = offset + 1
+                continue
+            while slash_count > 0:
+                if pos >= cap - 4:
+                    return -1
+                unsafe *((out as i64 + pos * 2) as *mut u16) = 92 as u16
+                pos = pos + 1
+                slash_count = slash_count - 1
+            unsafe *((out as i64 + pos * 2) as *mut u16) = ch as u16
+            pos = pos + 1
+            offset = offset + 1
+            if pos >= cap - 4:
+                return -1
+        while slash_count > 0:
+            if pos >= cap - 5:
+                return -1
+            unsafe *((out as i64 + pos * 2) as *mut u16) = 92 as u16
+            pos = pos + 1
+            unsafe *((out as i64 + pos * 2) as *mut u16) = 92 as u16
+            pos = pos + 1
+            slash_count = slash_count - 1
+        unsafe *((out as i64 + pos * 2) as *mut u16) = 34 as u16
+        pos = pos + 1
+        offset = offset + 1
+    unsafe *((out as i64 + pos * 2) as *mut u16) = 0 as u16
+    0
+
+fn win_make_security_attrs(out: *mut u8):
+    unsafe *(out as *mut u32) = 24 as u32
+    unsafe *((out as i64 + 8) as *mut i64) = 0
+    unsafe *((out as i64 + 16) as *mut i32) = 1
+
+fn win_open_redirect(path: &str, write_mode: bool) -> i64:
+    var wpath: [4096]u16 = [0 as u16; 4096]
+    let _ = win_str_to_utf16_buf(path, &raw mut wpath as *mut [4096]u16 as *mut u16, 4096)
+    var sec: [24]u8 = [0 as u8; 24]
+    win_make_security_attrs(&raw mut sec as *mut [24]u8 as *mut u8)
+    let access = if write_mode: GENERIC_WRITE else: GENERIC_READ
+    let creation = if write_mode: CREATE_ALWAYS else: OPEN_EXISTING
+    CreateFileW(&wpath as *const [4096]u16 as *const u16, access, FILE_SHARE_ALL, &raw mut sec as *mut [24]u8 as *mut u8, creation, FILE_ATTRIBUTE_NORMAL, 0)
+
+fn win_spawn_argv(args: &str, stdout_path: &str, stderr_path: &str, stdin_path: &str, cwd: &str, wait: bool, timeout_ms: i32) -> i32:
+    let data = win_str_data(args)
+    let cmd = with_alloc(32768 * 2)
+    if cmd as i64 == 0:
+        return -12
+    if win_build_command_line(data, args.len(), cmd as *mut u16, 32768) != 0:
+        with_free(cmd)
+        return -1
+    var startup: [104]u8 = [0 as u8; 104]
+    var proc_info: [24]u8 = [0 as u8; 24]
+    unsafe *((&raw mut startup) as *mut [104]u8 as *mut u32) = 104 as u32
+    var inherit = 0
+    var stdin_h = GetStdHandle(STD_INPUT_HANDLE)
+    var stdout_h = GetStdHandle(STD_OUTPUT_HANDLE)
+    var stderr_h = GetStdHandle(STD_ERROR_HANDLE)
+    let has_stdin = stdin_path.len() > 0
+    let has_stdout = stdout_path.len() > 0
+    let has_stderr = stderr_path.len() > 0
+    if has_stdin:
+        stdin_h = win_open_redirect(stdin_path, false)
+        inherit = 1
+    if has_stdout:
+        stdout_h = win_open_redirect(stdout_path, true)
+        inherit = 1
+    if has_stderr:
+        stderr_h = win_open_redirect(stderr_path, true)
+        inherit = 1
+    if inherit != 0:
+        let startup_base = (&raw mut startup) as *mut [104]u8 as i64
+        unsafe *((startup_base + 60) as *mut u32) = 0x00000100 as u32
+        unsafe *((startup_base + 80) as *mut i64) = stdin_h
+        unsafe *((startup_base + 88) as *mut i64) = stdout_h
+        unsafe *((startup_base + 96) as *mut i64) = stderr_h
+    var cwdw: [4096]u16 = [0 as u16; 4096]
+    var cwdp = 0 as *const u16
+    if cwd.len() > 0:
+        let _ = win_str_to_utf16_buf(cwd, &raw mut cwdw as *mut [4096]u16 as *mut u16, 4096)
+        cwdp = &cwdw as *const [4096]u16 as *const u16
+    let ok = CreateProcessW(0 as *const u16, cmd as *mut u16, 0 as *mut u8, 0 as *mut u8, inherit, 0 as u32, 0 as *mut u8, cwdp, &raw mut startup as *mut [104]u8 as *mut u8, &raw mut proc_info as *mut [24]u8 as *mut u8)
+    with_free(cmd)
+    if has_stdin and stdin_h != 0 and stdin_h != INVALID_HANDLE_VALUE:
+        let _ = CloseHandle(stdin_h)
+    if has_stdout and stdout_h != 0 and stdout_h != INVALID_HANDLE_VALUE:
+        let _ = CloseHandle(stdout_h)
+    if has_stderr and stderr_h != 0 and stderr_h != INVALID_HANDLE_VALUE:
+        let _ = CloseHandle(stderr_h)
+    if ok == 0:
+        return win_neg_error()
+    let process_h = unsafe *((&proc_info as i64 + 0) as *const i64)
+    let thread_h = unsafe *((&proc_info as i64 + 8) as *const i64)
+    let pid = unsafe *((&proc_info as i64 + 16) as *const i32)
+    let _thread_close = CloseHandle(thread_h)
+    let slot = win_process_alloc(process_h, pid)
+    if slot < 0:
+        let _close = CloseHandle(process_h)
+        return -1
+    if wait:
+        return win_wait_process_slot(slot, timeout_ms, true)
+    slot
+
+pub fn rt_compat_setenv_str(name: &str, value: &str) -> i32:
+    win_setenv(name, value)
+
+pub fn rt_compat_install_interrupt_handlers() -> Unit:
+    let _ = 0
+
+pub fn rt_compat_raise_stack_limit() -> Unit:
+    let _ = 0
+
+pub fn rt_set_process_memory_limit_bytes(limit: i64) -> i32:
+    let _ = limit
+    0
+
+pub fn rt_compat_interrupt_requested() -> i32:
+    0
+
+pub fn rt_compat_exec_binary(path: &str) -> i32:
+    var blob: [4096]u8 = [0 as u8; 4096]
+    let data = win_str_data(path)
+    var i: i64 = 0
+    while i < path.len() and i < 4095:
+        unsafe *((((&raw mut blob) as *mut [4096]u8 as i64) + i) as *mut u8) = unsafe *((data as i64 + i) as *const u8)
+        i = i + 1
+    unsafe *((((&raw mut blob) as *mut [4096]u8 as i64) + i) as *mut u8) = 0
+    let argv = make_windows_blob_str(&raw mut blob as *mut [4096]u8 as *const u8, i + 1)
+    win_spawn_argv(argv, "", "", "", "", true, 0)
+
+fn make_windows_blob_str(ptr: *const u8, len: i64) -> str:
+    var raw: [2]i64 = [ptr as i64, len]
+    let p = &raw as *const str
+    unsafe *p
+
+pub fn rt_compat_exec_argv(args: &str) -> i32:
+    win_spawn_argv(args, "", "", "", "", true, 0)
+
+pub fn rt_compat_exec_argv_cwd(args: &str, cwd: &str) -> i32:
+    win_spawn_argv(args, "", "", "", cwd, true, 0)
+
+pub fn rt_compat_exec_argv_capture(args: &str, stdout_path: &str, stderr_path: &str, timeout_ms: i32) -> i32:
+    win_spawn_argv(args, stdout_path, stderr_path, "", "", true, timeout_ms)
+
+pub fn rt_compat_exec_argv_capture_input(args: &str, stdout_path: &str, stderr_path: &str, timeout_ms: i32, stdin_path: &str) -> i32:
+    win_spawn_argv(args, stdout_path, stderr_path, stdin_path, "", true, timeout_ms)
+
+pub fn rt_compat_exec_argv_capture_cwd(args: &str, stdout_path: &str, stderr_path: &str, timeout_ms: i32, cwd: &str) -> i32:
+    win_spawn_argv(args, stdout_path, stderr_path, "", cwd, true, timeout_ms)
+
+pub fn rt_compat_exec_argv_capture_spawn(args: &str, stdout_path: &str, stderr_path: &str) -> i32:
+    win_spawn_argv(args, stdout_path, stderr_path, "", "", false, 0)
+
+pub fn rt_compat_exec_wait(pid: i32, timeout_ms: i32) -> i32:
+    win_wait_process_slot(pid, timeout_ms, true)
+
+// ---------------------------------------------------------------------------
+// Networking (Winsock2 / ws2_32). Mirrors the POSIX backend in
+// rt/linux_x86_64.w:with_net_*, translated to Winsock semantics: SOCKET
+// handles are returned as i64 (INVALID_SOCKET reads as -1), closesocket
+// replaces close, send/recv take int-width lengths, and socket creation is
+// gated behind a one-time WSAStartup. ws2_32.lib is already on the Windows
+// link line (src/compiler/Link.w). Loopback handles fit in i32, so the public
+// with_net_* i32-fd ABI declared by std.net is preserved on both platforms.
+// ---------------------------------------------------------------------------
+
+extern fn WSAStartup(version: u16, data: *mut u8) -> i32
+extern fn socket(af: i32, ty: i32, protocol: i32) -> i64
+extern fn connect(s: i64, addr: *const u8, namelen: i32) -> i32
+@[link_name("bind")]
+extern fn rt_libc_bind(s: i64, addr: *const u8, namelen: i32) -> i32
+extern fn listen(s: i64, backlog: i32) -> i32
+extern fn accept(s: i64, addr: *mut u8, addrlen: *mut i32) -> i64
+extern fn getsockname(s: i64, addr: *mut u8, addrlen: *mut i32) -> i32
+@[link_name("send")]
+extern fn rt_libc_send(s: i64, buf: *const u8, len: i32, flags: i32) -> i32
+@[link_name("recv")]
+extern fn rt_libc_recv(s: i64, buf: *mut u8, len: i32, flags: i32) -> i32
+extern fn closesocket(s: i64) -> i32
+extern fn getaddrinfo(node: *const u8, service: *const u8, hints: *const WindowsAddrInfo, res: *mut *mut WindowsAddrInfo) -> i32
+extern fn freeaddrinfo(res: *mut WindowsAddrInfo) -> Unit
+extern fn with_str_from_bytes(s: *const u8, len: i64) -> str
+
+// Win64 ADDRINFOA (ws2def.h): ai_addrlen is size_t (u64) and ai_canonname
+// precedes ai_addr — both differ from the Linux struct addrinfo layout.
+type WindowsAddrInfo:
+    ai_flags: i32
+    ai_family: i32
+    ai_socktype: i32
+    ai_protocol: i32
+    ai_addrlen: u64
+    ai_canonname: *mut u8
+    ai_addr: *mut u8
+    ai_next: *mut WindowsAddrInfo
+
+fn rt_net_str_data(s: &str) -> *const u8:
+    unsafe **(&s as *const *const *const u8)
+
+fn rt_net_wsa_ensure() -> i32:
+    // 0x0202 == Winsock 2.2. WSAStartup is refcounted; we never WSACleanup
+    // (a process-lifetime refcount leak, matching how the runtime treats other
+    // one-shot OS init).
+    var wsadata: [512]u8 = [0 as u8; 512]
+    WSAStartup(514 as u16, &raw mut wsadata as *mut [512]u8 as *mut u8)
+
+fn rt_net_empty_str() -> str:
+    with_str_from_bytes("" as *const u8, 0)
+
+fn rt_net_copy_str_to_c_buf(s: &str, out: *mut u8, cap: i64) -> i32:
+    if s.len() + 1 > cap:
+        return -1
+    var i: i64 = 0
+    while i < s.len():
+        unsafe *((out as i64 + i) as *mut u8) = s.byte_at(i) as u8
+        i = i + 1
+    unsafe *((out as i64 + i) as *mut u8) = 0
+    0
+
+fn rt_net_write_port_to_c_buf(port: i32, out: *mut u8, cap: i64) -> i32:
+    if port < 0 or port > 65535 or cap < 2:
+        return -1
+    var rev: [6]u8 = [0 as u8; 6]
+    var n = port
+    var len: i64 = 0
+    if n == 0:
+        rev[0] = 48 as u8
+        len = 1
+    else:
+        while n > 0:
+            rev[len] = (48 + (n % 10)) as u8
+            len = len + 1
+            n = n / 10
+    if len + 1 > cap:
+        return -1
+    var i: i64 = 0
+    while i < len:
+        unsafe *((out as i64 + i) as *mut u8) = rev[len - i - 1]
+        i = i + 1
+    unsafe *((out as i64 + len) as *mut u8) = 0
+    0
+
+// Fill a 16-byte sockaddr_in for `port` from a dotted-quad IPv4 literal.
+// Returns 0 on success, -1 when `host` is not a numeric IPv4 address (the
+// caller then resolves it through getaddrinfo).
+fn rt_net_fill_sockaddr_ipv4(host: &str, port: i32, sa: *mut u8) -> i32:
+    var parts: [4]i32 = [0 as i32; 4]
+    var idx: i64 = 0
+    var cur: i32 = 0
+    var have_digit = false
+    var i: i64 = 0
+    while i < host.len():
+        let c = host.byte_at(i) as i32
+        if c >= 48 and c <= 57:
+            cur = cur * 10 + (c - 48)
+            if cur > 255:
+                return -1
+            have_digit = true
+        else if c == 46:
+            if not have_digit or idx >= 3:
+                return -1
+            parts[idx] = cur
+            idx = idx + 1
+            cur = 0
+            have_digit = false
+        else:
+            return -1
+        i = i + 1
+    if not have_digit or idx != 3:
+        return -1
+    parts[3] = cur
+    // sin_family=AF_INET(2) LE, sin_port big-endian, sin_addr network order.
+    unsafe *((sa as i64 + 0) as *mut u8) = 2 as u8
+    unsafe *((sa as i64 + 1) as *mut u8) = 0 as u8
+    unsafe *((sa as i64 + 2) as *mut u8) = ((port >> 8) & 255) as u8
+    unsafe *((sa as i64 + 3) as *mut u8) = (port & 255) as u8
+    unsafe *((sa as i64 + 4) as *mut u8) = parts[0] as u8
+    unsafe *((sa as i64 + 5) as *mut u8) = parts[1] as u8
+    unsafe *((sa as i64 + 6) as *mut u8) = parts[2] as u8
+    unsafe *((sa as i64 + 7) as *mut u8) = parts[3] as u8
+    var j: i64 = 8
+    while j < 16:
+        unsafe *((sa as i64 + j) as *mut u8) = 0 as u8
+        j = j + 1
+    0
+
+fn rt_net_connect_any(host: &str, port: i32, socktype: i32, protocol: i32) -> i32:
+    if rt_net_wsa_ensure() != 0:
+        return -1
+    var sa: [16]u8 = [0 as u8; 16]
+    if rt_net_fill_sockaddr_ipv4(host, port, &raw mut sa as *mut [16]u8 as *mut u8) == 0:
+        let fd = socket(2, socktype, protocol)
+        if fd < 0:
+            return -1
+        if connect(fd, &sa as *const [16]u8 as *const u8, 16) != 0:
+            let _ = closesocket(fd)
+            return -1
+        return fd as i32
+    // Non-numeric host: resolve through getaddrinfo.
+    var host_buf: [256]u8 = [0 as u8; 256]
+    var port_buf: [16]u8 = [0 as u8; 16]
+    if rt_net_copy_str_to_c_buf(host, &raw mut host_buf as *mut [256]u8 as *mut u8, 256) != 0:
+        return -1
+    if rt_net_write_port_to_c_buf(port, &raw mut port_buf as *mut [16]u8 as *mut u8, 16) != 0:
+        return -1
+    var hints = WindowsAddrInfo {
+        ai_flags: 0,
+        ai_family: 0,
+        ai_socktype: socktype,
+        ai_protocol: protocol,
+        ai_addrlen: 0 as u64,
+        ai_canonname: 0 as *mut u8,
+        ai_addr: 0 as *mut u8,
+        ai_next: 0 as *mut WindowsAddrInfo,
+    }
+    var res: *mut WindowsAddrInfo = 0 as *mut WindowsAddrInfo
+    let gai = getaddrinfo(&host_buf as *const [256]u8 as *const u8, &port_buf as *const [16]u8 as *const u8, &hints as *const WindowsAddrInfo, &raw mut res as *mut *mut WindowsAddrInfo)
+    if gai != 0 or res as i64 == 0:
+        return -1
+    var p = res
+    while p as i64 != 0:
+        let fd = socket((unsafe *p).ai_family, (unsafe *p).ai_socktype, (unsafe *p).ai_protocol)
+        if fd >= 0:
+            let rc = connect(fd, (unsafe *p).ai_addr as *const u8, (unsafe *p).ai_addrlen as i32)
+            if rc == 0:
+                freeaddrinfo(res)
+                return fd as i32
+            let _ = closesocket(fd)
+        p = (unsafe *p).ai_next
+    freeaddrinfo(res)
+    -1
+
+pub fn with_net_tcp_connect(host: str, port: i32) -> i32:
+    rt_net_connect_any(&host, port, 1, 6)
+
+pub fn with_net_udp_connect(host: str, port: i32) -> i32:
+    rt_net_connect_any(&host, port, 2, 17)
+
+fn rt_net_bind_inaddr_any(fd: i64, port: i32) -> i32:
+    var sa: [16]u8 = [0 as u8; 16]
+    sa[0] = 2 as u8
+    sa[2] = ((port >> 8) & 255) as u8
+    sa[3] = (port & 255) as u8
+    rt_libc_bind(fd, &sa as *const [16]u8 as *const u8, 16)
+
+pub fn with_net_tcp_listen(port: i32, backlog: i32) -> i32:
+    if port < 0 or port > 65535:
+        return -1
+    if rt_net_wsa_ensure() != 0:
+        return -1
+    let fd = socket(2, 1, 6)
+    if fd < 0:
+        return -1
+    if rt_net_bind_inaddr_any(fd, port) != 0:
+        let _ = closesocket(fd)
+        return -1
+    if listen(fd, backlog) != 0:
+        let _ = closesocket(fd)
+        return -1
+    fd as i32
+
+pub fn with_net_tcp_accept(sock: i32) -> i32:
+    let fd = accept(sock as i64, 0 as *mut u8, 0 as *mut i32)
+    if fd < 0:
+        return -1
+    fd as i32
+
+pub fn with_net_udp_bind(port: i32) -> i32:
+    if port < 0 or port > 65535:
+        return -1
+    if rt_net_wsa_ensure() != 0:
+        return -1
+    let fd = socket(2, 2, 17)
+    if fd < 0:
+        return -1
+    if rt_net_bind_inaddr_any(fd, port) != 0:
+        let _ = closesocket(fd)
+        return -1
+    fd as i32
+
+pub fn with_net_sock_port(sock: i32) -> i32:
+    var sa: [16]u8 = [0 as u8; 16]
+    var sl: i32 = 16
+    if getsockname(sock as i64, &raw mut sa as *mut [16]u8 as *mut u8, &raw mut sl) != 0:
+        return -1
+    ((sa[2] as i32) << 8) | (sa[3] as i32)
+
+pub fn with_net_send(sock: i32, data: str) -> i64:
+    let ptr = rt_net_str_data(&data)
+    let total = data.len()
+    var written: i64 = 0
+    while written < total:
+        let chunk = total - written
+        let r = rt_libc_send(sock as i64, (ptr as i64 + written) as *const u8, chunk as i32, 0)
+        if r <= 0:
+            return if written > 0: written else: -1
+        written = written + (r as i64)
+    written
+
+pub fn with_net_recv(sock: i32, max_len: i64) -> str:
+    if max_len <= 0:
+        return rt_net_empty_str()
+    let buf = with_alloc(max_len)
+    if buf as i64 == 0:
+        return rt_net_empty_str()
+    let r = rt_libc_recv(sock as i64, buf, max_len as i32, 0)
+    if r <= 0:
+        with_free(buf)
+        return rt_net_empty_str()
+    let out = with_str_from_bytes(buf as *const u8, r as i64)
+    with_free(buf)
+    out
+
+pub fn with_net_close(sock: i32) -> i32:
+    closesocket(sock as i64)

--- a/runtime/fiber_asm_windows_aarch64.s
+++ b/runtime/fiber_asm_windows_aarch64.s
@@ -1,0 +1,89 @@
+// Fiber context switch for Windows ARM64 (AArch64, COFF).
+//
+// Sibling of runtime/fiber_asm_linux_aarch64.s. Windows-on-ARM64 uses the
+// AAPCS64 integer/FP calling convention, so the register save/restore set
+// and the x0..x3 argument registers are identical to the Linux backend.
+// The Windows deltas are COFF-only:
+//   - plain (non-underscored) global symbol names, like the x86_64 Windows
+//     backend (COFF/aarch64 does not use a leading-underscore mangling);
+//   - an explicit .text section directive;
+//   - x18 is the Windows TEB pointer and is callee-clobbered-reserved, so it
+//     is neither saved nor restored (this template never touches it).
+//
+// Context layout (saved registers):
+//   [0]  x19   [1]  x20   [2]  x21   [3]  x22   [4]  x23   [5]  x24
+//   [6]  x25   [7]  x26   [8]  x27   [9]  x28   [10] x29 (fp)  [11] x30 (lr)
+//   [12] sp
+//   [13] d8    [14] d9    [15] d10   [16] d11   [17] d12   [18] d13
+//   [19] d14   [20] d15
+
+        .text
+        .globl with_fiber_switch
+        .globl with_fiber_prepare_initial_context
+        .p2align 2
+with_fiber_switch:
+        // x0 = pointer to current fiber context (save here)
+        // x1 = pointer to target fiber context (restore from here)
+
+        // Save callee-saved registers to current context
+        stp x19, x20, [x0, #0]
+        stp x21, x22, [x0, #16]
+        stp x23, x24, [x0, #32]
+        stp x25, x26, [x0, #48]
+        stp x27, x28, [x0, #64]
+        stp x29, x30, [x0, #80]
+        mov x2, sp
+        str x2, [x0, #96]
+
+        // Save callee-saved FP registers
+        stp d8, d9, [x0, #104]
+        stp d10, d11, [x0, #120]
+        stp d12, d13, [x0, #136]
+        stp d14, d15, [x0, #152]
+
+        // Restore callee-saved registers from target context
+        ldp x19, x20, [x1, #0]
+        ldp x21, x22, [x1, #16]
+        ldp x23, x24, [x1, #32]
+        ldp x25, x26, [x1, #48]
+        ldp x27, x28, [x1, #64]
+        ldp x29, x30, [x1, #80]
+        ldr x2, [x1, #96]
+        mov sp, x2
+
+        // Restore callee-saved FP registers
+        ldp d8, d9, [x1, #104]
+        ldp d10, d11, [x1, #120]
+        ldp d12, d13, [x1, #136]
+        ldp d14, d15, [x1, #152]
+
+        ret
+
+        .p2align 2
+with_fiber_prepare_initial_context:
+        // x0 = context pointer
+        // x1 = usable stack base
+        // x2 = usable stack size
+        add x3, x1, x2
+        and x3, x3, #-16
+        str x3, [x0, #96]              // sp
+        str x3, [x0, #80]              // x29/fp
+        adrp x4, with_fiber_start
+        add  x4, x4, :lo12:with_fiber_start
+        str x4, [x0, #88]              // x30/lr
+        ret
+
+        .globl with_fiber_start
+        .p2align 2
+with_fiber_start:
+        sub sp, sp, #32
+        mov x0, sp
+        add x1, sp, #8
+        add x2, sp, #16
+        bl with_fiber_bootstrap_load
+        ldr x9, [sp]
+        ldr x0, [sp, #8]
+        ldr x1, [sp, #16]
+        blr x9
+        bl with_fiber_bootstrap_finish
+        brk #0

--- a/src/BuildGraphOps.w
+++ b/src/BuildGraphOps.w
@@ -299,6 +299,7 @@ pub fn build_graph_embed_object_files(root: &str, target: &BuildGraphTarget) -> 
     var has_darwin_runtime = false
     var has_linux_runtime = false
     var has_windows_runtime = false
+    var has_windows_aarch64_runtime = false
     // The embed target's entry names the PLATFORM the assembly is for
     // (e.g. "linux_x86_64" for a cross-built compiler); empty = host.
     var macho_sections = build_graph_host_target_kind() == 3 or build_graph_host_target_kind() == 4
@@ -327,6 +328,8 @@ pub fn build_graph_embed_object_files(root: &str, target: &BuildGraphTarget) -> 
             has_linux_runtime = true
         if sym == "rt_windows_x86_64_o":
             has_windows_runtime = true
+        if sym == "rt_windows_aarch64_o":
+            has_windows_aarch64_runtime = true
         asm_text = asm_text ++ build_graph_emit_embedded_blob(sym, input_path)
     if not has_darwin_runtime:
         asm_text = asm_text ++ build_graph_emit_empty_embedded_blob("rt_darwin_aarch64_o")
@@ -334,6 +337,8 @@ pub fn build_graph_embed_object_files(root: &str, target: &BuildGraphTarget) -> 
         asm_text = asm_text ++ build_graph_emit_empty_embedded_blob("rt_linux_x86_64_o")
     if not has_windows_runtime:
         asm_text = asm_text ++ build_graph_emit_empty_embedded_blob("rt_windows_x86_64_o")
+    if not has_windows_aarch64_runtime:
+        asm_text = asm_text ++ build_graph_emit_empty_embedded_blob("rt_windows_aarch64_o")
     if build_graph_rt_write_file(output_path, asm_text) != 0:
         build_graph_rt_eprint("error: could not write embedded-object assembly for target '" ++ target.name ++ "': " ++ output_path)
         return 1

--- a/src/TargetSpec.w
+++ b/src/TargetSpec.w
@@ -111,4 +111,4 @@ pub fn target_spec_name() -> str:
 // binaries for today. Gate is checked by the driver; anything else
 // non-native must fail loudly (§18.5: never fall back to native).
 pub fn target_spec_cross_supported(kind: i32) -> bool:
-    kind == 1 or kind == 2 or kind == 5
+    kind == 1 or kind == 2 or kind == 5 or kind == 6

--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -31,6 +31,8 @@ extern let with_embedded_rt_linux_x86_64_o_start: u8
 extern let with_embedded_rt_linux_x86_64_o_end: u8
 extern let with_embedded_rt_windows_x86_64_o_start: u8
 extern let with_embedded_rt_windows_x86_64_o_end: u8
+extern let with_embedded_rt_windows_aarch64_o_start: u8
+extern let with_embedded_rt_windows_aarch64_o_end: u8
 
 // D30 R2c: set by Compilation when THIS compile emitted the runtime
 // in-unit (WITH_RT_IN_UNIT lane, prelude on) — the .w-derived rt objects
@@ -716,6 +718,8 @@ fn link_stage_embedded_runtime_object(name: &str) -> str:
         return link_stage_embedded_obj_slice(&with_embedded_rt_linux_x86_64_o_start as *const u8, &with_embedded_rt_linux_x86_64_o_end as *const u8)
     if name == "rt_windows_x86_64.o":
         return link_stage_embedded_obj_slice(&with_embedded_rt_windows_x86_64_o_start as *const u8, &with_embedded_rt_windows_x86_64_o_end as *const u8)
+    if name == "rt_windows_aarch64.o":
+        return link_stage_embedded_obj_slice(&with_embedded_rt_windows_aarch64_o_start as *const u8, &with_embedded_rt_windows_aarch64_o_end as *const u8)
     ""
 
 fn link_stage_extract_runtime_obj(name: &str, path: &str) -> i32:


### PR DESCRIPTION
Stacked on #863 (target kind 6 plumbing). Makes `--target aarch64-pc-windows-msvc` actually buildable: adds the Windows-on-ARM64 runtime backend and the cross build target, then flips kind 6 to `cross_supported`.

The change is **additive to the host build** — kinds 0–5 are untouched, and host `with build` + `:fixpoint` stay green.

## What's here
- **`rt/windows_aarch64.w`** — Windows-on-ARM64 runtime backend. Near-verbatim from `rt/windows_x86_64.w` (the Win32 externs are ABI-identical across x64/arm64); `rt_sysinfo_arch` reports `"aarch64"`.
- **`runtime/fiber_asm_windows_aarch64.s`** — AAPCS64 fiber switch emitted as ARM64 COFF: saves `x19–x28`/fp/lr/sp and `d8–d15`, leaves `x18` (TEB) untouched, plain (non-underscored) COFF symbols.
- **`build.w`** — `cross_windows_aarch64_*` helpers and a `:cross-rt-windows-aarch64` group mirroring the `windows_x86_64` cross family (`out/lib/cross/windows_aarch64`, triple `aarch64-pc-windows-msvc`, prefix `.deps/llvm-<ver>-windows-aarch64-msvc`); `EmbedObjectFiles` for platform `windows_aarch64` with the `rt_windows_aarch64.o` blob; release/asset and package targets for `with-windows-aarch64.exe`; the `windows_aarch64` empty-blob slot on every non-self host.
- **`build/sdk.w`** — windows-aarch64 host tag (`-msvc`) + cache validation (clang-cl; the llvm-ml64 MASM assert stays x86_64-only).
- **`build/emit_c.w`** — arch-aware Windows `-target` and libdir defaults (arm64 vs x64), still env-overridable.
- **`src/BuildGraphOps.w`** — `has_windows_aarch64_runtime` flag + empty-blob fallback so the embedded symbol resolves before a real object exists.
- **`src/compiler/Link.w`** — `with_embedded_rt_windows_aarch64_o_{start,end}` externs + the `rt_windows_aarch64.o` embedded-slice arm.
- **`src/TargetSpec.w`** — `target_spec_cross_supported` now includes kind 6.

## Verification (linux-x86_64)
- `with build` — green (kind-6 path additive).
- `with build :fixpoint` — **stage2 == stage3**.
- `with build :cross-rt-windows-aarch64` — emits `COFF-ARM64` objects (`IMAGE_FILE_MACHINE_ARM64` `0xAA64`) for every runtime unit, incl. `rt_windows_aarch64.o` and the fiber asm. The `llvm-link-metadata` step fails loudly on a missing local windows-aarch64 SDK — expected off-CI; the seed link uses the SDK on CI (next PR).

Next in the stack: CI to cross-build + publish the `with-windows-aarch64.exe` seed on Linux, then the `windows-11-arm` bootstrap/fixpoint + nightly.