### PR TITLE
ci(linux-aarch64): pin the seed to the v0.15.1.5 release asset

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -311,13 +311,13 @@ jobs:
       # ships without .sha256/.manifest sidecars (as on Windows), so the archive
       # digest is pinned directly here instead of fetching sidecar files.
       WITH_SEED_REPO: withlang-dev/with
-      # Rolling bootstrap seed, fixpoint-verified from main ae4c6a75 -- the commit
-      # carrying the #851 posix_str_to_c_buf fix, without which the runtime builds
-      # every child argv from a mis-dereferenced str and no fork/exec (hence no
-      # link) works at all on this platform.
-      WITH_SEED_VERSION: with-linux-aarch64
+      # Pinned to the v0.15.1.5 stable release asset, matching how the other
+      # three platforms pin (a versioned release, not a rolling tag). That asset
+      # was produced by this very job on the v0.15.1.5 tag, so the platform now
+      # bootstraps from its own fixpoint-verified output.
+      WITH_SEED_VERSION: v0.15.1.5
       WITH_SEED_ASSET: with-linux-aarch64
-      WITH_SEED_SHA256: 49e65242e753f4db68b66752a03e2b0b5a619c2a121f2c5ac8034b0cf0e18057
+      WITH_SEED_SHA256: 20995c2de78d94c8e9c022107b48901ce97144ac2fb2b016f9ab19a22ae50683
       WITH_SDK_REPO: withlang-dev/with
       WITH_SDK_VERSION: sdk-linux-aarch64
       WITH_SDK_ASSET: with-llvm-sdk-22.1.6-linux-aarch64.tar.gz
@@ -327,6 +327,9 @@ jobs:
       # rt_linux_aarch64.o from <bindir>/runtime/ -- here src/runtime/, since the
       # seed is installed as src/main.
       WITH_RUNTIME_ASSET: with-linux-aarch64-runtime.tar.gz
+      # Runtime objects live on the rolling with-linux-aarch64 seed release, not
+      # on the versioned one, so they need their own tag.
+      WITH_RUNTIME_VERSION: with-linux-aarch64
       WITH_RUNTIME_SHA256: bdfd139b898a0c0d2ad0d989c2c4f2c9c8a63487fb54c08649cd56f34a3844db
     steps:
       - name: Checkout source
@@ -383,7 +386,7 @@ jobs:
           chmod +x src/main
           mkdir -p src/runtime
           curl -fL -o "$RUNNER_TEMP/rt.tar.gz" \
-            "https://github.com/$WITH_SEED_REPO/releases/download/$WITH_SEED_VERSION/$WITH_RUNTIME_ASSET"
+            "https://github.com/$WITH_SEED_REPO/releases/download/$WITH_RUNTIME_VERSION/$WITH_RUNTIME_ASSET"
           printf '%s  %s\n' "$WITH_RUNTIME_SHA256" "$RUNNER_TEMP/rt.tar.gz" | sha256sum -c -
           tar -xzf "$RUNNER_TEMP/rt.tar.gz" -C src/runtime
           test -f src/runtime/rt_linux_aarch64.o || { echo "runtime bundle missing rt_linux_aarch64.o"; exit 1; }

--- a/.github/workflows/selfhost-linux-aarch64.yml
+++ b/.github/workflows/selfhost-linux-aarch64.yml
@@ -30,8 +30,12 @@ jobs:
       # which no fork/exec — and therefore no link — works on linux-aarch64).
       WITH_SEED_REPO: withlang-dev/with
       WITH_SEED_ASSET: with-linux-aarch64
