### PR TITLE
linux-aarch64: fix the remaining test failures (c_import char, AAPCS64 va_list, emit-c host)

### DIFF
--- a/build/emit_c.w
+++ b/build/emit_c.w
@@ -121,6 +121,8 @@ fn emitc_host_platform_runtime_object() -> str:
     let host_arch = arch()
     if host_os == "Linux" and host_arch == "x86_64":
         return "rt_linux_x86_64.o"
+    if host_os == "Linux" and comp_arch_is_aarch64(host_arch):
+        return "rt_linux_aarch64.o"
     if host_os == "Macos" and comp_arch_is_aarch64(host_arch):
         return "rt_darwin_aarch64.o"
     if host_os == "Windows" and host_arch == "x86_64":

--- a/build/selfhost.w
+++ b/build/selfhost.w
@@ -99,6 +99,8 @@ fn bs_host_platform_runtime_object() -> str:
     let host_arch = arch()
     if host_os == "Linux" and host_arch == "x86_64":
         return "rt_linux_x86_64.o"
+    if host_os == "Linux" and comp_arch_is_aarch64(host_arch):
+        return "rt_linux_aarch64.o"
     if host_os == "Macos" and comp_arch_is_aarch64(host_arch):
         return "rt_darwin_aarch64.o"
     if host_os == "Windows" and host_arch == "x86_64":

--- a/src/CImport.w
+++ b/src/CImport.w
@@ -6216,6 +6216,15 @@ fn ci_cxtype_kind_is_int(kind: i32) -> bool:
 fn ci_cxtype_kind_is_float(kind: i32) -> bool:
     kind == CXT_Float or kind == CXT_Double or kind == CXT_LongDouble or kind == CXT_Float128 or kind == CXT_Half or kind == CXT_Float16
 
+// True for the aggregate `va_list` shapes: `__va_list_tag[N]` (glibc/x86_64)
+// and `struct __va_list` (AAPCS64 Linux). Darwin's `char *` va_list is a
+// pointer and never reaches here.
+fn ci_canonical_is_aggregate_va_list(session: i64, canon: i32) -> bool:
+    if with_ci_type_kind(session, canon) == CXT_ConstantArray:
+        let elem = with_ci_type_array_element(session, canon)
+        return elem >= 0 and ci_str_contains(with_ci_type_spelling(session, elem), "__va_list_tag")
+    with_ci_type_kind(session, canon) == CXT_Record and ci_str_contains(with_ci_type_spelling(session, canon), "__va_list")
+
 // ci_type_from_libclang — walks a libclang CXType tree into
 // CiType nodes, preserving structural decomposition for
 // pointers / arrays / function pointers and using CT_NAMED at
@@ -6346,23 +6355,21 @@ impl CiTypePool:
                 i = i + 1
             return self.ty_fn_ptr(ret_ty, params_start, arg_count)
 
-        // Aggregate `va_list` (glibc/aarch64 `__va_list_tag[N]`) has no
-        // spellable field layout, so the bridge demotes it to `c_void` —
-        // which `check` rejects as a value type, breaking every migrated
-        // variadic function. LLVM's `llvm.va_start`/`va_end` only need
-        // correctly-sized storage, so lower it to a `[u8; N]` buffer sized
-        // to the target's actual va_list. Detection is structural: the
-        // canonical type is an array whose element record is `__va_list_tag`
-        // — target-independent, and Darwin's `char*` va_list never reaches
-        // here (it lowers through the CXT_Pointer path above).
+        // Aggregate `va_list` has no spellable field layout, so the bridge
+        // demotes it to `c_void` — which `check` rejects as a value type,
+        // breaking every migrated variadic function. LLVM's
+        // `llvm.va_start`/`va_end` only need correctly-sized storage, so lower
+        // it to a `[u8; N]` buffer sized to the target's actual va_list.
+        // Detection is structural over the canonical type: glibc/x86_64 spells
+        // it `__va_list_tag[N]`, AAPCS64 Linux spells it `struct __va_list`.
+        // Darwin's `char*` va_list never reaches here (it lowers through the
+        // CXT_Pointer path above).
         let va_canon = with_ci_type_canonical(session, cxtype)
