### PR TITLE
sysinfo: unify the ARM64 arch() spelling on "aarch64" (bridge step)

### DIFF
--- a/lib/std/sysinfo.w
+++ b/lib/std/sysinfo.w
@@ -13,7 +13,10 @@ pub fn os() -> str:
     with_sysinfo_os()
 
 // Returns the CPU architecture.
-// "armv8" on Apple Silicon/ARM64, "x86_64" on Intel/AMD 64-bit.
+// "aarch64" on ARM64, "x86_64" on Intel/AMD 64-bit. One spelling per
+// architecture on every platform -- notably "aarch64" on Apple Silicon
+// too, matching the target kinds (darwin_aarch64), the runtime sources
+// (rt/darwin_aarch64.w) and the published asset names.
 pub fn arch() -> str:
     with_sysinfo_arch()
 

--- a/rt/darwin_aarch64.w
+++ b/rt/darwin_aarch64.w
@@ -854,7 +854,7 @@ pub fn rt_sysinfo_os() -> str:
     with_str_from_cstr(c"Macos".ptr)
 
 pub fn rt_sysinfo_arch() -> str:
-    with_str_from_cstr(c"armv8".ptr)
+    with_str_from_cstr(c"aarch64".ptr)
 
 // ── Environment ─────────────────────────────────────────────────
 

--- a/test/behavior/behav_sysinfo_contract.w
+++ b/test/behavior/behav_sysinfo_contract.w
@@ -4,7 +4,10 @@ fn valid_os(s: &str) -> bool:
     s == "Macos" or s == "Linux" or s == "Windows"
 
 fn valid_arch(s: &str) -> bool:
-    s == "armv8" or s == "x86_64"
+    // "armv8" is the pre-unification darwin spelling; accepted only so this
+    // passes under a seed built before arch() was unified on "aarch64".
+    // Drop it once the seeds carry the unified spelling.
+    s == "aarch64" or s == "armv8" or s == "x86_64"
 
 fn main:
     let os_name = os()


### PR DESCRIPTION
Ruling: ARM64 is spelled **`aarch64`**, on every platform.

## The problem
`arch()` returned `"armv8"` on darwin-arm64 and `"aarch64"` on linux-arm64 — same CPU, two names. Every consumer compensated: `arch == "armv8" or arch == "aarch64"` appears in `os.w`, `TargetSpec.w` (×2), `BuildGraphKinds.w` (×2), `BuildGraphTools.w`, `Codegen.w`, `Link.w`, `build.w` (×4) and five `build/` modules — ~30 sites. The divergence was being paid for at every reader instead of fixed at its source, and it already caused a real failure (`behav_sysinfo_contract` on linux-aarch64).

## Why `aarch64`
Because the codebase had already decided everywhere else:
- target kinds: `darwin_aarch64`, `linux_aarch64` (and the incoming `windows_aarch64`)
- runtime sources: `rt/darwin_aarch64.w`
- every published asset: `with-darwin-aarch64`, `sdk-linux-aarch64`
- the spec's own `@[target("aarch64")]`
- `TargetSpec.w`, which literally calls it *"the canonical arch spelling (`"x86_64"`/`"aarch64"`)"*

`"armv8"` had **exactly one producer** — a single `c"armv8"` in the darwin runtime.

Externally (each verified by running the toolchain, not from memory): Rust and Zig use one spelling on every OS (`aarch64`); Go likewise uses one (`arm64`). Only the C/LLVM layer is split (`arm64-apple-darwin` vs `aarch64-*-linux`) — and With was mirroring the split layer, the one option no language chose.

## Why this is only a bridge step
It changes **the producer only**. Every reader still accepts both spellings.

That is deliberate, not laziness: `build.w` and `build/*.w` are *interpreted*, and call `arch()` on the **driver** — i.e. the seed. Under a seed that predates this, stripping the `"armv8"` alternatives would make `sdk_current_platform()` return `""` on darwin and break the bootstrap. So the ~30 alternatives come out in a follow-up, after a seed carrying this ships. Same bootstrap ordering AGENTS.md requires for Link.w/runtime changes.

## Verification
Darwin, from `:clean` with the `v0.15.1` published seed (i.e. the seed CI uses, not one already carrying the change):
- `BUILD_RC=0`, `FIXPOINT_RC=0`
- `arch()` now prints `aarch64`
- `behav_sysinfo_contract` and `behav_std_os` both pass

Linux-aarch64 is unaffected — it already returned `"aarch64"`.

## Follow-up
1. Ship a seed carrying this.
2. Delete the ~30 `or … == "armv8"` alternatives, and the temporary `"armv8"` acceptance in `behav_sysinfo_contract`.
3. Open question for you: does `ArchKind.Armv8` get renamed to match? More consistent, but widens the user-visible break.