-      WITH_SEED_VERSION: with-linux-aarch64
-      WITH_SEED_SHA256: 49e65242e753f4db68b66752a03e2b0b5a619c2a121f2c5ac8034b0cf0e18057
+      # Pinned to the v0.15.1.5 stable release asset, matching how the other
+      # three platforms pin (a versioned release, not a rolling tag). That
+      # asset is itself CI-produced and fixpoint-verified by the Release
+      # workflow's build-linux-aarch64 job.
+      WITH_SEED_VERSION: v0.15.1.5
+      WITH_SEED_SHA256: 20995c2de78d94c8e9c022107b48901ce97144ac2fb2b016f9ab19a22ae50683
       WITH_SDK_REPO: withlang-dev/with
       WITH_SDK_VERSION: sdk-linux-aarch64
       # NOTE: this platform's SDK ships as .tar.gz (the linux-x86_64 asset is
@@ -48,6 +52,11 @@ jobs:
       # so the fixpoint-verified runtime objects are published beside the seed
       # and fetched here.
       WITH_RUNTIME_ASSET: with-linux-aarch64-runtime.tar.gz
+      # The runtime objects live on the rolling with-linux-aarch64 seed release,
+      # NOT on the versioned release, so they need their own tag. They are
+      # interchangeable across these two builds -- verified by running a full
+      # self-host + fixpoint on main with exactly this seed/runtime pair.
+      WITH_RUNTIME_VERSION: with-linux-aarch64
       WITH_RUNTIME_SHA256: bdfd139b898a0c0d2ad0d989c2c4f2c9c8a63487fb54c08649cd56f34a3844db
     steps:
       - name: Checkout
@@ -103,7 +112,7 @@ jobs:
           # in <bindir>/runtime/, i.e. beside with-seed at the workspace root.
           mkdir -p runtime
           curl -fL -o /tmp/rt.tar.gz \
-            "https://github.com/$WITH_SEED_REPO/releases/download/$WITH_SEED_VERSION/$WITH_RUNTIME_ASSET"
+            "https://github.com/$WITH_SEED_REPO/releases/download/$WITH_RUNTIME_VERSION/$WITH_RUNTIME_ASSET"
           printf '%s  %s\n' "$WITH_RUNTIME_SHA256" /tmp/rt.tar.gz | sha256sum -c -
           tar -xzf /tmp/rt.tar.gz -C runtime
           test -f runtime/rt_linux_aarch64.o || { echo "runtime bundle missing rt_linux_aarch64.o"; exit 1; }


### PR DESCRIPTION
Switches both linux-aarch64 jobs from the rolling `with-linux-aarch64` tag to the **v0.15.1.5** release asset.

## Why
The rolling tag is a hand-published seed. v0.15.1.5 now carries a `with-linux-aarch64` asset that the Release workflow's own `build-linux-aarch64` job produced and verified — build, **fixpoint**, checksum, upload. So the platform bootstraps from its own fixpoint-verified output, and pins a versioned release the way darwin, linux-x86_64 and windows already do.

```
WITH_SEED_VERSION: with-linux-aarch64  →  v0.15.1.5
WITH_SEED_SHA256:  49e65242…           →  20995c2d…
```

## The part that would have broken silently
The runtime-objects fetch derived its URL from `$WITH_SEED_VERSION`, but that bundle exists **only** on the rolling seed release. Moving the seed pin alone would have 404'd it — and not at the seed step, but later, after the SDK and linker shim had set up cleanly. It now has its own `WITH_RUNTIME_VERSION`, still pointing at the rolling tag.

## Mixed-generation risk, checked rather than assumed
Seed and runtime now come from different builds — v0.15.1.5 from `a897d8d7`, the runtime bundle from `ae4c6a75` — and `c3d0a29c` between them touches `rt/`. Pairing a newer compiler with older runtime objects is the mixed-world hazard, so I ran it: **exactly this seed + runtime pair, on current main (`aa275a95`), on an aarch64 Linux host**, full self-host from a clean tree:

```
BUILD_RC=0   FIXPOINT_RC=0   0 errors   survey: all targets green
```

A `hello.w` link alone would not have caught a stage-level incompatibility, so this is the full battery's build and fixpoint, not a smoke test.

## Follow-up
The runtime pin disappears once the compiler embeds its own `rt_linux_aarch64.o` (#869 + #860). The seed pin is the durable half.