### PR TITLE
arch: finish the aarch64 unification — retire "armv8" throughout

### DIFF
--- a/build.w
+++ b/build.w
@@ -447,7 +447,7 @@ fn release_compiler_bin(name: &str) -> str:
 fn release_platform_asset_bin() -> str:
     let host_os = os()
     let host_arch = arch()
-    if host_os == "Macos" and (host_arch == "armv8" or host_arch == "aarch64"):
+    if host_os == "Macos" and comp_arch_is_aarch64(host_arch):
         return "out/release/with-darwin-aarch64"
     if host_os == "Linux" and host_arch == "x86_64":
         return "out/release/with-linux-x86_64"
@@ -467,7 +467,7 @@ fn release_uat_platform_asset_dep(t: Target) -> Target:
     t
 
 fn host_runtime_spec() -> HostRuntimeSpec:
-    if os() == "Linux" and (arch() == "armv8" or arch() == "aarch64"):
+    if os() == "Linux" and comp_arch_is_aarch64(arch()):
         return HostRuntimeSpec {
             platform_source: "rt/linux_aarch64.w",
             compat_source: "rt/compat_runtime.w",
@@ -538,7 +538,7 @@ fn host_runtime_spec() -> HostRuntimeSpec:
 fn release_asset_for_host() -> str:
     if os() == "Linux" and arch() == "x86_64":
         return "with-linux-x86_64"
-    if os() == "Macos" and (arch() == "armv8" or arch() == "aarch64"):
+    if os() == "Macos" and comp_arch_is_aarch64(arch()):
         return "with-darwin-aarch64"
     if os() == "Windows" and arch() == "x86_64":
         return "with-windows-x86_64.exe"
@@ -557,7 +557,7 @@ fn release_platform_tag() -> str:
 fn supported_release_platform_tag() -> str:
     if os() == "Linux" and arch() == "x86_64":
         return "linux-x86_64"
-    if os() == "Macos" and (arch() == "armv8" or arch() == "aarch64"):
+    if os() == "Macos" and comp_arch_is_aarch64(arch()):
         return "darwin-aarch64"
     if os() == "Windows" and arch() == "x86_64":
         return "windows-x86_64"

--- a/build/compiler.w
+++ b/build/compiler.w
@@ -217,14 +217,27 @@ fn comp_tool_from_env(primary: &str, legacy: &str, fallback: &str) -> str:
         return old
     compiler_owned_text(fallback)
 
+// True when a host-arch string denotes ARM64.
+//
+// arch() is unified on "aarch64" (rt/darwin_aarch64.w). This predicate exists
+// only because build.w and build/*.w are INTERPRETED BY THE SEED: a seed built
+// before that unification still reports "armv8" on darwin, so the build layer
+// must accept both until every pinned seed carries the unified spelling.
+//
+// This is the ONLY place in the tree that still knows the legacy spelling
+// (aside from ConanClient, where "armv8" is Conan's own ecosystem name and is
+// correct). Delete the "armv8" branch after the next reseed.
+pub fn comp_arch_is_aarch64(a: &str) -> bool:
+    a == "aarch64" or a == "armv8"
+
 fn comp_default_llvm_prefix() -> str:
     let host_os = os()
     let host_arch = arch()
-    if host_os == "Macos" and (host_arch == "armv8" or host_arch == "aarch64"):
+    if host_os == "Macos" and comp_arch_is_aarch64(host_arch):
         return ".deps/llvm-" ++ COMPILER_LLVM_VERSION ++ "-darwin-arm64"
     if host_os == "Linux" and host_arch == "x86_64":
         return ".deps/llvm-" ++ COMPILER_LLVM_VERSION ++ "-linux-x86_64"
-    if host_os == "Linux" and (host_arch == "armv8" or host_arch == "aarch64"):
+    if host_os == "Linux" and comp_arch_is_aarch64(host_arch):
         return ".deps/llvm-" ++ COMPILER_LLVM_VERSION ++ "-linux-aarch64"
     if host_os == "Windows" and host_arch == "x86_64":
         return ".deps/llvm-" ++ COMPILER_LLVM_VERSION ++ "-windows-x86_64-msvc"

--- a/build/emit_c.w
+++ b/build/emit_c.w
@@ -121,7 +121,7 @@ fn emitc_host_platform_runtime_object() -> str:
     let host_arch = arch()
     if host_os == "Linux" and host_arch == "x86_64":
         return "rt_linux_x86_64.o"
-    if host_os == "Macos" and (host_arch == "armv8" or host_arch == "aarch64"):
+    if host_os == "Macos" and comp_arch_is_aarch64(host_arch):
         return "rt_darwin_aarch64.o"
     if host_os == "Windows" and host_arch == "x86_64":
         return "rt_windows_x86_64.o"

--- a/build/package.w
+++ b/build/package.w
@@ -1,5 +1,6 @@
 module build.package
 
+use build.compiler
 use std.build
 use std.string.StringBuilder
 use std.sysinfo
@@ -139,7 +140,7 @@ fn pkg_host_exe_suffix() -> str:
     ""
 
 fn pkg_current_platform() -> str:
-    if os() == "Macos" and (arch() == "armv8" or arch() == "aarch64"):
+    if os() == "Macos" and comp_arch_is_aarch64(arch()):
         return "darwin-aarch64"
     if os() == "Linux" and arch() == "x86_64":
         return "linux-x86_64"

--- a/build/sdk.w
+++ b/build/sdk.w
@@ -97,11 +97,11 @@ fn sdk_exe_name(name: &str) -> str:
     sdk_owned_text(name)
 
 pub fn sdk_current_platform() -> str:
-    if os() == "Macos" and (arch() == "armv8" or arch() == "aarch64"):
+    if os() == "Macos" and comp_arch_is_aarch64(arch()):
         return "darwin-aarch64"
     if os() == "Linux" and arch() == "x86_64":
         return "linux-x86_64"
-    if os() == "Linux" and (arch() == "armv8" or arch() == "aarch64"):
+    if os() == "Linux" and comp_arch_is_aarch64(arch()):
         return "linux-aarch64"
     if os() == "Windows" and arch() == "x86_64":
         return "windows-x86_64"
@@ -809,7 +809,7 @@ pub fn run_sdk_llvm_action(ctx: ActionCtx) -> i32:
                 return sdk_fail(ctx, "SDKROOT must be set for macOS SDK rebuilds; the graph will not shell out to xcrun")
             configure.push("-DCMAKE_OSX_SYSROOT=" ++ sdkroot)
             configure.push("-DCMAKE_OSX_DEPLOYMENT_TARGET=" ++ deployment_target)
-            if arch() == "armv8" or arch() == "aarch64":
+            if comp_arch_is_aarch64(arch()):
                 configure.push("-DCMAKE_OSX_ARCHITECTURES=arm64")
             else if arch() == "x86_64":
                 configure.push("-DCMAKE_OSX_ARCHITECTURES=x86_64")

--- a/build/selfhost.w
+++ b/build/selfhost.w
@@ -1,5 +1,6 @@
 module build.selfhost
 
+use build.compiler
 use pcre2
 use std.build
 use std.process
@@ -98,7 +99,7 @@ fn bs_host_platform_runtime_object() -> str:
     let host_arch = arch()
     if host_os == "Linux" and host_arch == "x86_64":
         return "rt_linux_x86_64.o"
-    if host_os == "Macos" and (host_arch == "armv8" or host_arch == "aarch64"):
+    if host_os == "Macos" and comp_arch_is_aarch64(host_arch):
         return "rt_darwin_aarch64.o"
     if host_os == "Windows" and host_arch == "x86_64":
         return "rt_windows_x86_64.o"
@@ -107,13 +108,13 @@ fn bs_host_platform_runtime_object() -> str:
 fn bs_host_target_triple() -> str:
     let host_os = os()
     let host_arch = arch()
-    if host_os == "Macos" and (host_arch == "armv8" or host_arch == "aarch64"):
+    if host_os == "Macos" and comp_arch_is_aarch64(host_arch):
         return "aarch64-apple-darwin"
     if host_os == "Macos" and host_arch == "x86_64":
         return "x86_64-apple-darwin"
     if host_os == "Linux" and host_arch == "x86_64":
         return "x86_64-unknown-linux-gnu"
-    if host_os == "Linux" and (host_arch == "armv8" or host_arch == "aarch64"):
+    if host_os == "Linux" and comp_arch_is_aarch64(host_arch):
         return "aarch64-unknown-linux-gnu"
     if host_os == "Windows" and host_arch == "x86_64":
         return "x86_64-pc-windows-msvc"
@@ -3273,7 +3274,7 @@ fn bs_check_emit_c_array_ref(ctx: &ActionCtx, compiler_path: &str, case_dir: &st
     bs_edge_assert_exact(ctx, run_result.stdout, "", "emit_c_array_ref", "stdout")
 
 fn bs_check_darwin_arm64_c_abi_direct_aggregates(ctx: &ActionCtx, compiler_path: &str, case_dir: &str) -> i32:
-    if not (os() == "Macos" and (arch() == "armv8" or arch() == "aarch64")):
+    if not (os() == "Macos" and comp_arch_is_aarch64(arch())):
         return 0
 
     let root = ctx.project_info().project_root()
@@ -6105,7 +6106,7 @@ fn bs_check_build_w_library_and_targets(ctx: &ActionCtx, compiler_path: &str, ba
     if rc != 0: return rc
     rc = bs_build_w_write_fixture(ctx, bs_join(host_dir, "src/main.w"), "fn main:\n    print(\"explicit host target\")\n", ctx.target_name(), "host source")
     if rc != 0: return rc
-    rc = bs_build_w_write_fixture(ctx, bs_join(host_dir, "build.w"), "use std.build\nuse std.sysinfo\n\npub fn build(ctx: BuildCtx) -> Build:\n    var host = BuildTarget.native\n    if os() == \"Macos\":\n        if arch() == \"armv8\" or arch() == \"aarch64\":\n            host = BuildTarget.darwin_aarch64\n        else if arch() == \"x86_64\":\n            host = BuildTarget.darwin_x86_64\n    else if os() == \"Linux\":\n        if arch() == \"armv8\" or arch() == \"aarch64\":\n            host = BuildTarget.linux_aarch64\n        else if arch() == \"x86_64\":\n            host = BuildTarget.linux_x86_64\n    else if os() == \"Windows\":\n        if arch() == \"x86_64\":\n            host = BuildTarget.windows_x86_64\n    var target = target_new(.Executable, \"host-target\", \"src/main.w\")\n    target = target.target(host)\n    var out = ctx.new_build()\n    out.add_target(target)\n", ctx.target_name(), "host build.w")
+    rc = bs_build_w_write_fixture(ctx, bs_join(host_dir, "build.w"), "use std.build\nuse std.sysinfo\n\npub fn build(ctx: BuildCtx) -> Build:\n    var host = BuildTarget.native\n    if os() == \"Macos\":\n        if arch() == \"aarch64\":\n            host = BuildTarget.darwin_aarch64\n        else if arch() == \"x86_64\":\n            host = BuildTarget.darwin_x86_64\n    else if os() == \"Linux\":\n        if arch() == \"aarch64\":\n            host = BuildTarget.linux_aarch64\n        else if arch() == \"x86_64\":\n            host = BuildTarget.linux_x86_64\n    else if os() == \"Windows\":\n        if arch() == \"x86_64\":\n            host = BuildTarget.windows_x86_64\n    var target = target_new(.Executable, \"host-target\", \"src/main.w\")\n    target = target.target(host)\n    var out = ctx.new_build()\n    out.add_target(target)\n", ctx.target_name(), "host build.w")
     if rc != 0: return rc
     let host_result = bs_build_w_expect_success(ctx, compiler_path, host_dir, "build-w-explicit-host-target", bs_blob_to_args(bs_argv_append("", "build")))
     if host_result.rc != 0: return host_result.rc

--- a/lib/std/os.w
+++ b/lib/std/os.w
@@ -23,7 +23,7 @@ pub enum OsKind: i32:
     Unknown
 
 pub enum ArchKind: i32:
-    Armv8
+    Aarch64
     X86_64
     Unknown
 
@@ -49,8 +49,8 @@ pub fn arch() -> str:
 /// Return the host CPU architecture as a closed tag for platform switches.
 pub fn arch_kind() -> ArchKind:
     let name = arch()
-    if name == "armv8" or name == "aarch64":
-        return ArchKind.Armv8
+    if name == "aarch64":
+        return ArchKind.Aarch64
     if name == "x86_64":
         return ArchKind.X86_64
     ArchKind.Unknown

--- a/src/BuildGraphKinds.w
+++ b/src/BuildGraphKinds.w
@@ -111,17 +111,17 @@ pub fn build_graph_host_target_kind() -> i32:
     let os = with_sysinfo_os()
     let arch = with_sysinfo_arch()
     if os == "Macos":
-        if arch == "armv8" or arch == "aarch64":
+        if arch == "aarch64":
             return 4
         if arch == "x86_64":
             return 3
     if os == "Linux":
-        if arch == "armv8" or arch == "aarch64":
+        if arch == "aarch64":
             return 2
         if arch == "x86_64":
             return 1
     if os == "Windows":
-        if arch == "armv8" or arch == "aarch64":
+        if arch == "aarch64":
             return 6
         if arch == "x86_64":
             return 5

--- a/src/BuildGraphTools.w
+++ b/src/BuildGraphTools.w
@@ -54,7 +54,7 @@ pub fn build_graph_llvm_prefix() -> str:
         return prefix
     let host_os = with_sysinfo_os()
     let host_arch = with_sysinfo_arch()
-    if host_os == "Macos" and (host_arch == "armv8" or host_arch == "aarch64"):
+    if host_os == "Macos" and host_arch == "aarch64":
         return ".deps/llvm-" ++ BUILD_GRAPH_LLVM_VERSION ++ "-darwin-arm64"
     if host_os == "Linux" and host_arch == "x86_64":
         return ".deps/llvm-" ++ BUILD_GRAPH_LLVM_VERSION ++ "-linux-x86_64"

--- a/src/Codegen.w
+++ b/src/Codegen.w
@@ -4961,7 +4961,7 @@ fn codegen_c_abi_needs_byval_attr() -> bool:
 fn codegen_c_abi_darwin_arm64() -> bool:
     let os = target_spec_os()
     let arch = target_spec_arch()
-    os == "Macos" and (arch == "armv8" or arch == "aarch64")
+    os == "Macos" and arch == "aarch64"
 
 fn codegen_windows_x86_64() -> bool:
     let os = target_spec_os()

--- a/src/TargetSpec.w
+++ b/src/TargetSpec.w
@@ -33,17 +33,17 @@ pub fn target_spec_host_kind() -> i32:
     let os = with_sysinfo_os()
     let arch = with_sysinfo_arch()
     if os == "Macos":
-        if arch == "armv8" or arch == "aarch64":
+        if arch == "aarch64":
             return 4
         if arch == "x86_64":
             return 3
     if os == "Linux":
-        if arch == "armv8" or arch == "aarch64":
+        if arch == "aarch64":
             return 2
         if arch == "x86_64":
             return 1
     if os == "Windows":
-        if arch == "armv8" or arch == "aarch64":
+        if arch == "aarch64":
             return 6
         if arch == "x86_64":
             return 5
@@ -60,10 +60,9 @@ pub fn target_spec_os() -> str:
         return "Windows"
     with_sysinfo_os()
 
-// Resolved target arch. Cross targets use the canonical spelling
-// ("x86_64"/"aarch64"); native returns the host sysinfo spelling
-// unchanged (e.g. "armv8") so native behavior is byte-identical to
-// the pre-TargetSpec compiler.
+// Resolved target arch. Cross targets and the host now share one canonical
+// spelling ("x86_64"/"aarch64"), so a native target returns exactly what the
+// host sysinfo reports.
 pub fn target_spec_arch() -> str:
     let kind = target_spec_active
     if kind == 1 or kind == 3 or kind == 5:

--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -664,9 +664,9 @@ fn link_stage_make_llvm_link_command(llvm_ld: &str, obj_path: &str, bin_path: &s
     let arch = runtime_sysinfo_arch()
     if os == "Linux" and arch == "x86_64":
         return link_stage_make_linux_llvm_link_command(llvm_ld, obj_path, bin_path, extras, link_libs, link_args)
-    if os == "Linux" and (arch == "armv8" or arch == "aarch64"):
+    if os == "Linux" and arch == "aarch64":
         return link_stage_make_linux_llvm_link_command(llvm_ld, obj_path, bin_path, extras, link_libs, link_args)
-    if os == "Macos" and (arch == "armv8" or arch == "aarch64"):
+    if os == "Macos" and arch == "aarch64":
         return link_stage_make_darwin_llvm_link_command(llvm_ld, obj_path, bin_path, extras, link_libs, link_args)
     if os == "Windows" and arch == "x86_64":
         return link_stage_make_windows_llvm_link_command(llvm_ld, obj_path, bin_path, extras, link_libs, link_args)
@@ -1016,15 +1016,15 @@ fn link_stage_host_platform_runtime_object() -> str:
     let arch = runtime_sysinfo_arch()
     if os == "Linux" and arch == "x86_64":
         return "rt_linux_x86_64.o"
-    if os == "Linux" and (arch == "armv8" or arch == "aarch64"):
+    if os == "Linux" and arch == "aarch64":
         // No embedded slot yet — resolved from the on-disk runtime root
         // only (see link_stage_embedded_runtime_object).
         return "rt_linux_aarch64.o"
-    if os == "Macos" and (arch == "armv8" or arch == "aarch64"):
+    if os == "Macos" and arch == "aarch64":
         return "rt_darwin_aarch64.o"
     if os == "Windows" and arch == "x86_64":
         return "rt_windows_x86_64.o"
-    if os == "Windows" and (arch == "armv8" or arch == "aarch64"):
+    if os == "Windows" and arch == "aarch64":
         return "rt_windows_aarch64.o"
     with_eprint("error: unsupported host runtime platform: " ++ os ++ "/" ++ arch)
     ""

--- a/src/compiler/LlvmBridge.w
+++ b/src/compiler/LlvmBridge.w
@@ -556,7 +556,7 @@ pub fn wl_set_active_target_triple(triple: str) -> Unit:
 fn llvm_object_triple(default_triple: *mut u8) -> *const u8:
     if wl_active_triple_len > 0:
         return &wl_active_triple_buf as *const u8
-    if rt_sysinfo_os() == "Macos" and (rt_sysinfo_arch() == "armv8" or rt_sysinfo_arch() == "aarch64"):
+    if rt_sysinfo_os() == "Macos" and (rt_sysinfo_arch() == "aarch64"):
         return c"arm64-apple-macosx11.0.0".ptr as *const u8
     default_triple as *const u8
 

--- a/src/main.w
+++ b/src/main.w
@@ -2872,14 +2872,14 @@ fn test_parse_i32(text: &str) -> i32:
     value * sign
 
 fn test_arch_is_aarch64(arch: &str) -> bool:
-    arch == "aarch64" or arch == "armv8" or arch == "arm64"
+    arch == "aarch64" or arch == "arm64"
 
 fn test_arch_is_x86_64(arch: &str) -> bool:
     arch == "x86_64" or arch == "amd64" or arch == "x64"
 
 fn test_arch_matches(required: &str, host: &str) -> bool:
-    // Canonicalize the ISA spellings the runtime and directives may use so a
-    // `requires-arch: aarch64` gate also matches an "armv8"/"arm64" host.
+    // Canonicalize the ISA spellings a directive may use so a
+    // `requires-arch: aarch64` gate also matches an "arm64" host.
     if test_arch_is_aarch64(required): return test_arch_is_aarch64(host)
     if test_arch_is_x86_64(required): return test_arch_is_x86_64(host)
     required == host

--- a/test/behavior/behav_std_os.w
+++ b/test/behavior/behav_std_os.w
@@ -6,7 +6,7 @@ fn valid_os(s: str) -> bool:
     s == "Macos" or s == "Linux" or s == "Windows"
 
 fn valid_arch(s: str) -> bool:
-    s == "armv8" or s == "aarch64" or s == "x86_64"
+    s == "aarch64" or s == "x86_64"
 
 fn main:
     assert(valid_os(os()), "unexpected std.os.os(): " ++ os())

--- a/test/behavior/behav_sysinfo_contract.w
+++ b/test/behavior/behav_sysinfo_contract.w
@@ -4,10 +4,7 @@ fn valid_os(s: &str) -> bool:
     s == "Macos" or s == "Linux" or s == "Windows"
 
 fn valid_arch(s: &str) -> bool:
-    // "armv8" is the pre-unification darwin spelling; accepted only so this
-    // passes under a seed built before arch() was unified on "aarch64".
-    // Drop it once the seeds carry the unified spelling.
-    s == "aarch64" or s == "armv8" or s == "x86_64"
+    s == "aarch64" or s == "x86_64"
 
 fn main:
     let os_name = os()


### PR DESCRIPTION
Follow-up to #868, which made `arch()` report `"aarch64"` on darwin but left every reader accepting both spellings. This retires the legacy one.

**38 occurrences → 5**, and both survivors are deliberate.

## What changed
- **`ArchKind.Armv8` → `ArchKind.Aarch64`**, and `arch_kind()` no longer accepts `"armv8"`. A user-visible rename — but the variant had no users outside `lib/std/os.w` itself.
- **19 compiled sites** (`src/`, `lib/`, `rt/`) collapse to a single-spelling check. These ship inside the compiler, whose own `arch()` reports `"aarch64"`, so none of them can still see the old string.
- **16 build-layer sites** now route through one predicate, `comp_arch_is_aarch64`.
- Both arch behavior tests tightened; the embedded selfhost `build.w` fixture updated.
- **No filenames needed renaming** — they were already `*_aarch64.*`.

## Why the build layer keeps a compat branch
`build.w` and `build/*.w` are **interpreted by the seed**, so they call `arch()` on the *seed*, and every currently pinned seed still reports `"armv8"` on darwin. Dropping the alternative outright would make `sdk_current_platform()` return `""` mid-bootstrap — and only on darwin, several steps into a build.

Routing all 16 through one predicate means there is **one line to delete after the next reseed** instead of sixteen, and its comment says exactly that.

## The survivor that must not be "cleaned up"
`ConanClient.w` does:

```
fn conan_detect_arch -> str:
    let arch = runtime_sysinfo_arch()
    if arch == "aarch64":
        return "armv8"
```

That translates to **Conan's** settings vocabulary, where ARM64 genuinely is spelled `armv8`, and it feeds `target_arch` in queries against `center2.conan.io`. Renaming it would silently break C package resolution. The comment on `comp_arch_is_aarch64` names this survivor explicitly so a later `grep armv8` sweep doesn't "finish the job" and break interop.

## Verification
Darwin, from `:clean`, with the **v0.15.1 published seed** — the one that still reports `"armv8"`, which is the case that actually matters here:

```
BUILD_RC=0   FIXPOINT_RC=0
arch() prints "aarch64"
behav_std_os → ok        behav_sysinfo_contract → pass
```

## Follow-up
Once a seed carrying #868 is pinned everywhere, delete the `"armv8"` branch in `comp_arch_is_aarch64` and the predicate collapses to a plain equality.