-        if va_canon >= 0 and with_ci_type_kind(session, va_canon) == CXT_ConstantArray:
-            let va_elem = with_ci_type_array_element(session, va_canon)
-            if va_elem >= 0 and ci_str_contains(with_ci_type_spelling(session, va_elem), "__va_list_tag"):
-                let va_size = with_ci_type_sizeof(session, cxtype) as i32
-                if va_size > 0:
-                    let u8_idx = self.add_string("u8")
-                    return self.ty_array(self.ty_named(u8_idx), va_size)
+        if va_canon >= 0 and ci_canonical_is_aggregate_va_list(session, va_canon):
+            let va_size = with_ci_type_sizeof(session, cxtype) as i32
+            if va_size > 0:
+                let u8_idx = self.add_string("u8")
+                return self.ty_array(self.ty_named(u8_idx), va_size)
 
         // Typedef, elaborated, atomic, and other named wrappers.
         // Normalize builtin typedef spellings so C names like size_t do

--- a/src/compiler/ClangBridge.w
+++ b/src/compiler/ClangBridge.w
@@ -773,8 +773,13 @@ unsafe fn translate_type_recursive_mode(s: *mut CImportSession, ty: CXType, dept
 
     if kind == CXType_Void: return session_strdup(s, "Unit\0" as *const u8)
     if kind == CXType_Bool: return session_strdup(s, "bool\0" as *const u8)
-    if kind == CXType_Char_S or kind == CXType_SChar: return session_strdup(s, "c_char\0" as *const u8)
-    if kind == CXType_Char_U or kind == CXType_UChar: return session_strdup(s, "u8\0" as *const u8)
+    // Plain `char` is CXType_Char_S where char is signed (x86_64, Apple) and
+    // CXType_Char_U where it is unsigned (AArch64/ARM Linux). Both spell C's
+    // `char`, so both map to `c_char` — With's `c_char` is a fixed `i8` alias,
+    // and the char-pointer rule below already treats Char_U as a char. Only
+    // an explicit `unsigned char` (CXType_UChar) is `u8`.
+    if kind == CXType_Char_S or kind == CXType_Char_U or kind == CXType_SChar: return session_strdup(s, "c_char\0" as *const u8)
+    if kind == CXType_UChar: return session_strdup(s, "u8\0" as *const u8)
     if kind == CXType_Short: return session_strdup(s, "c_short\0" as *const u8)
     if kind == CXType_UShort: return session_strdup(s, "c_ushort\0" as *const u8)
     if kind == CXType_Int: return session_strdup(s, "c_int\0" as *const u8)
@@ -3309,7 +3314,11 @@ pub fn with_ci_type_is_unsigned(session: i64, cursor_idx: i32) -> i32:
         let ty = clang_getCursorType(cursor)
         let canonical = clang_getCanonicalType(ty)
         let k = canonical.kind
-        if k == CXType_UChar or k == CXType_Char_U or k == CXType_UShort or k == CXType_UInt or k == CXType_ULong or k == CXType_ULongLong or k == CXType_UInt128:
+        // CXType_Char_U is plain `char` on an unsigned-char target (AArch64/ARM
+        // Linux). c_import models C `char` as `c_char` (= i8) on every target,
+        // so it must classify as signed here too — otherwise the translated
+        // arithmetic picks unsigned wrap ops for an i8-typed value.
+        if k == CXType_UChar or k == CXType_UShort or k == CXType_UInt or k == CXType_ULong or k == CXType_ULongLong or k == CXType_UInt128:
             return 1
         0
 
@@ -4039,7 +4048,9 @@ unsafe fn is_float_kind(k: i32) -> i32:
     0
 
 unsafe fn is_unsigned_kind(k: i32) -> i32:
-    if k >= CXType_Char_U and k <= CXType_UInt128: return 1
+    // Starts at UChar, not Char_U: plain `char` maps to c_char (= i8) on every
+    // target, including the unsigned-char ones (AArch64/ARM Linux).
+    if k >= CXType_UChar and k <= CXType_UInt128: return 1
     0
 
 pub fn with_ci_implicit_cast_kind(session: i64, cursor_idx: i32) -> i32:


### PR DESCRIPTION
Stacked on #860. Makes `build :test` green on linux-aarch64, which is why `selfhost-linux-aarch64.yml` does not yet run the battery.

These are **real failures, not skips** — the prior run reported `7 of 948 files failed (0 cached, 948 ran)`. Nothing here adds a platform skip, exemption, or early-out.

## Root causes (8 failing groups → 4 causes)

**1. `c_import` mismaps plain `char` on unsigned-char targets** (`ClangBridge.w`)
On AArch64 plain `char` is unsigned, so libclang reports `CXType_Char_U`, which was mapped to `u8`. But the char-*pointer* rule nine lines below already treats `Char_U` as `*const i8`. The two disagree the moment a type is built structurally rather than via the pointer special case, so `static inline const char *f(void)` got a `*const u8` declared return and an `*const i8` body:
`invalid MIR before codegen: use rvalue type is incompatible with assign destination`.
Fixed by mapping `Char_U` to `c_char` (an unconditional `i8` alias); only explicit `unsigned char` stays `u8`. Signedness predicates follow, else translated arithmetic picks unsigned wrap ops for an i8-typed value. No signed-char target is affected — `Char_U` never occurs there. Fixes the 4 `behav_c_import_*` tests.

**2. AAPCS64 `va_list`** (`CImport.w`)
Only glibc/x86_64's `__va_list_tag[N]` was recognised; AAPCS64 spells it as a single record `struct __va_list`, which fell through to the opaque-record path (`cannot create value of opaque type`). Both aggregate shapes now lower to the same `[u8; N]` buffer. Darwin's `char *` va_list still goes through the pointer path, verified unchanged.

**3. emit-c host table stops at Linux/x86_64** (`build/selfhost.w`, `build/emit_c.w`)
`unsupported host runtime object for emit-c smoke C compile: Linux/aarch64`. Added the case to both.

**4. `behav_sysinfo_contract` enumerated two of three arch spellings**
`valid_arch` accepted `"armv8"`/`"x86_64"` but not `"aarch64"`, which is what Linux ARM64 reports.

## The one test-file change, called out deliberately
I first tried the *other* fix — making `rt/linux_aarch64.w` report `"armv8"` like darwin — and **reverted it on finding it would silently miscompile**: `link_stage_linux_arch()` matches `"aarch64"` to pick the multiarch dir, the ld emulation (`aarch64linux`) and the dynamic linker; reporting `"armv8"` sends all three down the x86_64 branches. So `"aarch64"` is load-bearing and the test was simply incomplete — its sibling `behav_std_os.w` and `lib/std/os.w` already accept all three spellings.

**Worth a ruling:** `arch()` genuinely returns `"armv8"` on darwin-arm64 and `"aarch64"` on linux-arm64 for the same CPU. Unifying is a user-visible break on darwin and would require normalizing `link_stage_linux_arch()`; deliberately not done here.

## Verification (linux-aarch64, clean build, verified directly rather than taken on report)
```
CLEAN_RC=0  BUILD_RC=0  FIXPOINT_RC=0  TEST_RC=0
0 failed targets; zero occurrences of "failed" in the test log
behavior-tests:             948 files ok (0 cached, 948 ran)
native-compile-error-tests: 736 files ok (0 cached, 736 ran)
native-codegen-tests:        16 files ok (0 cached,  16 ran)
```
`test-green` evidence recorded (90.9s) — it refuses to run after earlier failures, so its running is itself proof the battery passed. Darwin regression-checked separately: build + fixpoint green from `:clean`.

## Follow-up
Once this lands, the `:test` step can be added to `selfhost-linux-aarch64.yml` so the platform matches the other three selfhost workflows.