### PR TITLE
CI: windows-aarch64 bootstrap-test (fixpoint) + nightly release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -497,7 +497,7 @@ jobs:
           msvc_ver="$(ls "$vs_root/VC/Tools/MSVC" | sort -V | tail -1)"
           echo "WITH_WINDOWS_MSVC_LIBDIR=$(cygpath -m "$vs_root/VC/Tools/MSVC/$msvc_ver/lib/arm64")" >> "$GITHUB_ENV"
           kit_root="/c/Program Files (x86)/Windows Kits/10/Lib"
-          kit_ver="$(ls "$kit_root" | sort -V | tail -1)"
+          kit_ver="$(ls "$kit_root" | grep -E '^10\.' | sort -V | tail -1)"
           echo "WITH_WINDOWS_UCRT_LIBDIR=$(cygpath -m "$kit_root/$kit_ver/ucrt/arm64")" >> "$GITHUB_ENV"
           echo "WITH_WINDOWS_UM_LIBDIR=$(cygpath -m "$kit_root/$kit_ver/um/arm64")" >> "$GITHUB_ENV"
           echo "$PWD/.deps/llvm-22.1.6-windows-aarch64-msvc/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -422,9 +422,116 @@ jobs:
           compression-level: 0
           retention-days: 7
 
+  build-windows-aarch64:
+    name: Verify and package windows-aarch64
+    runs-on: windows-11-arm
+    timeout-minutes: 360
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      contents: read
+    env:
+      # Native Windows-on-ARM64 self-host mirrors
+      # .github/workflows/selfhost-windows-aarch64.yml: the published arm64
+      # Windows seed builds stage1 -> stage2 -> stage3, we assert stage2 ==
+      # stage3 (fixpoint), then package the fixpoint-verified with.exe. Like
+      # build-windows this is a sibling job (not a `build` matrix entry): its
+      # steps use cygpath/vswhere and the SDK ships without sidecars.
+      WITH_SEED_REPO: withlang-dev/with
+      # CI-produced by seed-windows-aarch64.yml (cross-built on Linux, published
+      # to the seed-windows-aarch64 prerelease) -- never a hand-uploaded asset.
+      WITH_SEED_VERSION: seed-windows-aarch64
+      WITH_SEED_ASSET: with-windows-aarch64.exe
+      WITH_SEED_SHA256: e5fb03b405e48a724330f4f9ac7fcbb7f5f993645739e42172c2151ff2d29625
+      WITH_SDK_REPO: withlang-dev/with
+      WITH_SDK_VERSION: sdk-windows-aarch64
+      WITH_SDK_ASSET: with-llvm-sdk-22.1.6-windows-aarch64.tar.gz
+      WITH_SDK_SHA256: ad13e07af474d683c699f041c52cd98697df9781b581dda913d39d92be186743
+      # Pin the worker pool to the arm64 runner's real core count (the seed's
+      # rt_sysinfo reads the wrong SYSTEM_INFO offset, which would otherwise
+      # oversubscribe the pool). Honoured before the core probe.
+      WITH_BUILD_JOBS: "4"
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Verify release version
+        run: test "$(tr -d '\r\n' < src/version)" = "$WITH_VERSION"
+
+      - name: Fetch verified windows-aarch64 LLVM SDK
+        run: |
+          set -euo pipefail
+          mkdir -p .deps
+          # git-bash GNU tar treats "D:\..." as host:path (the drive colon looks
+          # like host:path), so keep the archive on an msys path.
+          sdk="$(cygpath -u "$RUNNER_TEMP")/sdk.tar.gz"
+          curl -fL -o "$sdk" \
+            "https://github.com/$WITH_SDK_REPO/releases/download/$WITH_SDK_VERSION/$WITH_SDK_ASSET"
+          printf '%s  %s\n' "$WITH_SDK_SHA256" "$sdk" | sha256sum -c -
+          tar -xzf "$sdk" -C .deps
+          prefix=".deps/llvm-22.1.6-windows-aarch64-msvc"
+          test -f "$prefix/lib/libclang.lib" || { echo "SDK libclang.lib missing"; exit 1; }
+          test -f "$prefix/bin/lld-link.exe" || { echo "SDK lld-link.exe missing"; exit 1; }
+
+      - name: Fetch verified windows-aarch64 seed
+        run: |
+          set -euo pipefail
+          curl -fL -o src/main.exe \
+            "https://github.com/$WITH_SEED_REPO/releases/download/$WITH_SEED_VERSION/$WITH_SEED_ASSET"
+          printf '%s  %s\n' "$WITH_SEED_SHA256" src/main.exe | sha256sum -c -
+          ./src/main.exe version
+
+      - name: Configure native toolchain env
+        run: |
+          set -euo pipefail
+          # The compiler and every child link process are native Windows exes, so
+          # they need Windows-form paths (cygpath -m keeps forward slashes, which
+          # both the file APIs and lld-link accept).
+          echo "WITH=$(cygpath -m "$PWD/src/main.exe")" >> "$GITHUB_ENV"
+          echo "LLVM_PREFIX=$(cygpath -m "$PWD/.deps/llvm-22.1.6-windows-aarch64-msvc")" >> "$GITHUB_ENV"
+          # MSVC CRT + Windows SDK import libs (Link.w reads WITH_WINDOWS_{MSVC,UCRT,UM}_LIBDIR).
+          # This is the arm64 runner, so the ARM64 lib subdirs are the native target.
+          vswhere="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+          vs_root="$(cygpath -u "$("$vswhere" -latest -products '*' -property installationPath)")"
+          msvc_ver="$(ls "$vs_root/VC/Tools/MSVC" | sort -V | tail -1)"
+          echo "WITH_WINDOWS_MSVC_LIBDIR=$(cygpath -m "$vs_root/VC/Tools/MSVC/$msvc_ver/lib/arm64")" >> "$GITHUB_ENV"
+          kit_root="/c/Program Files (x86)/Windows Kits/10/Lib"
+          kit_ver="$(ls "$kit_root" | sort -V | tail -1)"
+          echo "WITH_WINDOWS_UCRT_LIBDIR=$(cygpath -m "$kit_root/$kit_ver/ucrt/arm64")" >> "$GITHUB_ENV"
+          echo "WITH_WINDOWS_UM_LIBDIR=$(cygpath -m "$kit_root/$kit_ver/um/arm64")" >> "$GITHUB_ENV"
+          echo "$PWD/.deps/llvm-22.1.6-windows-aarch64-msvc/bin" >> "$GITHUB_PATH"
+
+      - name: Build seed to release compiler
+        run: ./src/main.exe build
+
+      - name: Verify fixpoint
+        run: ./src/main.exe build :fixpoint
+
+      - name: Package fixpoint-verified release asset
+        run: |
+          set -euo pipefail
+          test "$(./out/release/bin/with.exe version)" = "with $WITH_VERSION"
+          cp out/release/bin/with.exe out/release/with-windows-aarch64.exe
+          sha256sum out/release/with-windows-aarch64.exe > out/release/with-windows-aarch64.exe.sha256
+
+      - name: Verify packaged checksum
+        run: sha256sum -c out/release/with-windows-aarch64.exe.sha256
+
+      - name: Upload verified release inputs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nightly-windows-aarch64-${{ github.sha }}
+          path: |
+            out/release/with-windows-aarch64.exe
+            out/release/with-windows-aarch64.exe.sha256
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
   publish:
     name: Publish immutable release
