### PR TITLE
ci(release): derive the version on nightlies instead of a stale literal

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -30,7 +30,16 @@ concurrency:
 permissions: {}
 
 env:
-  WITH_VERSION: ${{ github.event_name == 'push' && github.ref_name || inputs.version || 'v0.15.1.3' }}
+  # A tag push supplies the version independently of the tree, so every job
+  # asserts src/version agrees with it -- that check is the only thing stopping
+  # a tag being cut against a tree that disagrees about its own version.
+  #
+  # schedule/workflow_dispatch-without-input have no tag, so there is nothing to
+  # cross-check: the version is DERIVED from src/version by the "Resolve and
+  # verify version" step below. Deliberately empty here rather than a literal --
+  # the previous hardcoded fallback had to be hand-edited on every version bump,
+  # was not, and failed every nightly once src/version moved past it.
+  WITH_VERSION: ${{ github.event_name == 'push' && github.ref_name || inputs.version || '' }}
 
 jobs:
   build:
@@ -85,8 +94,19 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Verify release version
-        run: test "$(tr -d '\r\n' < src/version)" = "$WITH_VERSION"
+      - name: Resolve and verify version
+        run: |
+          set -euo pipefail
+          src="$(tr -d '\r\n' < src/version)"
+          test -n "$src"
+          if [ -n "$WITH_VERSION" ]; then
+            # Tag push or explicit dispatch input: the version was supplied
+            # independently, so the tree must agree with it.
+            test "$src" = "$WITH_VERSION"
+          else
+            # Nightly: no tag exists, so src/version IS the version.
+            echo "WITH_VERSION=$src" >> "$GITHUB_ENV"
+          fi
 
       - name: Fetch verified bootstrap seed
         run: |
@@ -217,8 +237,19 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Verify release version
-        run: test "$(tr -d '\r\n' < src/version)" = "$WITH_VERSION"
+      - name: Resolve and verify version
+        run: |
+          set -euo pipefail
+          src="$(tr -d '\r\n' < src/version)"
+          test -n "$src"
+          if [ -n "$WITH_VERSION" ]; then
+            # Tag push or explicit dispatch input: the version was supplied
+            # independently, so the tree must agree with it.
+            test "$src" = "$WITH_VERSION"
+          else
+            # Nightly: no tag exists, so src/version IS the version.
+            echo "WITH_VERSION=$src" >> "$GITHUB_ENV"
+          fi
 
       - name: Fetch verified Windows LLVM SDK
         run: |
@@ -335,8 +366,19 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Verify release version
-        run: test "$(tr -d '\r\n' < src/version)" = "$WITH_VERSION"
+      - name: Resolve and verify version
+        run: |
+          set -euo pipefail
+          src="$(tr -d '\r\n' < src/version)"
+          test -n "$src"
+          if [ -n "$WITH_VERSION" ]; then
+            # Tag push or explicit dispatch input: the version was supplied
+            # independently, so the tree must agree with it.
+            test "$src" = "$WITH_VERSION"
+          else
+            # Nightly: no tag exists, so src/version IS the version.
+            echo "WITH_VERSION=$src" >> "$GITHUB_ENV"
+          fi
 
       - name: Install host packages
         run: |
@@ -459,8 +501,19 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Verify release version
-        run: test "$(tr -d '\r\n' < src/version)" = "$WITH_VERSION"
+      - name: Resolve and verify version
+        run: |
+          set -euo pipefail
+          src="$(tr -d '\r\n' < src/version)"
+          test -n "$src"
+          if [ -n "$WITH_VERSION" ]; then
+            # Tag push or explicit dispatch input: the version was supplied
+            # independently, so the tree must agree with it.
+            test "$src" = "$WITH_VERSION"
+          else
+            # Nightly: no tag exists, so src/version IS the version.
+            echo "WITH_VERSION=$src" >> "$GITHUB_ENV"
+          fi
 
       - name: Fetch verified windows-aarch64 LLVM SDK
         run: |
@@ -558,6 +611,21 @@ jobs:
     steps:
       - name: Checkout release metadata generator
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      # GITHUB_ENV does not cross job boundaries, so the build jobs' resolved
+      # WITH_VERSION is not visible here. Resolve it the same way, from the same
+      # source, or the metadata generator below is handed an empty version on a
+      # nightly.
+      - name: Resolve version
+        run: |
+          set -euo pipefail
+          src="$(tr -d '\r\n' < src/version)"
+          test -n "$src"
+          if [ -n "$WITH_VERSION" ]; then
+            test "$src" = "$WITH_VERSION"
+          else
+            echo "WITH_VERSION=$src" >> "$GITHUB_ENV"
+          fi
 
       - name: Download verified release inputs
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
Every scheduled nightly fails `Verify release version`.

## Cause
```yaml
WITH_VERSION: ${{ github.event_name == 'push' && github.ref_name || inputs.version || 'v0.15.1.3' }}
```
On a `schedule` run the event isn't `push` and `inputs.version` is empty, so it falls through to the hardcoded **`v0.15.1.3`** and is compared against `src/version`, now `v0.15.1.6`.

That literal has to be hand-edited on every version bump and isn't, so this **breaks again the moment the version moves**. The recurrence was guaranteed.

## Fix: keep the check where it means something, drop it where it doesn't
A tag push supplies the version *independently of the tree*, so asserting `src/version` agrees is the only thing stopping a tag being cut against a tree that disagrees about its own version. Worth keeping.

A nightly has no tag — `src/version` is the sole source of truth, so comparing it to a literal compares it to nothing.

- **tag push / explicit dispatch input** → assert `src/version` matches
- **nightly** → derive `WITH_VERSION` from `src/version`

The stale literal is gone entirely, so there's nothing left to hand-update.

## Why not overwrite `src/version` from the tag
That was the other obvious option, and it's worse on both counts:

1. **Unnecessary.** `comp_resolve_compiler_version` already lets `$WITH_VERSION` override the stamp outright (`build/compiler.w:1336`) — the seam exists.
2. **It deletes the guarantee.** With `src/version` rewritten from the tag, `git tag v9.9.9` on any commit silently yields a "v9.9.9" release. The check exists precisely to catch that.

It would also dirty the working tree that the git-hash stamp path reads.

## The subtle one
`GITHUB_ENV` doesn't cross job boundaries, so the build jobs' resolved value isn't visible in `publish` — which passes `WITH_VERSION` to the release metadata generator. Without resolving it there too, every nightly would hand that generator an **empty version**: a silently bad release rather than a failed build. The `publish` job now resolves from the same source.

## Verified
- YAML parses; all five jobs intact (`build`, `build-windows`, `build-linux-aarch64`, `build-windows-aarch64`, `publish`)
- Zero remaining references to the stale literal
- All four `Verify release version` steps replaced, plus the new `publish` resolve

## Follow-up, deliberately not done here
A nightly now stamps exactly the release version (`v0.15.1.6`), so a nightly artifact is indistinguishable from the real release. A `-nightly-<sha>` suffix would fix that — but `WITH_VERSION` feeds the release metadata generator and I haven't verified how it parses the string, so I'm not changing tag-naming behaviour blind in a fix for something else.