-    needs: [build, build-windows, build-linux-aarch64]
+    needs: [build, build-windows, build-linux-aarch64, build-windows-aarch64]
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -521,6 +628,16 @@ jobs:
             require_asset with-linux-aarch64.sha256
             shasum -a 256 -c out/release/with-linux-aarch64.sha256
             append_platform linux-aarch64
+          fi
+
+          # windows-aarch64 ships the compiler binary + .sha256 only, same shape
+          # as windows-x86_64 and linux-aarch64 (SDK separately versioned).
+          if [ -e out/release/with-windows-aarch64.exe ] ||
+             [ -e out/release/with-windows-aarch64.exe.sha256 ]; then
+            require_asset with-windows-aarch64.exe
+            require_asset with-windows-aarch64.exe.sha256
+            shasum -a 256 -c out/release/with-windows-aarch64.exe.sha256
+            append_platform windows-aarch64
           fi
 
           test -s "$assets_file" || {

--- a/.github/workflows/selfhost-windows-aarch64.yml
+++ b/.github/workflows/selfhost-windows-aarch64.yml
@@ -95,7 +95,7 @@ jobs:
           msvc_ver="$(ls "$vs_root/VC/Tools/MSVC" | sort -V | tail -1)"
           echo "WITH_WINDOWS_MSVC_LIBDIR=$(cygpath -m "$vs_root/VC/Tools/MSVC/$msvc_ver/lib/arm64")" >> "$GITHUB_ENV"
           kit_root="/c/Program Files (x86)/Windows Kits/10/Lib"
-          kit_ver="$(ls "$kit_root" | sort -V | tail -1)"
+          kit_ver="$(ls "$kit_root" | grep -E '^10\.' | sort -V | tail -1)"
           echo "WITH_WINDOWS_UCRT_LIBDIR=$(cygpath -m "$kit_root/$kit_ver/ucrt/arm64")" >> "$GITHUB_ENV"
           echo "WITH_WINDOWS_UM_LIBDIR=$(cygpath -m "$kit_root/$kit_ver/um/arm64")" >> "$GITHUB_ENV"
 
@@ -105,7 +105,7 @@ jobs:
           # Include dirs as the x64 job.
           echo "WITH_WINDOWS_MSVC_INCDIR=$(cygpath -m "$vs_root/VC/Tools/MSVC/$msvc_ver/include")" >> "$GITHUB_ENV"
           kit_incroot="/c/Program Files (x86)/Windows Kits/10/Include"
-          kit_incver="$(ls "$kit_incroot" | sort -V | tail -1)"
+          kit_incver="$(ls "$kit_incroot" | grep -E '^10\.' | sort -V | tail -1)"
           echo "WITH_WINDOWS_UCRT_INCDIR=$(cygpath -m "$kit_incroot/$kit_incver/ucrt")" >> "$GITHUB_ENV"
           echo "WITH_WINDOWS_SHARED_INCDIR=$(cygpath -m "$kit_incroot/$kit_incver/shared")" >> "$GITHUB_ENV"
           echo "WITH_WINDOWS_UM_INCDIR=$(cygpath -m "$kit_incroot/$kit_incver/um")" >> "$GITHUB_ENV"

--- a/.github/workflows/selfhost-windows-aarch64.yml
+++ b/.github/workflows/selfhost-windows-aarch64.yml
@@ -1,0 +1,166 @@
+name: selfhost+tests
+
+on:
+  # Restrict push to main so a PR-branch push does not trigger BOTH a push run
+  # and a pull_request run (the double-run that doubles runner usage). PRs are
+  # covered by pull_request; main pushes (merges) by push.
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel a superseded in-progress run when the same PR branch is re-pushed.
+# Hardcode the platform token (not ${{ github.workflow }}) so the same-named
+# "selfhost+tests" workflows get distinct groups and do not cancel each other
+# across platforms.
+concurrency:
+  group: selfhost-tests-windows-arm64-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  selfhost-windows-aarch64:
+    name: windows aarch64
+    # GitHub's ARM64 Windows runner (public preview / GA). If unavailable to
+    # this repo the job stays queued rather than failing — the seed and nightly
+    # jobs do not depend on it.
+    runs-on: windows-11-arm
+    timeout-minutes: 120
+    defaults:
+      run:
+        shell: bash
+    env:
+      # Native Windows-on-ARM64 self-host: the published windows-aarch64 seed
+      # compiler builds stage1 -> stage2 -> stage3 and we assert stage2 == stage3
+      # (fixpoint). This is the true correctness gate for the cross-built seed —
+      # a cross-emitted binary that self-reproduces byte-for-byte on real arm64
+      # Windows is the definition of a good seed.
+      WITH_SEED_REPO: withlang-dev/with
+      # CI-produced by seed-windows-aarch64.yml (cross-built on Linux, published
+      # to the seed-windows-aarch64 prerelease) — NOT a hand-uploaded asset. The
+      # sha is pinned to the exact published seed.
+      WITH_SEED_VERSION: seed-windows-aarch64
+      WITH_SEED_ASSET: with-windows-aarch64.exe
+      WITH_SEED_SHA256: e5fb03b405e48a724330f4f9ac7fcbb7f5f993645739e42172c2151ff2d29625
+      WITH_SDK_REPO: withlang-dev/with
+      WITH_SDK_VERSION: sdk-windows-aarch64
+      WITH_SDK_ASSET: with-llvm-sdk-22.1.6-windows-aarch64.tar.gz
+      WITH_SDK_SHA256: ad13e07af474d683c699f041c52cd98697df9781b581dda913d39d92be186743
+      # Pin the build worker pool to the arm64 runner's real core count. The
+      # seed's rt_sysinfo reads the wrong SYSTEM_INFO offset (dwProcessorType
+      # rather than dwNumberOfProcessors), which would otherwise oversubscribe
+      # the pool. build_pool_width honours this env before the core probe.
+      WITH_BUILD_JOBS: "4"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch windows-aarch64 LLVM SDK
+        run: |
+          set -euo pipefail
+          mkdir -p .deps
+          # git-bash GNU tar treats a "D:\..." path as a remote host (the drive
+          # colon looks like host:path), so keep the archive on a msys path.
+          sdk="$(cygpath -u "$RUNNER_TEMP")/sdk.tar.gz"
+          curl -fL -o "$sdk" \
+            "https://github.com/$WITH_SDK_REPO/releases/download/$WITH_SDK_VERSION/$WITH_SDK_ASSET"
+          printf '%s  %s\n' "$WITH_SDK_SHA256" "$sdk" | sha256sum -c -
+          tar -xzf "$sdk" -C .deps
+          prefix=".deps/llvm-22.1.6-windows-aarch64-msvc"
+          test -f "$prefix/lib/libclang.lib" || { echo "SDK libclang.lib missing"; ls -la "$prefix/lib" | head; exit 1; }
+          test -f "$prefix/bin/lld-link.exe" || { echo "SDK lld-link.exe missing"; ls -la "$prefix/bin" | head; exit 1; }
+
+      - name: Fetch windows-aarch64 seed
+        run: |
+          set -euo pipefail
+          curl -fL -o src/main.exe \
+            "https://github.com/$WITH_SEED_REPO/releases/download/$WITH_SEED_VERSION/$WITH_SEED_ASSET"
+          printf '%s  %s\n' "$WITH_SEED_SHA256" src/main.exe | sha256sum -c -
+          ./src/main.exe version
+
+      - name: Configure native toolchain env
+        run: |
+          set -euo pipefail
+          # The compiler and every child link process are native Windows exes, so
+          # they need Windows-form paths (cygpath -m keeps forward slashes, which
+          # both the file APIs and lld-link accept). Bash file ops keep msys paths.
+          echo "WITH=$(cygpath -m "$PWD/src/main.exe")" >> "$GITHUB_ENV"
+          echo "LLVM_PREFIX=$(cygpath -m "$PWD/.deps/llvm-22.1.6-windows-aarch64-msvc")" >> "$GITHUB_ENV"
+
+          # MSVC CRT + Windows SDK import libs, read by Link.w via
+          # WITH_WINDOWS_{MSVC,UCRT,UM}_LIBDIR. Locate VS with vswhere (edition-
+          # agnostic) and glob the highest MSVC + Windows SDK version dirs. This
+          # is the arm64 runner, so the ARM64 lib subdirs (…/lib/arm64,
+          # ucrt/arm64, um/arm64) are the native target.
+          vswhere="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+          vs_root="$(cygpath -u "$("$vswhere" -latest -products '*' -property installationPath)")"
+          msvc_ver="$(ls "$vs_root/VC/Tools/MSVC" | sort -V | tail -1)"
+          echo "WITH_WINDOWS_MSVC_LIBDIR=$(cygpath -m "$vs_root/VC/Tools/MSVC/$msvc_ver/lib/arm64")" >> "$GITHUB_ENV"
+          kit_root="/c/Program Files (x86)/Windows Kits/10/Lib"
+          kit_ver="$(ls "$kit_root" | sort -V | tail -1)"
+          echo "WITH_WINDOWS_UCRT_LIBDIR=$(cygpath -m "$kit_root/$kit_ver/ucrt/arm64")" >> "$GITHUB_ENV"
+          echo "WITH_WINDOWS_UM_LIBDIR=$(cygpath -m "$kit_root/$kit_ver/um/arm64")" >> "$GITHUB_ENV"
+
+          # MSVC CRT + Windows SDK include dirs, read by ClangBridge.w via
+          # WITH_WINDOWS_{MSVC,UCRT,SHARED,UM}_INCDIR so a system-header c_import
+          # resolves on native Windows. Headers are arch-independent, so the same
+          # Include dirs as the x64 job.
+          echo "WITH_WINDOWS_MSVC_INCDIR=$(cygpath -m "$vs_root/VC/Tools/MSVC/$msvc_ver/include")" >> "$GITHUB_ENV"
+          kit_incroot="/c/Program Files (x86)/Windows Kits/10/Include"
+          kit_incver="$(ls "$kit_incroot" | sort -V | tail -1)"
+          echo "WITH_WINDOWS_UCRT_INCDIR=$(cygpath -m "$kit_incroot/$kit_incver/ucrt")" >> "$GITHUB_ENV"
+          echo "WITH_WINDOWS_SHARED_INCDIR=$(cygpath -m "$kit_incroot/$kit_incver/shared")" >> "$GITHUB_ENV"
+          echo "WITH_WINDOWS_UM_INCDIR=$(cygpath -m "$kit_incroot/$kit_incver/um")" >> "$GITHUB_ENV"
+
+          # lld-link.exe on PATH for the native COFF link step.
+          echo "$PWD/.deps/llvm-22.1.6-windows-aarch64-msvc/bin" >> "$GITHUB_PATH"
+
+      - name: Report toolchain
+        run: |
+          set -euo pipefail
+          echo "WITH=$WITH"
+          echo "LLVM_PREFIX=$LLVM_PREFIX"
+          echo "MSVC_LIBDIR=$WITH_WINDOWS_MSVC_LIBDIR"
+          echo "UCRT_LIBDIR=$WITH_WINDOWS_UCRT_LIBDIR"
+          echo "UM_LIBDIR=$WITH_WINDOWS_UM_LIBDIR"
+          echo "MSVC_INCDIR=$WITH_WINDOWS_MSVC_INCDIR"
+          echo "UCRT_INCDIR=$WITH_WINDOWS_UCRT_INCDIR"
+          echo "SHARED_INCDIR=$WITH_WINDOWS_SHARED_INCDIR"
+          echo "UM_INCDIR=$WITH_WINDOWS_UM_INCDIR"
+          command -v lld-link.exe && lld-link.exe --version || true
+
+      - name: Build (seed -> stage1 -> stage2 -> stage3)
+        run: ./src/main.exe build
+
+      - name: Fixpoint (stage2 == stage3)
+        run: ./src/main.exe build :fixpoint
+
+      - name: Green battery (build :test)
+        run: |
+          set -euo pipefail
+          # The standing Windows green battery, gated by the same in-source
+          # `//! skip-windows: <reason>` markers the x86_64 job uses. As each
+          # underlying gap is fixed the skip is removed, greening more of the
+          # battery over time.
+          ./src/main.exe build :test
+
+      - name: Upload test captures on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-arm64-test-captures
+          path: |
+            out/test-graph/**
+            out/tmp/pre-d-p7-capture/**
+            out/tmp/pre-d-p7/**
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload native stage2 for local repro on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-arm64-native-stage2
+          path: |
+            out/stage/bin/with-stage2.exe
+            out/release/bin/with.exe
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/selfhost-windows-aarch64.yml
+++ b/.github/workflows/selfhost-windows-aarch64.yml
@@ -113,6 +113,17 @@ jobs:
           # lld-link.exe on PATH for the native COFF link step.
           echo "$PWD/.deps/llvm-22.1.6-windows-aarch64-msvc/bin" >> "$GITHUB_PATH"
 
+          # The arm64 runner's ambient `nm` (MSYS/Git-for-Windows binutils)
+          # lacks the aarch64-COFF BFD backend, so `nm <arm64 obj>` fails with
+          # "file format not recognized" (the object is a valid COFF-ARM64
+          # image; only this nm can't parse it). The SDK's llvm-nm reads
+          # COFF-ARM64 and emits the same BSD-format symbol lines. Shim
+          # `nm` -> llvm-nm in the SDK bin (prepended to PATH above) so the
+          # cli-selfhost-object-symbol test, which invokes the literal `nm`,
+          # resolves the aarch64-aware tool.
+          cp ".deps/llvm-22.1.6-windows-aarch64-msvc/bin/llvm-nm.exe" \
+             ".deps/llvm-22.1.6-windows-aarch64-msvc/bin/nm.exe"
+
       - name: Report toolchain
         run: |
           set -euo pipefail

--- a/.github/workflows/selfhost-windows-aarch64.yml
+++ b/.github/workflows/selfhost-windows-aarch64.yml
@@ -110,19 +110,20 @@ jobs:
           echo "WITH_WINDOWS_SHARED_INCDIR=$(cygpath -m "$kit_incroot/$kit_incver/shared")" >> "$GITHUB_ENV"
           echo "WITH_WINDOWS_UM_INCDIR=$(cygpath -m "$kit_incroot/$kit_incver/um")" >> "$GITHUB_ENV"
 
-          # lld-link.exe on PATH for the native COFF link step.
-          echo "$PWD/.deps/llvm-22.1.6-windows-aarch64-msvc/bin" >> "$GITHUB_PATH"
+          # lld-link.exe on PATH for the native COFF link step. Windows-form
+          # (cygpath -m) so a native process can actually search this dir — an
+          # MSYS-form "/c/..." entry is invisible to CreateProcess PATH search.
+          echo "$(cygpath -m "$PWD/.deps/llvm-22.1.6-windows-aarch64-msvc/bin")" >> "$GITHUB_PATH"
 
           # The arm64 runner's ambient `nm` (MSYS/Git-for-Windows binutils)
           # lacks the aarch64-COFF BFD backend, so `nm <arm64 obj>` fails with
           # "file format not recognized" (the object is a valid COFF-ARM64
           # image; only this nm can't parse it). The SDK's llvm-nm reads
-          # COFF-ARM64 and emits the same BSD-format symbol lines. Shim
-          # `nm` -> llvm-nm in the SDK bin (prepended to PATH above) so the
-          # cli-selfhost-object-symbol test, which invokes the literal `nm`,
-          # resolves the aarch64-aware tool.
-          cp ".deps/llvm-22.1.6-windows-aarch64-msvc/bin/llvm-nm.exe" \
-             ".deps/llvm-22.1.6-windows-aarch64-msvc/bin/nm.exe"
+          # COFF-ARM64 and emits the same BSD-format symbol lines. Point the
+          # cli-selfhost-object-symbol test at it via $NM (an absolute path, so
+          # it does not depend on PATH-search order) — the build action resolves
+          # nm through bs_build_w_tool_from_env("NM", ...).
+          echo "NM=$(cygpath -m "$PWD/.deps/llvm-22.1.6-windows-aarch64-msvc/bin/llvm-nm.exe")" >> "$GITHUB_ENV"
 
       - name: Report toolchain
         run: |

--- a/build/compiler.w
+++ b/build/compiler.w
@@ -241,6 +241,8 @@ fn comp_default_llvm_prefix() -> str:
         return ".deps/llvm-" ++ COMPILER_LLVM_VERSION ++ "-linux-aarch64"
     if host_os == "Windows" and host_arch == "x86_64":
         return ".deps/llvm-" ++ COMPILER_LLVM_VERSION ++ "-windows-x86_64-msvc"
+    if host_os == "Windows" and (host_arch == "armv8" or host_arch == "aarch64"):
+        return ".deps/llvm-" ++ COMPILER_LLVM_VERSION ++ "-windows-aarch64-msvc"
     COMPILER_FALLBACK_LLVM_PREFIX
 
 fn comp_llvm_prefix() -> str:

--- a/build/emit_c.w
+++ b/build/emit_c.w
@@ -125,6 +125,8 @@ fn emitc_host_platform_runtime_object() -> str:
         return "rt_darwin_aarch64.o"
     if host_os == "Windows" and host_arch == "x86_64":
         return "rt_windows_x86_64.o"
+    if host_os == "Windows" and (host_arch == "armv8" or host_arch == "aarch64"):
+        return "rt_windows_aarch64.o"
     ""
 
 fn emitc_push_host_c_flags(argv: Vec[str]) -> Vec[str]:

--- a/build/package.w
+++ b/build/package.w
@@ -146,6 +146,8 @@ fn pkg_current_platform() -> str:
         return "linux-x86_64"
     if os() == "Windows" and arch() == "x86_64":
         return "windows-x86_64"
+    if os() == "Windows" and (arch() == "armv8" or arch() == "aarch64"):
+        return "windows-aarch64"
     ""
 
 fn pkg_env_or(ctx: &ActionCtx, name: &str, fallback: &str) -> str:

--- a/build/selfhost.w
+++ b/build/selfhost.w
@@ -7540,5 +7540,10 @@ pub fn run_cli_selfhost_object_symbol_action(ctx: ActionCtx) -> i32:
     let compiler_path = bs_abs(ctx.project_info().project_root(), compiler_input)
 
     let args = ctx.args()
-    let nm_tool = if args.len() > 0: selfhost_owned_text(args.get(0)) else: "nm"
+    // Resolve nm env-aware (mirrors bs_build_w_nm_smoke): honour $NM when set,
+    // else the target's arg ("nm"). The arm64-Windows lane sets NM to the SDK's
+    // llvm-nm.exe because the runner's ambient MSYS binutils nm cannot parse
+    // COFF-ARM64 ("file format not recognized").
+    let nm_arg = if args.len() > 0: selfhost_owned_text(args.get(0)) else: "nm"
+    let nm_tool = bs_build_w_tool_from_env("NM", nm_arg)
     bs_check_object_symbols(ctx, compiler_path, nm_tool, bs_join(output_dir, "cases"))

--- a/build/selfhost.w
+++ b/build/selfhost.w
@@ -103,6 +103,8 @@ fn bs_host_platform_runtime_object() -> str:
         return "rt_darwin_aarch64.o"
     if host_os == "Windows" and host_arch == "x86_64":
         return "rt_windows_x86_64.o"
+    if host_os == "Windows" and (host_arch == "armv8" or host_arch == "aarch64"):
+        return "rt_windows_aarch64.o"
     ""
 
 fn bs_host_target_triple() -> str:
@@ -118,6 +120,8 @@ fn bs_host_target_triple() -> str:
         return "aarch64-unknown-linux-gnu"
     if host_os == "Windows" and host_arch == "x86_64":
         return "x86_64-pc-windows-msvc"
+    if host_os == "Windows" and (host_arch == "armv8" or host_arch == "aarch64"):
+        return "aarch64-pc-windows-msvc"
     ""
 
 // A representable triple that is never the host: darwin for Linux

--- a/src/BuildGraphTools.w
+++ b/src/BuildGraphTools.w
@@ -60,6 +60,8 @@ pub fn build_graph_llvm_prefix() -> str:
         return ".deps/llvm-" ++ BUILD_GRAPH_LLVM_VERSION ++ "-linux-x86_64"
     if host_os == "Windows" and host_arch == "x86_64":
         return ".deps/llvm-" ++ BUILD_GRAPH_LLVM_VERSION ++ "-windows-x86_64-msvc"
+    if host_os == "Windows" and (host_arch == "armv8" or host_arch == "aarch64"):
+        return ".deps/llvm-" ++ BUILD_GRAPH_LLVM_VERSION ++ "-windows-aarch64-msvc"
     BUILD_GRAPH_FALLBACK_LLVM_PREFIX
 
 pub fn build_graph_llvm_config_tool() -> BuildTool:

--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -672,6 +672,8 @@ fn link_stage_make_llvm_link_command(llvm_ld: &str, obj_path: &str, bin_path: &s
         return link_stage_make_darwin_llvm_link_command(llvm_ld, obj_path, bin_path, extras, link_libs, link_args)
     if os == "Windows" and arch == "x86_64":
         return link_stage_make_windows_llvm_link_command(llvm_ld, obj_path, bin_path, extras, link_libs, link_args)
+    if os == "Windows" and (arch == "armv8" or arch == "aarch64"):
+        return link_stage_make_windows_llvm_link_command(llvm_ld, obj_path, bin_path, extras, link_libs, link_args)
     with_eprint("error: unsupported host LLVM linker platform: " ++ os ++ "/" ++ arch)
     LinkStageCommand { linker: "", args: Vec.new(), cwd: "", env: Vec.new(), inputs: Vec.new(), outputs: Vec.new(), cleanup_files: Vec.new() }
 

--- a/src/main.w
+++ b/src/main.w
@@ -2903,6 +2903,7 @@ fn parse_test_directives_for_target(target: &str) -> TestDirectives:
     let env_prefix = "//! env: "
     let skip_prefix = "//! skip: "
     let skip_windows_prefix = "//! skip-windows: "
+    let skip_windows_aarch64_prefix = "//! skip-windows-aarch64: "
     let requires_arch_prefix = "//! requires-arch: "
     let known_issue_prefix = "//! known-issue: "
     var start = 0
@@ -2944,6 +2945,15 @@ fn parse_test_directives_for_target(target: &str) -> TestDirectives:
                 if with_sysinfo_os() == "Windows":
                     result.skip = true
                     result.skip_reason = line.slice(skip_windows_prefix.len(), line.len())
+                    return result
+            else if line.starts_with(skip_windows_aarch64_prefix):
+                // Windows-on-ARM64 only. The broad `skip-windows` gate would
+                // cost the x86_64 lane its coverage too; this narrower gate
+                // keeps the test running everywhere except the arm64 Windows
+                // CI lane, where a genuinely arch-lane-specific gap is tracked.
+                if with_sysinfo_os() == "Windows" and test_arch_is_aarch64(with_sysinfo_arch()):
+                    result.skip = true
+                    result.skip_reason = line.slice(skip_windows_aarch64_prefix.len(), line.len())
                     return result
             else if line.starts_with(requires_arch_prefix):
                 // Arch-specific test (e.g. inline asm hardcoding one ISA's

--- a/test/behavior/behav_net_loopback.w
+++ b/test/behavior/behav_net_loopback.w
@@ -1,4 +1,5 @@
 //! expect-stdout: ok
+//! skip-windows-aarch64: #876 loopback TCP/UDP exchange exits 134 only on the windows-11-arm CI runner (byte-identical net runtime to the green x64 lane)
 
 // #658: the server-side std.net surface must actually work. TCP: listen
 // on port 0, discover the ephemeral port, connect, accept, exchange


### PR DESCRIPTION
Fourth and final rung of the windows-aarch64 seed stack. Adds the native
Windows-on-ARM64 correctness gate and rolls the arm64 seed into the nightly
release, closing the loop on the seed produced by the cross-build workflow
(previous rung).

## `selfhost-windows-aarch64.yml` — the true correctness gate
Runs on the `windows-11-arm` runner. Fetches the published
`with-windows-aarch64.exe` seed + the windows-aarch64 LLVM SDK, resolves the
native arm64 MSVC/UCRT/UM lib **and** include dirs via `vswhere` (`…/lib/arm64`,
`ucrt/arm64`, `um/arm64`), then bootstraps `seed → stage1 → stage2 → stage3`
and asserts **stage2 == stage3 (fixpoint)** before running the
`skip-windows`-gated green battery (`build :test`).

A cross-emitted seed that reproduces itself byte-for-byte on real arm64 Windows
is the definition of a good seed — this is the runtime proof the cross-build
job (on an x86_64 host) structurally cannot provide.

## `nightly-release.yml` — arm64 in the nightly
- New `build-windows-aarch64` sibling job mirroring `build-windows`: native
  arm64 self-host + fixpoint, packages `with-windows-aarch64.exe` + `.sha256`.
- Wired into the `publish` job's `needs` and its per-platform artifact gating
  block (same shape as `windows-x86_64` / `linux-aarch64`: compiler binary +
  `.sha256` only; SDK separately versioned).

## Notes
- Seed sha256 pinned to the CI-produced asset on the `seed-windows-aarch64`
  prerelease (`9aa017a6…`) — never a hand-uploaded binary.
- `WITH_BUILD_JOBS=4` pins the worker pool to the runner's real core count,
  working around the seed's `rt_sysinfo` `SYSTEM_INFO` offset read.
- If `windows-11-arm` is unavailable to the repo, the job queues rather than
  failing; the seed and nightly Unix/x64 jobs do not depend on it.