### PR TITLE
std: add RFC 4648 Base16, Base32, and Base64 codecs

### DIFF
--- a/docs/feature_plans/libstd-spec.md
+++ b/docs/feature_plans/libstd-spec.md
@@ -187,6 +187,10 @@ No serialization in v1. Parse-only.
 
 #### 1.4 `std.encoding` — Base64 and Hex
 
+> **Superseded:** The proposal below is retained for historical context. The
+> implemented RFC 4648 API and strict decoding contract are documented in
+> [docs/std-encoding-rfc4648.md](../std-encoding-rfc4648.md).
+
 ```
 // std.encoding.base64
 

--- a/docs/std-encoding-rfc4648.md
+++ b/docs/std-encoding-rfc4648.md
@@ -1,0 +1,147 @@
+# RFC 4648 Encodings
+
+The `std.encoding` family provides native, safe-With implementations of the
+Base16, Base32, Base32hex, Base64, and Base64URL encodings defined by
+[RFC 4648](https://www.rfc-editor.org/info/rfc4648/). Encoding represents bytes
+as text; it does not encrypt data, add entropy, or protect secrets.
+
+## API
+
+These are the family's only public declarations: one shared error and ten codec
+functions.
+
+| Module | Encode | Decode |
+|---|---|---|
+| `std.encoding.base16` | `base16_encode(data: []u8) -> str` | `base16_decode(text: &str) -> Result[Vec[u8], DecodeError]` |
+| `std.encoding.base32` | `base32_encode(data: []u8) -> str` | `base32_decode(text: &str) -> Result[Vec[u8], DecodeError]` |
+| `std.encoding.base32hex` | `base32hex_encode(data: []u8) -> str` | `base32hex_decode(text: &str) -> Result[Vec[u8], DecodeError]` |
+| `std.encoding.base64` | `base64_encode(data: []u8) -> str` | `base64_decode(text: &str) -> Result[Vec[u8], DecodeError]` |
+| `std.encoding.base64url` | `base64url_encode(data: []u8) -> str` | `base64url_decode(text: &str) -> Result[Vec[u8], DecodeError]` |
+
+Encoders accept borrowed byte slices; decoders borrow input text and return
+owned bytes. Behavior tests cover bound fixed arrays and vectors remaining
+usable after encoder calls.
+
+```with
+use std.encoding.base64
+
+let input = [102 as u8, 111 as u8, 111 as u8]
+let encoded = base64_encode(input)
+assert(encoded == "Zm9v")
+let decoded = base64_decode(encoded).unwrap()
+assert(decoded.len() == 3)
+```
+
+## Decode errors and strictness
+
+All decoders use the shared `std.encoding.DecodeError`:
+
+```with
+pub error DecodeError =
+    | InvalidLength(length: i64)
+    | InvalidByte(offset: i64, byte: u8)
+    | InvalidPadding(offset: i64)
+    | NonCanonicalBits(offset: i64)
+```
+
+Errors are selected deterministically: invalid encoded length first, then the
+first alphabet or padding violation from left to right, then non-zero unused
+bits in the final symbol. Validation and canonical-bit checks complete before
+output allocation, so failures return no partial output. No decoder ignores
+whitespace, CRLF, NUL, non-ASCII bytes, excess padding, or characters outside
+its accepted alphabet. Base32, Base32hex, Base64, and Base64URL require RFC
+padding on a partial final quantum.
+
+| Codec | Canonical alphabet | Decode case | Padding |
+|---|---|---|---|
+| Base16 | `0-9A-F` | ASCII-insensitive | none |
+| Base32 | `A-Z2-7` | ASCII-insensitive | required |
+| Base32hex | `0-9A-V` | ASCII-insensitive | required |
+| Base64 | `A-Za-z0-9+/` | significant | required |
+| Base64URL | `A-Za-z0-9-_` | significant | required |
+
+Case-insensitive decoders accept non-canonical letter case, but encoders always
+produce uppercase Base16 and Base32-family output. Compare canonical
+re-encodings when a single textual representation matters.
+
+## Compatibility note
+
+`std.crypto.sha256.sha256_hex` remains unchanged for its existing callers. It
+emits fixed-length lowercase hexadecimal, while RFC 4648 publishes uppercase
+Base16. Current implementation differs from RFC 4648. Compliance decision
+required. Defer to Eric Hartford.
+
+## RFC 4648 verification checklist
+
+Evidence files:
+
+- `test/behavior/behav_std_encoding_rfc4648_vectors.w` — alphabets, published
+  vectors, terminal quanta, case, and Section 9 examples.
+- `test/behavior/behav_std_encoding_rfc4648_strict.w` — exact errors,
+  non-alphabet bytes, padding, and unused-bit rejection.
+- `test/behavior/behav_std_encoding_rfc4648_properties.w` — deterministic
+  round trips, boundaries, large input, ownership, and Base32hex order.
+
+| ID | RFC source | Verified requirement | Evidence | Status |
+|---|---|---|---|---|
+| R01 | §3.1 | Encoders insert no line feeds | vectors + strict round trips | Passed |
+| R02 | §3.2 | Required padding is emitted and unpadded input rejected | terminal-quanta + length cases | Passed |
+| R03 | §3.3 | Non-alphabet bytes are rejected | whitespace, CRLF, NUL, non-ASCII, cross-alphabet cases | Passed |
+| R04 | §3.4 | Each named alphabet is selected explicitly; Base32 rejects `0` and `1` instead of remapping them | exhaustive alphabet loops + rejection cases | Passed |
+| R05 | §3.5 | Encoders zero unused bits; decoders reject non-zero unused bits | every terminal shape + `NonCanonicalBits` mutations | Passed |
+| R06 | §4/Table 1 | Base64 uses MSB-first 24-to-4 grouping and `+/` | 64-value alphabet, Section 9 examples, round trips | Passed |
+| R07 | §5/Table 2 | Base64URL uses `-_` and default padding | forced values 62/63 + cross-alphabet rejection | Passed |
+| R08 | §6/Table 3 | Base32 uses `A-Z2-7` and all four partial quanta | 32-value alphabet + terminal tests | Passed |
+| R09 | §7/Table 4 | Base32hex uses `0-9A-V` and preserves bit-wise order | 32-value alphabet + exhaustive two-octet order test | Passed |
+| R10 | §8/Table 5 | Base16 emits uppercase, has no padding, and decodes case-insensitively | nibble loop + case/length/error cases | Passed |
+| R11 | §9 | Published Base64 examples and Base32 grouping are reproduced | explicit Base64 octet examples + Base32 RFC vectors/source grouping review | Passed |
+| R12 | §10 | All published vectors use explicit ASCII octets and pass | seven vector lengths across every published family | Passed |
+| R13 | §11 | Non-normative ISO C99 sample is not imported | safe-With source/dependency audit | Passed |
+| R14 | §12 | Malformed input, including NUL, remains memory-safe | strict corpus + native debug allocator | Passed |
+| R15 | §12 | Ignored bytes and unused bits cannot form covert channels | strict rejection and canonical-bit tests | Passed |
+| R16 | §12 | Case-insensitive input is intentional but canonical output is uppercase | exhaustive/lowercase decode and re-encode tests | Passed |
+| R17 | §12 | Encoding supplies no confidentiality or entropy | module/API security documentation | Passed |
+
+### API and implementation checks
+
+| ID | Verified contract | Evidence | Status |
+|---|---|---|---|
+| A01 | All five modules and shared error compile together | focused behavior files | Passed |
+| A02 | Bound arrays and vectors remain reusable after encoder calls; decoder text is borrowed | ownership property cases | Passed |
+| A03 | Error precedence and zero-based context are deterministic | exact-error strict cases | Passed |
+| A04 | Complete validation precedes output construction | decoder source review | Passed |
+| A05 | Checked lengths and exact capacities are used | source review + boundary lengths | Passed |
+| A06 | Runtime and output storage are linear | source review + 65,536-byte corpus | Passed |
+| A07 | No unsafe, FFI, external codec, runtime/compiler edit, or `sha256_hex` mutation exists | file-by-file dependency/diff audit | Passed |
+
+### RFC Editor errata
+
+The source snapshot is unchanged. The live
+[RFC Editor registry](https://www.rfc-editor.org/errata_search.php?rfc=4648)
+contains the six entries below. Verified errata inform the reading; Reported
+errata are analyzed without being treated as corrections. `Passed` records
+coverage of that treatment, not promotion of an erratum's registry status.
+
+| EID | Registry status | Treatment | Evidence | Status |
+|---|---|---|---|---|
+| 2837 | Verified / Editorial | Reference article is `000316`; no codec effect | source review | Passed |
+| 5855 | Verified / Editorial | Vector strings are explicit ASCII octets | vector fixtures | Passed |
+| 7514 | Verified / Editorial | Read “does not hold”; canonical-bit rule unchanged | unused-bit tests | Passed |
+| 9030 | Verified / Editorial | Read “a URI”; Base64URL behavior unchanged | Base64URL tests/docs | Passed |
+| 4889 | Reported / Technical | Published Base32 octet/group rules and vectors remain controlling | Base32 vectors/grouping tests | Passed |
+| 8669 | Reported / Technical | Sections 4/9 and vectors establish Base64 bit order | Base64 examples/vectors | Passed |
+
+### Repository gates
+
+| Gate | Command/evidence | Status |
+|---|---|---|
+| Focused behavior | three direct `with run` cases | Passed |
+| Memory safety | three `with run --debug-alloc` cases, zero leaks/errors | Passed |
+| Self-host build | `with build` at repository-mandated `-O1` | Passed |
+| Fixpoint | `with build :fixpoint`, stage2 equals stage3 | Passed |
+| Full suite | `with build :test` | Passed |
+| Evidence record | `with build :test-green`, `with build :last-green` | Passed |
+| Production review | Rule 13 correctness, safety, test, dependency, documentation, and scope audit | Passed |
+
+`with build :last-green` also emitted the tracked #680 undeclared-edge notes;
+the command completed successfully and archived the passing evidence.

--- a/docs/with-specification.md
+++ b/docs/with-specification.md
@@ -10740,6 +10740,7 @@ what users import.
 | `std.rc` | `Rc[T]`, `Arc[T]`, explicit shared ownership | — |
 | `std.collections` | Vec, HashMap, HashSet, BTreeMap, SlotMap, Handle | — |
 | `std.string` | String/StrView types and methods | `string.h`, `ctype.h` |
+| `std.encoding` | Native RFC 4648 Base16, Base32, Base32hex, Base64, and Base64URL data encodings | — |
 | `std.net` | TCP, UDP, DNS | `sys/socket.h`, `netdb.h` |
 | `std.thread` | OS-level threading | `pthread.h` |
 | `std.sync` | Mutex, RwLock, Atomic, Condvar, Barrier, Once | `pthread.h`, `stdatomic.h` |

--- a/lib/std/encoding.w
+++ b/lib/std/encoding.w
@@ -1,0 +1,8 @@
+// std.encoding — shared encoding error surface.
+
+/// Why encoded input could not be decoded.
+pub error DecodeError =
+    | InvalidLength(length: i64)
+    | InvalidByte(offset: i64, byte: u8)
+    | InvalidPadding(offset: i64)
+    | NonCanonicalBits(offset: i64)

--- a/lib/std/encoding/base16.w
+++ b/lib/std/encoding/base16.w
@@ -1,0 +1,47 @@
+// RFC 4648 Base16. Encoding is representation, not confidentiality.
+
+use std.collections
+use std.result
+use std.string
+use std.encoding
+
+const BASE16_ALPHABET = "0123456789ABCDEF"
+
+fn base16_value(byte: i32):
+    if byte >= 48 and byte <= 57:
+        return byte - 48
+    if byte >= 65 and byte <= 70:
+        return byte - 65 + 10
+    if byte >= 97 and byte <= 102:
+        return byte - 97 + 10
+    -1
+
+/// Encode bytes as canonical uppercase RFC 4648 Base16.
+pub fn base16_encode(data: []u8) -> str:
+    var out = StringBuilder.with_capacity(data.len() * 2)
+    var i: i64 = 0
+    while i < data.len():
+        let byte = data[i] as i32
+        out.push_byte(BASE16_ALPHABET.byte_at((byte >> 4) as i64) as u8)
+        out.push_byte(BASE16_ALPHABET.byte_at((byte & 15) as i64) as u8)
+        i = i + 1
+    out.to_str()
+
+/// Decode case-insensitive RFC 4648 Base16, rejecting every non-alphabet byte.
+pub fn base16_decode(text: &str) -> Result[Vec[u8], DecodeError]:
+    if text.len() % 2 != 0:
+        return Err(.InvalidLength(text.len()))
+    var validate_i: i64 = 0
+    while validate_i < text.len():
+        let byte = text.byte_at(validate_i)
+        if base16_value(byte) < 0:
+            return Err(.InvalidByte(validate_i, byte as u8))
+        validate_i = validate_i + 1
+    let out = Vec[u8].with_capacity(text.len() / 2)
+    var i: i64 = 0
+    while i < text.len():
+        let high = base16_value(text.byte_at(i))
+        let low = base16_value(text.byte_at(i + 1))
+        out.push(((high << 4) | low) as u8)
+        i = i + 2
+    out

--- a/lib/std/encoding/base32.w
+++ b/lib/std/encoding/base32.w
@@ -1,0 +1,107 @@
+// RFC 4648 Base32. Encoding is representation, not confidentiality.
+
+use std.collections
+use std.result
+use std.string
+use std.encoding
+
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+fn base32_value(byte: i32):
+    if byte >= 65 and byte <= 90:
+        return byte - 65
+    if byte >= 97 and byte <= 122:
+        return byte - 97
+    if byte >= 50 and byte <= 55:
+        return byte - 50 + 26
+    -1
+
+fn base32_encoded_len(length: i64):
+    let full = length / 5
+    let tail = if length % 5 == 0: 0 else: 8
+    full * 8 + tail
+
+fn base32_validate(text: &str) -> Result[i64, DecodeError]:
+    if text.len() % 8 != 0:
+        return Err(.InvalidLength(text.len()))
+    var first_pad: i64 = -1
+    var i: i64 = 0
+    while i < text.len():
+        let byte = text.byte_at(i)
+        if byte == 61:
+            if first_pad < 0:
+                let remaining = text.len() - i
+                if remaining != 1 and remaining != 3 and remaining != 4 and remaining != 6:
+                    return Err(.InvalidPadding(i))
+                first_pad = i
+        else:
+            if first_pad >= 0:
+                return Err(.InvalidPadding(i))
+            if base32_value(byte) < 0:
+                return Err(.InvalidByte(i, byte as u8))
+        i = i + 1
+    let padding = if first_pad < 0: 0 else: text.len() - first_pad
+    if padding > 0:
+        let offset = first_pad - 1
+        let value = base32_value(text.byte_at(offset))
+        let mask = if padding == 6: 3 else if padding == 4: 15 else if padding == 3: 1 else: 7
+        if value & mask != 0:
+            return Err(.NonCanonicalBits(offset))
+    padding
+
+/// Encode bytes as canonical uppercase, padded RFC 4648 Base32.
+pub fn base32_encode(data: []u8) -> str:
+    var out = StringBuilder.with_capacity(base32_encoded_len(data.len()))
+    var offset: i64 = 0
+    while offset < data.len():
+        let remaining = data.len() - offset
+        let count = if remaining >= 5: 5 else: remaining
+        let b0 = data[offset] as i32
+        let b1 = if count > 1: data[offset + 1] as i32 else: 0
+        let b2 = if count > 2: data[offset + 2] as i32 else: 0
+        let b3 = if count > 3: data[offset + 3] as i32 else: 0
+        let b4 = if count > 4: data[offset + 4] as i32 else: 0
+        let symbols = if count == 1: 2 else if count == 2: 4 else if count == 3: 5 else if count == 4: 7 else: 8
+        let v0 = b0 >> 3
+        let v1 = ((b0 & 7) << 2) | (b1 >> 6)
+        let v2 = (b1 >> 1) & 31
+        let v3 = ((b1 & 1) << 4) | (b2 >> 4)
+        let v4 = ((b2 & 15) << 1) | (b3 >> 7)
+        let v5 = (b3 >> 2) & 31
+        let v6 = ((b3 & 3) << 3) | (b4 >> 5)
+        let v7 = b4 & 31
+        out.push_byte(BASE32_ALPHABET.byte_at(v0 as i64) as u8)
+        out.push_byte(BASE32_ALPHABET.byte_at(v1 as i64) as u8)
+        if symbols > 2: out.push_byte(BASE32_ALPHABET.byte_at(v2 as i64) as u8) else: out.push_byte(61 as u8)
+        if symbols > 3: out.push_byte(BASE32_ALPHABET.byte_at(v3 as i64) as u8) else: out.push_byte(61 as u8)
+        if symbols > 4: out.push_byte(BASE32_ALPHABET.byte_at(v4 as i64) as u8) else: out.push_byte(61 as u8)
+        if symbols > 5: out.push_byte(BASE32_ALPHABET.byte_at(v5 as i64) as u8) else: out.push_byte(61 as u8)
+        if symbols > 6: out.push_byte(BASE32_ALPHABET.byte_at(v6 as i64) as u8) else: out.push_byte(61 as u8)
+        if symbols > 7: out.push_byte(BASE32_ALPHABET.byte_at(v7 as i64) as u8) else: out.push_byte(61 as u8)
+        offset = offset + count
+    out.to_str()
+
+/// Decode padded RFC 4648 Base32, accepting ASCII letter case variants.
+pub fn base32_decode(text: &str) -> Result[Vec[u8], DecodeError]:
+    let padding = base32_validate(text)?
+    let removed = if padding == 6: 4 else if padding == 4: 3 else if padding == 3: 2 else if padding == 1: 1 else: 0
+    let out = Vec[u8].with_capacity((text.len() / 8) * 5 - removed)
+    var offset: i64 = 0
+    while offset < text.len():
+        let final_quantum = offset + 8 == text.len()
+        let symbols = if final_quantum: 8 - padding else: 8
+        let v0 = base32_value(text.byte_at(offset))
+        let v1 = base32_value(text.byte_at(offset + 1))
+        let v2 = if symbols > 2: base32_value(text.byte_at(offset + 2)) else: 0
+        let v3 = if symbols > 3: base32_value(text.byte_at(offset + 3)) else: 0
+        let v4 = if symbols > 4: base32_value(text.byte_at(offset + 4)) else: 0
+        let v5 = if symbols > 5: base32_value(text.byte_at(offset + 5)) else: 0
+        let v6 = if symbols > 6: base32_value(text.byte_at(offset + 6)) else: 0
+        let v7 = if symbols > 7: base32_value(text.byte_at(offset + 7)) else: 0
+        out.push(((v0 << 3) | (v1 >> 2)) as u8)
+        if symbols >= 4: out.push((((v1 & 3) << 6) | (v2 << 1) | (v3 >> 4)) as u8)
+        if symbols >= 5: out.push((((v3 & 15) << 4) | (v4 >> 1)) as u8)
+        if symbols >= 7: out.push((((v4 & 1) << 7) | (v5 << 2) | (v6 >> 3)) as u8)
+        if symbols == 8: out.push((((v6 & 7) << 5) | v7) as u8)
+        offset = offset + 8
+    out

--- a/lib/std/encoding/base32hex.w
+++ b/lib/std/encoding/base32hex.w
@@ -1,0 +1,107 @@
+// RFC 4648 Base32 extended hex. Encoding is representation, not confidentiality.
+
+use std.collections
+use std.result
+use std.string
+use std.encoding
+
+const BASE32HEX_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
+
+fn base32hex_value(byte: i32):
+    if byte >= 48 and byte <= 57:
+        return byte - 48
+    if byte >= 65 and byte <= 86:
+        return byte - 65 + 10
+    if byte >= 97 and byte <= 118:
+        return byte - 97 + 10
+    -1
+
+fn base32hex_encoded_len(length: i64):
+    let full = length / 5
+    let tail = if length % 5 == 0: 0 else: 8
+    full * 8 + tail
+
+fn base32hex_validate(text: &str) -> Result[i64, DecodeError]:
+    if text.len() % 8 != 0:
+        return Err(.InvalidLength(text.len()))
+    var first_pad: i64 = -1
+    var i: i64 = 0
+    while i < text.len():
+        let byte = text.byte_at(i)
+        if byte == 61:
+            if first_pad < 0:
+                let remaining = text.len() - i
+                if remaining != 1 and remaining != 3 and remaining != 4 and remaining != 6:
+                    return Err(.InvalidPadding(i))
+                first_pad = i
+        else:
+            if first_pad >= 0:
+                return Err(.InvalidPadding(i))
+            if base32hex_value(byte) < 0:
+                return Err(.InvalidByte(i, byte as u8))
+        i = i + 1
+    let padding = if first_pad < 0: 0 else: text.len() - first_pad
+    if padding > 0:
+        let offset = first_pad - 1
+        let value = base32hex_value(text.byte_at(offset))
+        let mask = if padding == 6: 3 else if padding == 4: 15 else if padding == 3: 1 else: 7
+        if value & mask != 0:
+            return Err(.NonCanonicalBits(offset))
+    padding
+
+/// Encode bytes as canonical uppercase, padded RFC 4648 Base32hex.
+pub fn base32hex_encode(data: []u8) -> str:
+    var out = StringBuilder.with_capacity(base32hex_encoded_len(data.len()))
+    var offset: i64 = 0
+    while offset < data.len():
+        let remaining = data.len() - offset
+        let count = if remaining >= 5: 5 else: remaining
+        let b0 = data[offset] as i32
+        let b1 = if count > 1: data[offset + 1] as i32 else: 0
+        let b2 = if count > 2: data[offset + 2] as i32 else: 0
+        let b3 = if count > 3: data[offset + 3] as i32 else: 0
+        let b4 = if count > 4: data[offset + 4] as i32 else: 0
+        let symbols = if count == 1: 2 else if count == 2: 4 else if count == 3: 5 else if count == 4: 7 else: 8
+        let v0 = b0 >> 3
+        let v1 = ((b0 & 7) << 2) | (b1 >> 6)
+        let v2 = (b1 >> 1) & 31
+        let v3 = ((b1 & 1) << 4) | (b2 >> 4)
+        let v4 = ((b2 & 15) << 1) | (b3 >> 7)
+        let v5 = (b3 >> 2) & 31
+        let v6 = ((b3 & 3) << 3) | (b4 >> 5)
+        let v7 = b4 & 31
+        out.push_byte(BASE32HEX_ALPHABET.byte_at(v0 as i64) as u8)
+        out.push_byte(BASE32HEX_ALPHABET.byte_at(v1 as i64) as u8)
+        if symbols > 2: out.push_byte(BASE32HEX_ALPHABET.byte_at(v2 as i64) as u8) else: out.push_byte(61 as u8)
+        if symbols > 3: out.push_byte(BASE32HEX_ALPHABET.byte_at(v3 as i64) as u8) else: out.push_byte(61 as u8)
+        if symbols > 4: out.push_byte(BASE32HEX_ALPHABET.byte_at(v4 as i64) as u8) else: out.push_byte(61 as u8)
+        if symbols > 5: out.push_byte(BASE32HEX_ALPHABET.byte_at(v5 as i64) as u8) else: out.push_byte(61 as u8)
+        if symbols > 6: out.push_byte(BASE32HEX_ALPHABET.byte_at(v6 as i64) as u8) else: out.push_byte(61 as u8)
+        if symbols > 7: out.push_byte(BASE32HEX_ALPHABET.byte_at(v7 as i64) as u8) else: out.push_byte(61 as u8)
+        offset = offset + count
+    out.to_str()
+
+/// Decode padded RFC 4648 Base32hex, accepting ASCII letter case variants.
+pub fn base32hex_decode(text: &str) -> Result[Vec[u8], DecodeError]:
+    let padding = base32hex_validate(text)?
+    let removed = if padding == 6: 4 else if padding == 4: 3 else if padding == 3: 2 else if padding == 1: 1 else: 0
+    let out = Vec[u8].with_capacity((text.len() / 8) * 5 - removed)
+    var offset: i64 = 0
+    while offset < text.len():
+        let final_quantum = offset + 8 == text.len()
+        let symbols = if final_quantum: 8 - padding else: 8
+        let v0 = base32hex_value(text.byte_at(offset))
+        let v1 = base32hex_value(text.byte_at(offset + 1))
+        let v2 = if symbols > 2: base32hex_value(text.byte_at(offset + 2)) else: 0
+        let v3 = if symbols > 3: base32hex_value(text.byte_at(offset + 3)) else: 0
+        let v4 = if symbols > 4: base32hex_value(text.byte_at(offset + 4)) else: 0
+        let v5 = if symbols > 5: base32hex_value(text.byte_at(offset + 5)) else: 0
+        let v6 = if symbols > 6: base32hex_value(text.byte_at(offset + 6)) else: 0
+        let v7 = if symbols > 7: base32hex_value(text.byte_at(offset + 7)) else: 0
+        out.push(((v0 << 3) | (v1 >> 2)) as u8)
+        if symbols >= 4: out.push((((v1 & 3) << 6) | (v2 << 1) | (v3 >> 4)) as u8)
+        if symbols >= 5: out.push((((v3 & 15) << 4) | (v4 >> 1)) as u8)
+        if symbols >= 7: out.push((((v4 & 1) << 7) | (v5 << 2) | (v6 >> 3)) as u8)
+        if symbols == 8: out.push((((v6 & 7) << 5) | v7) as u8)
+        offset = offset + 8
+    out

--- a/lib/std/encoding/base64.w
+++ b/lib/std/encoding/base64.w
@@ -1,0 +1,92 @@
+// RFC 4648 Base64. Encoding is representation, not confidentiality.
+
+use std.collections
+use std.result
+use std.string
+use std.encoding
+
+const BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+fn base64_value(byte: i32):
+    if byte >= 65 and byte <= 90:
+        return byte - 65
+    if byte >= 97 and byte <= 122:
+        return byte - 97 + 26
+    if byte >= 48 and byte <= 57:
+        return byte - 48 + 52
+    if byte == 43:
+        return 62
+    if byte == 47:
+        return 63
+    -1
+
+fn base64_encoded_len(length: i64):
+    let full = length / 3
+    let tail = if length % 3 == 0: 0 else: 4
+    full * 4 + tail
+
+fn base64_validate(text: &str) -> Result[i64, DecodeError]:
+    if text.len() % 4 != 0:
+        return Err(.InvalidLength(text.len()))
+    var first_pad: i64 = -1
+    var i: i64 = 0
+    while i < text.len():
+        let byte = text.byte_at(i)
+        if byte == 61:
+            if first_pad < 0:
+                if text.len() - i > 2:
+                    return Err(.InvalidPadding(i))
+                first_pad = i
+        else:
+            if first_pad >= 0:
+                return Err(.InvalidPadding(i))
+            if base64_value(byte) < 0:
+                return Err(.InvalidByte(i, byte as u8))
+        i = i + 1
+    let padding = if first_pad < 0: 0 else: text.len() - first_pad
+    if padding > 0:
+        let offset = first_pad - 1
+        let value = base64_value(text.byte_at(offset))
+        let mask = if padding == 2: 15 else: 3
+        if value & mask != 0:
+            return Err(.NonCanonicalBits(offset))
+    padding
+
+/// Encode bytes as canonical padded RFC 4648 Base64.
+pub fn base64_encode(data: []u8) -> str:
+    var out = StringBuilder.with_capacity(base64_encoded_len(data.len()))
+    var offset: i64 = 0
+    while offset < data.len():
+        let remaining = data.len() - offset
+        let count = if remaining >= 3: 3 else: remaining
+        let b0 = data[offset] as i32
+        let b1 = if count > 1: data[offset + 1] as i32 else: 0
+        let b2 = if count > 2: data[offset + 2] as i32 else: 0
+        let v0 = b0 >> 2
+        let v1 = ((b0 & 3) << 4) | (b1 >> 4)
+        let v2 = ((b1 & 15) << 2) | (b2 >> 6)
+        let v3 = b2 & 63
+        out.push_byte(BASE64_ALPHABET.byte_at(v0 as i64) as u8)
+        out.push_byte(BASE64_ALPHABET.byte_at(v1 as i64) as u8)
+        if count > 1: out.push_byte(BASE64_ALPHABET.byte_at(v2 as i64) as u8) else: out.push_byte(61 as u8)
+        if count > 2: out.push_byte(BASE64_ALPHABET.byte_at(v3 as i64) as u8) else: out.push_byte(61 as u8)
+        offset = offset + count
+    out.to_str()
+
+/// Decode padded RFC 4648 Base64 with strict alphabet and unused-bit checks.
+pub fn base64_decode(text: &str) -> Result[Vec[u8], DecodeError]:
+    let padding = base64_validate(text)?
+    let out = Vec[u8].with_capacity((text.len() / 4) * 3 - padding)
+    var offset: i64 = 0
+    while offset < text.len():
+        let final_quantum = offset + 4 == text.len()
+        let symbols = if final_quantum: 4 - padding else: 4
+        let v0 = base64_value(text.byte_at(offset))
+        let v1 = base64_value(text.byte_at(offset + 1))
+        let v2 = if symbols > 2: base64_value(text.byte_at(offset + 2)) else: 0
+        let v3 = if symbols > 3: base64_value(text.byte_at(offset + 3)) else: 0
+        out.push(((v0 << 2) | (v1 >> 4)) as u8)
+        if symbols >= 3: out.push((((v1 & 15) << 4) | (v2 >> 2)) as u8)
+        if symbols == 4: out.push((((v2 & 3) << 6) | v3) as u8)
+        offset = offset + 4
+    out

--- a/lib/std/encoding/base64url.w
+++ b/lib/std/encoding/base64url.w
@@ -1,0 +1,92 @@
+// RFC 4648 Base64URL. Encoding is representation, not confidentiality.
+
+use std.collections
+use std.result
+use std.string
+use std.encoding
+
+const BASE64URL_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+
+fn base64url_value(byte: i32):
+    if byte >= 65 and byte <= 90:
+        return byte - 65
+    if byte >= 97 and byte <= 122:
+        return byte - 97 + 26
+    if byte >= 48 and byte <= 57:
+        return byte - 48 + 52
+    if byte == 45:
+        return 62
+    if byte == 95:
+        return 63
+    -1
+
+fn base64url_encoded_len(length: i64):
+    let full = length / 3
+    let tail = if length % 3 == 0: 0 else: 4
+    full * 4 + tail
+
+fn base64url_validate(text: &str) -> Result[i64, DecodeError]:
+    if text.len() % 4 != 0:
+        return Err(.InvalidLength(text.len()))
+    var first_pad: i64 = -1
+    var i: i64 = 0
+    while i < text.len():
+        let byte = text.byte_at(i)
+        if byte == 61:
+            if first_pad < 0:
+                if text.len() - i > 2:
+                    return Err(.InvalidPadding(i))
+                first_pad = i
+        else:
+            if first_pad >= 0:
+                return Err(.InvalidPadding(i))
+            if base64url_value(byte) < 0:
+                return Err(.InvalidByte(i, byte as u8))
+        i = i + 1
+    let padding = if first_pad < 0: 0 else: text.len() - first_pad
+    if padding > 0:
+        let offset = first_pad - 1
+        let value = base64url_value(text.byte_at(offset))
+        let mask = if padding == 2: 15 else: 3
+        if value & mask != 0:
+            return Err(.NonCanonicalBits(offset))
+    padding
+
+/// Encode bytes as canonical padded RFC 4648 Base64URL.
+pub fn base64url_encode(data: []u8) -> str:
+    var out = StringBuilder.with_capacity(base64url_encoded_len(data.len()))
+    var offset: i64 = 0
+    while offset < data.len():
+        let remaining = data.len() - offset
+        let count = if remaining >= 3: 3 else: remaining
+        let b0 = data[offset] as i32
+        let b1 = if count > 1: data[offset + 1] as i32 else: 0
+        let b2 = if count > 2: data[offset + 2] as i32 else: 0
+        let v0 = b0 >> 2
+        let v1 = ((b0 & 3) << 4) | (b1 >> 4)
+        let v2 = ((b1 & 15) << 2) | (b2 >> 6)
+        let v3 = b2 & 63
+        out.push_byte(BASE64URL_ALPHABET.byte_at(v0 as i64) as u8)
+        out.push_byte(BASE64URL_ALPHABET.byte_at(v1 as i64) as u8)
+        if count > 1: out.push_byte(BASE64URL_ALPHABET.byte_at(v2 as i64) as u8) else: out.push_byte(61 as u8)
+        if count > 2: out.push_byte(BASE64URL_ALPHABET.byte_at(v3 as i64) as u8) else: out.push_byte(61 as u8)
+        offset = offset + count
+    out.to_str()
+
+/// Decode padded RFC 4648 Base64URL with strict alphabet and unused-bit checks.
+pub fn base64url_decode(text: &str) -> Result[Vec[u8], DecodeError]:
+    let padding = base64url_validate(text)?
+    let out = Vec[u8].with_capacity((text.len() / 4) * 3 - padding)
+    var offset: i64 = 0
+    while offset < text.len():
+        let final_quantum = offset + 4 == text.len()
+        let symbols = if final_quantum: 4 - padding else: 4
+        let v0 = base64url_value(text.byte_at(offset))
+        let v1 = base64url_value(text.byte_at(offset + 1))
+        let v2 = if symbols > 2: base64url_value(text.byte_at(offset + 2)) else: 0
+        let v3 = if symbols > 3: base64url_value(text.byte_at(offset + 3)) else: 0
+        out.push(((v0 << 2) | (v1 >> 4)) as u8)
+        if symbols >= 3: out.push((((v1 & 15) << 4) | (v2 >> 2)) as u8)
+        if symbols == 4: out.push((((v2 & 3) << 6) | v3) as u8)
+        offset = offset + 4
+    out

--- a/test/behavior/behav_std_encoding_rfc4648_properties.w
+++ b/test/behavior/behav_std_encoding_rfc4648_properties.w
@@ -1,0 +1,44 @@
+//! expect-stdout: ok
+
+use std.collections
+use std.encoding.base16
+
+fn corpus(length: i64):
+    let out = Vec[u8].with_capacity(length)
+    var i: i64 = 0
+    while i < length:
+        out.push(((i * 73 + length * 29 + 17) % 256) as u8)
+        i = i + 1
+    out
+
+fn assert_bytes_eq(actual: &Vec[u8], expected: &Vec[u8]):
+    assert(actual.len() == expected.len())
+    var i: i64 = 0
+    while i < expected.len():
+        assert(actual.get(i) == expected.get(i))
+        i = i + 1
+
+fn assert_base16_round_trip(data: Vec[u8]):
+    let encoded = base16_encode(data)
+    assert(encoded.len() == data.len() * 2)
+    assert_bytes_eq(&base16_decode(encoded).unwrap(), &data)
+
+fn test_base16_boundaries:
+    var length: i64 = 0
+    while length <= 257:
+        assert_base16_round_trip(corpus(length))
+        length = length + 1
+    assert_base16_round_trip(corpus(65536))
+
+fn test_base16_borrowed_inputs:
+    let fixed = [1 as u8, 2 as u8, 3 as u8]
+    let values = corpus(3)
+    assert(base16_encode(fixed) == "010203")
+    assert(fixed[0] == 1 as u8)
+    assert(base16_encode(values) == "68B1FA")
+    assert(values.len() == 3)
+
+fn main:
+    test_base16_boundaries()
+    test_base16_borrowed_inputs()
+    print("ok")

--- a/test/behavior/behav_std_encoding_rfc4648_properties.w
+++ b/test/behavior/behav_std_encoding_rfc4648_properties.w
@@ -5,6 +5,8 @@ use std.string
 use std.encoding.base16
 use std.encoding.base32
 use std.encoding.base32hex
+use std.encoding.base64
+use std.encoding.base64url
 
 fn corpus(length: i64):
     let out = Vec[u8].with_capacity(length)
@@ -100,6 +102,59 @@ fn test_base32_borrowed_inputs:
     assert(base32hex_encode(values).len() == 8)
     assert(values.len() == 5)
 
+fn assert_base64_round_trips(data: Vec[u8]):
+    let encoded = base64_encode(data)
+    let encoded_url = base64url_encode(data)
+    assert(encoded.len() == ((data.len() + 2) / 3) * 4)
+    assert(encoded_url.len() == encoded.len())
+    assert_bytes_eq(&base64_decode(encoded).unwrap(), &data)
+    assert_bytes_eq(&base64url_decode(encoded_url).unwrap(), &data)
+
+fn test_base64_boundary_round_trips:
+    var length: i64 = 0
+    while length <= 257:
+        assert_base64_round_trips(corpus(length))
+        length = length + 1
+    assert_base64_round_trips(corpus(65536))
+
+fn test_base64_exhaustive_short_inputs:
+    var value = 0
+    while value < 256:
+        let input = [value as u8]
+        let encoded = base64_encode(input)
+        let encoded_url = base64url_encode(input)
+        let decoded = base64_decode(encoded).unwrap()
+        let decoded_url = base64url_decode(encoded_url).unwrap()
+        assert(decoded.len() == 1)
+        assert(decoded_url.len() == 1)
+        assert(decoded.get(0) == input[0])
+        assert(decoded_url.get(0) == input[0])
+        value = value + 1
+    value = 0
+    while value < 65536:
+        let input = [(value >> 8) as u8, (value & 255) as u8]
+        let encoded = base64_encode(input)
+        let encoded_url = base64url_encode(input)
+        let decoded = base64_decode(encoded).unwrap()
+        let decoded_url = base64url_decode(encoded_url).unwrap()
+        assert(decoded.len() == 2)
+        assert(decoded_url.len() == 2)
+        assert(decoded.get(0) == input[0])
+        assert(decoded.get(1) == input[1])
+        assert(decoded_url.get(0) == input[0])
+        assert(decoded_url.get(1) == input[1])
+        value = value + 1
+
+fn test_base64_borrowed_inputs:
+    let fixed = [1 as u8, 2 as u8, 3 as u8]
+    let values = corpus(3)
+    assert(base64_encode(fixed) == "AQID")
+    assert(base64url_encode(fixed) == "AQID")
+    assert(fixed[0] == 1 as u8)
+    assert(base64_encode(values) == "aLH6")
+    assert(base64url_encode(values) == "aLH6")
+    assert(values.len() == 3)
+
 fn main:
     test_base16_boundaries()
     test_base16_borrowed_inputs()
@@ -107,4 +162,7 @@ fn main:
     test_base32hex_ordering()
     test_base32_all_single_octets()
     test_base32_borrowed_inputs()
+    test_base64_boundary_round_trips()
+    test_base64_exhaustive_short_inputs()
+    test_base64_borrowed_inputs()
     print("ok")

--- a/test/behavior/behav_std_encoding_rfc4648_properties.w
+++ b/test/behavior/behav_std_encoding_rfc4648_properties.w
@@ -1,7 +1,10 @@
 //! expect-stdout: ok
 
 use std.collections
+use std.string
 use std.encoding.base16
+use std.encoding.base32
+use std.encoding.base32hex
 
 fn corpus(length: i64):
     let out = Vec[u8].with_capacity(length)
@@ -38,7 +41,70 @@ fn test_base16_borrowed_inputs:
     assert(base16_encode(values) == "68B1FA")
     assert(values.len() == 3)
 
+fn assert_base32_round_trips(data: Vec[u8]):
+    let encoded = base32_encode(data)
+    let encoded_hex = base32hex_encode(data)
+    assert(encoded.len() == ((data.len() + 4) / 5) * 8)
+    assert(encoded_hex.len() == encoded.len())
+    assert_bytes_eq(&base32_decode(encoded).unwrap(), &data)
+    assert_bytes_eq(&base32hex_decode(encoded_hex).unwrap(), &data)
+
+fn test_base32_boundary_round_trips:
+    var length: i64 = 0
+    while length <= 257:
+        assert_base32_round_trips(corpus(length))
+        length = length + 1
+    assert_base32_round_trips(corpus(65536))
+
+fn test_base32hex_ordering:
+    var previous = ""
+    var value = 0
+    while value < 65536:
+        let bytes = [(value >> 8) as u8, (value & 255) as u8]
+        let current = base32hex_encode(bytes)
+        let standard = base32_encode(bytes)
+        let decoded = base32_decode(standard).unwrap()
+        let decoded_hex = base32hex_decode(current).unwrap()
+        assert(decoded.len() == 2)
+        assert(decoded_hex.len() == 2)
+        assert(decoded.get(0) == bytes[0])
+        assert(decoded.get(1) == bytes[1])
+        assert(decoded_hex.get(0) == bytes[0])
+        assert(decoded_hex.get(1) == bytes[1])
+        if value > 0:
+            assert(string_cmp(previous, current) < 0)
+        previous = current
+        value = value + 1
+
+fn test_base32_all_single_octets:
+    var value = 0
+    while value < 256:
+        let input = [value as u8]
+        let encoded = base32_encode(input)
+        let encoded_hex = base32hex_encode(input)
+        let decoded = base32_decode(encoded).unwrap()
+        let decoded_hex = base32hex_decode(encoded_hex).unwrap()
+        assert(decoded.len() == 1)
+        assert(decoded_hex.len() == 1)
+        assert(decoded.get(0) == value as u8)
+        assert(decoded_hex.get(0) == value as u8)
+        value = value + 1
+
+fn test_base32_borrowed_inputs:
+    let fixed = [1 as u8, 2 as u8, 3 as u8, 4 as u8, 5 as u8]
+    let values = corpus(5)
+    assert(base32_encode(fixed).len() == 8)
+    assert(base32hex_encode(fixed).len() == 8)
+    assert(fixed[0] == 1 as u8)
+    assert(base32_encode(values).len() == 8)
+    assert(base32hex_encode(values).len() == 8)
+    assert(values.len() == 5)
+
 fn main:
     test_base16_boundaries()
     test_base16_borrowed_inputs()
+    test_base32_boundary_round_trips()
+    test_base32hex_ordering()
+    test_base32_all_single_octets()
+    test_base32_borrowed_inputs()
     print("ok")

--- a/test/behavior/behav_std_encoding_rfc4648_strict.w
+++ b/test/behavior/behav_std_encoding_rfc4648_strict.w
@@ -5,6 +5,8 @@ use std.result
 use std.string
 use std.encoding
 use std.encoding.base16
+use std.encoding.base32
+use std.encoding.base32hex
 
 fn raw_text(bytes: []u8):
     var out = StringBuilder.with_capacity(bytes.len())
@@ -26,6 +28,16 @@ fn expect_invalid_byte(result: Result[Vec[u8], DecodeError], offset: i64, byte: 
             assert(actual_byte == byte)
         _ => assert(false)
 
+fn expect_invalid_padding(result: Result[Vec[u8], DecodeError], offset: i64):
+    match result:
+        Err(.InvalidPadding(actual)) => assert(actual == offset)
+        _ => assert(false)
+
+fn expect_noncanonical(result: Result[Vec[u8], DecodeError], offset: i64):
+    match result:
+        Err(.NonCanonicalBits(actual)) => assert(actual == offset)
+        _ => assert(false)
+
 fn test_base16_rejection:
     expect_invalid_length(base16_decode("0"), 1)
     expect_invalid_length(base16_decode("G"), 1)
@@ -37,6 +49,47 @@ fn test_base16_rejection:
     let non_ascii = [54 as u8, 54 as u8, 255 as u8, 70 as u8]
     expect_invalid_byte(base16_decode(raw_text(non_ascii)), 2, 255 as u8)
 
+fn test_base32_rejection:
+    expect_invalid_length(base32_decode("MY"), 2)
+    expect_invalid_length(base32hex_decode("CO"), 2)
+    expect_invalid_byte(base32_decode("M0======"), 1, 48 as u8)
+    expect_invalid_byte(base32_decode("M1======"), 1, 49 as u8)
+    expect_invalid_byte(base32hex_decode("CW======"), 1, 87 as u8)
+    expect_invalid_byte(base32_decode("M?======"), 1, 63 as u8)
+    expect_invalid_byte(base32_decode("M\n======"), 1, 10 as u8)
+    let nul = [77 as u8, 0 as u8, 61 as u8, 61 as u8, 61 as u8, 61 as u8, 61 as u8, 61 as u8]
+    expect_invalid_byte(base32_decode(raw_text(nul)), 1, 0 as u8)
+    let non_ascii = [77 as u8, 255 as u8, 61 as u8, 61 as u8, 61 as u8, 61 as u8, 61 as u8, 61 as u8]
+    expect_invalid_byte(base32_decode(raw_text(non_ascii)), 1, 255 as u8)
+    expect_invalid_byte(base32hex_decode("0?======"), 1, 63 as u8)
+    expect_invalid_byte(base32hex_decode("0\n======"), 1, 10 as u8)
+    let hex_nul = [48 as u8, 0 as u8, 61 as u8, 61 as u8, 61 as u8, 61 as u8, 61 as u8, 61 as u8]
+    expect_invalid_byte(base32hex_decode(raw_text(hex_nul)), 1, 0 as u8)
+    let hex_non_ascii = [48 as u8, 255 as u8, 61 as u8, 61 as u8, 61 as u8, 61 as u8, 61 as u8, 61 as u8]
+    expect_invalid_byte(base32hex_decode(raw_text(hex_non_ascii)), 1, 255 as u8)
+
+fn test_base32_padding:
+    expect_invalid_padding(base32_decode("A======="), 1)
+    expect_invalid_padding(base32_decode("AAAAAA=="), 6)
+    expect_invalid_padding(base32_decode("AA====A="), 6)
+    expect_invalid_padding(base32_decode("MZ====A="), 6)
+    expect_invalid_padding(base32hex_decode("0======="), 1)
+    expect_invalid_padding(base32hex_decode("000000=="), 6)
+    expect_invalid_padding(base32hex_decode("00====0="), 6)
+
+fn test_base32_noncanonical_bits:
+    expect_noncanonical(base32_decode("MZ======"), 1)
+    expect_noncanonical(base32_decode("MZXR===="), 3)
+    expect_noncanonical(base32_decode("MZXW7==="), 4)
+    expect_noncanonical(base32_decode("MZXW6YR="), 6)
+    expect_noncanonical(base32hex_decode("CP======"), 1)
+    expect_noncanonical(base32hex_decode("CPNH===="), 3)
+    expect_noncanonical(base32hex_decode("CPNMV==="), 4)
+    expect_noncanonical(base32hex_decode("CPNMUOH="), 6)
+
 fn main:
     test_base16_rejection()
+    test_base32_rejection()
+    test_base32_padding()
+    test_base32_noncanonical_bits()
     print("ok")

--- a/test/behavior/behav_std_encoding_rfc4648_strict.w
+++ b/test/behavior/behav_std_encoding_rfc4648_strict.w
@@ -1,0 +1,42 @@
+//! expect-stdout: ok
+
+use std.collections
+use std.result
+use std.string
+use std.encoding
+use std.encoding.base16
+
+fn raw_text(bytes: []u8):
+    var out = StringBuilder.with_capacity(bytes.len())
+    var i: i64 = 0
+    while i < bytes.len():
+        out.push_byte(bytes[i])
+        i = i + 1
+    out.to_str()
+
+fn expect_invalid_length(result: Result[Vec[u8], DecodeError], length: i64):
+    match result:
+        Err(.InvalidLength(actual)) => assert(actual == length)
+        _ => assert(false)
+
+fn expect_invalid_byte(result: Result[Vec[u8], DecodeError], offset: i64, byte: u8):
+    match result:
+        Err(.InvalidByte(actual_offset, actual_byte)) =>
+            assert(actual_offset == offset)
+            assert(actual_byte == byte)
+        _ => assert(false)
+
+fn test_base16_rejection:
+    expect_invalid_length(base16_decode("0"), 1)
+    expect_invalid_length(base16_decode("G"), 1)
+    expect_invalid_byte(base16_decode("GG"), 0, 71 as u8)
+    expect_invalid_byte(base16_decode("=="), 0, 61 as u8)
+    expect_invalid_byte(base16_decode("66\nF"), 2, 10 as u8)
+    let nul = [54 as u8, 54 as u8, 0 as u8, 70 as u8]
+    expect_invalid_byte(base16_decode(raw_text(nul)), 2, 0 as u8)
+    let non_ascii = [54 as u8, 54 as u8, 255 as u8, 70 as u8]
+    expect_invalid_byte(base16_decode(raw_text(non_ascii)), 2, 255 as u8)
+
+fn main:
+    test_base16_rejection()
+    print("ok")

--- a/test/behavior/behav_std_encoding_rfc4648_strict.w
+++ b/test/behavior/behav_std_encoding_rfc4648_strict.w
@@ -7,6 +7,8 @@ use std.encoding
 use std.encoding.base16
 use std.encoding.base32
 use std.encoding.base32hex
+use std.encoding.base64
+use std.encoding.base64url
 
 fn raw_text(bytes: []u8):
     var out = StringBuilder.with_capacity(bytes.len())
@@ -87,9 +89,56 @@ fn test_base32_noncanonical_bits:
     expect_noncanonical(base32hex_decode("CPNMV==="), 4)
     expect_noncanonical(base32hex_decode("CPNMUOH="), 6)
 
+fn test_base64_rejection:
+    expect_invalid_length(base64_decode("Zg"), 2)
+    expect_invalid_length(base64url_decode("Zg"), 2)
+    expect_invalid_length(base64_decode("A?="), 3)
+    expect_invalid_byte(base64_decode("-_8="), 0, 45 as u8)
+    expect_invalid_byte(base64url_decode("+/8="), 0, 43 as u8)
+    expect_invalid_byte(base64_decode("AA?="), 2, 63 as u8)
+    expect_invalid_byte(base64_decode("AA\n="), 2, 10 as u8)
+    expect_invalid_byte(base64_decode("AA\r\n"), 2, 13 as u8)
+    let nul = [65 as u8, 65 as u8, 0 as u8, 61 as u8]
+    expect_invalid_byte(base64_decode(raw_text(nul)), 2, 0 as u8)
+    let non_ascii = [65 as u8, 65 as u8, 255 as u8, 61 as u8]
+    expect_invalid_byte(base64_decode(raw_text(non_ascii)), 2, 255 as u8)
+    expect_invalid_byte(base64url_decode("AA?="), 2, 63 as u8)
+    expect_invalid_byte(base64url_decode("AA\n="), 2, 10 as u8)
+    let url_nul = [65 as u8, 65 as u8, 0 as u8, 61 as u8]
+    expect_invalid_byte(base64url_decode(raw_text(url_nul)), 2, 0 as u8)
+    let url_non_ascii = [65 as u8, 65 as u8, 255 as u8, 61 as u8]
+    expect_invalid_byte(base64url_decode(raw_text(url_non_ascii)), 2, 255 as u8)
+
+fn test_base64_padding:
+    expect_invalid_padding(base64_decode("A==="), 1)
+    expect_invalid_padding(base64_decode("=AAA"), 0)
+    expect_invalid_padding(base64_decode("AA=A"), 3)
+    expect_invalid_padding(base64_decode("Zh=A"), 3)
+    expect_invalid_padding(base64_decode("AAAA===="), 4)
+    expect_invalid_padding(base64url_decode("A==="), 1)
+    expect_invalid_padding(base64url_decode("=AAA"), 0)
+    expect_invalid_padding(base64url_decode("AA=A"), 3)
+    expect_invalid_padding(base64url_decode("Zh=A"), 3)
+    expect_invalid_padding(base64url_decode("AAAA===="), 4)
+
+fn test_base64_noncanonical_bits:
+    expect_noncanonical(base64_decode("Zh=="), 1)
+    expect_noncanonical(base64_decode("Zm9="), 2)
+    expect_noncanonical(base64url_decode("Zh=="), 1)
+    expect_noncanonical(base64url_decode("Zm9="), 2)
+
+fn test_base64_case_is_significant:
+    let upper = base64_decode("Zg==").unwrap()
+    let lower = base64_decode("zg==").unwrap()
+    assert(upper.get(0) != lower.get(0))
+
 fn main:
     test_base16_rejection()
     test_base32_rejection()
     test_base32_padding()
     test_base32_noncanonical_bits()
+    test_base64_rejection()
+    test_base64_padding()
+    test_base64_noncanonical_bits()
+    test_base64_case_is_significant()
     print("ok")

--- a/test/behavior/behav_std_encoding_rfc4648_vectors.w
+++ b/test/behavior/behav_std_encoding_rfc4648_vectors.w
@@ -2,6 +2,9 @@
 
 use std.collections
 use std.encoding.base16
+use std.string
+use std.encoding.base32
+use std.encoding.base32hex
 
 fn ascii_bytes(text: &str):
     let out = Vec[u8].with_capacity(text.len())
@@ -65,8 +68,70 @@ fn test_base16_all_octets:
         assert(decoded.get(0) == value as u8)
         value = value + 1
 
+fn assert_base32_vector(input: &str, encoded: &str, encoded_hex: &str):
+    let bytes = ascii_bytes(input)
+    assert(base32_encode(bytes) == encoded)
+    assert(base32hex_encode(bytes) == encoded_hex)
+    assert_bytes_eq(&base32_decode(encoded).unwrap(), &bytes)
+    assert_bytes_eq(&base32hex_decode(encoded_hex).unwrap(), &bytes)
+
+fn ascii_lower(text: &str):
+    var out = StringBuilder.with_capacity(text.len())
+    var i: i64 = 0
+    while i < text.len():
+        let byte = text.byte_at(i)
+        out.push_byte((if byte >= 65 and byte <= 90: byte + 32 else: byte) as u8)
+        i = i + 1
+    out.to_str()
+
+fn test_base32_vectors:
+    assert_base32_vector("", "", "")
+    assert_base32_vector("f", "MY======", "CO======")
+    assert_base32_vector("fo", "MZXQ====", "CPNG====")
+    assert_base32_vector("foo", "MZXW6===", "CPNMU===")
+    assert_base32_vector("foob", "MZXW6YQ=", "CPNMUOG=")
+    assert_base32_vector("fooba", "MZXW6YTB", "CPNMUOJ1")
+    assert_base32_vector("foobar", "MZXW6YTBOI======", "CPNMUOJ1E8======")
+
+fn test_base32_alphabets:
+    let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+    let alphabet_hex = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
+    var value: i32 = 0
+    while value < 32:
+        let input = [(value << 3) as u8]
+        let encoded = base32_encode(input)
+        let encoded_hex = base32hex_encode(input)
+        let lower = ascii_lower(encoded)
+        let lower_hex = ascii_lower(encoded_hex)
+        assert(encoded.byte_at(0) == alphabet.byte_at(value as i64))
+        assert(encoded_hex.byte_at(0) == alphabet_hex.byte_at(value as i64))
+        assert(base32_decode(lower).unwrap().get(0) == input[0])
+        assert(base32hex_decode(lower_hex).unwrap().get(0) == input[0])
+        value = value + 1
+
+fn test_base32_terminal_quanta_and_case:
+    let one = ascii_bytes("f")
+    let two = ascii_bytes("fo")
+    let three = ascii_bytes("foo")
+    let four = ascii_bytes("foob")
+    let five = ascii_bytes("fooba")
+    assert(base32_encode(one).ends_with("======"))
+    assert(base32_encode(two).ends_with("===="))
+    assert(base32_encode(three).ends_with("==="))
+    assert(base32_encode(four).ends_with("="))
+    assert(not base32_encode(five).contains("="))
+    assert_bytes_eq(&base32_decode("mzxw6===").unwrap(), &three)
+    assert_bytes_eq(&base32hex_decode("cpnmu===").unwrap(), &three)
+    let decoded = base32_decode("mzxw6===").unwrap()
+    let decoded_hex = base32hex_decode("cpnmu===").unwrap()
+    assert(base32_encode(decoded) == "MZXW6===")
+    assert(base32hex_encode(decoded_hex) == "CPNMU===")
+
 fn main:
     test_base16_vectors()
     test_base16_alphabet_and_case()
     test_base16_all_octets()
+    test_base32_vectors()
+    test_base32_alphabets()
+    test_base32_terminal_quanta_and_case()
     print("ok")

--- a/test/behavior/behav_std_encoding_rfc4648_vectors.w
+++ b/test/behavior/behav_std_encoding_rfc4648_vectors.w
@@ -1,0 +1,72 @@
+//! expect-stdout: ok
+
+use std.collections
+use std.encoding.base16
+
+fn ascii_bytes(text: &str):
+    let out = Vec[u8].with_capacity(text.len())
+    var i: i64 = 0
+    while i < text.len():
+        out.push(text.byte_at(i) as u8)
+        i = i + 1
+    out
+
+fn assert_bytes_eq(actual: &Vec[u8], expected: &Vec[u8]):
+    assert(actual.len() == expected.len())
+    var i: i64 = 0
+    while i < expected.len():
+        assert(actual.get(i) == expected.get(i))
+        i = i + 1
+
+fn assert_base16_vector(input: &str, encoded: &str):
+    let bytes = ascii_bytes(input)
+    assert(base16_encode(bytes) == encoded)
+    assert_bytes_eq(&base16_decode(encoded).unwrap(), &bytes)
+
+fn test_base16_vectors:
+    assert_base16_vector("", "")
+    assert_base16_vector("f", "66")
+    assert_base16_vector("fo", "666F")
+    assert_base16_vector("foo", "666F6F")
+    assert_base16_vector("foob", "666F6F62")
+    assert_base16_vector("fooba", "666F6F6261")
+    assert_base16_vector("foobar", "666F6F626172")
+
+fn test_base16_alphabet_and_case:
+    let alphabet = "0123456789ABCDEF"
+    var value: i32 = 0
+    while value < 16:
+        let input = [(value << 4) as u8]
+        assert(base16_encode(input).byte_at(0) == alphabet.byte_at(value as i64))
+        let low_input = [value as u8]
+        let encoded = base16_encode(low_input)
+        assert(encoded.byte_at(0) == 48)
+        assert(encoded.byte_at(1) == alphabet.byte_at(value as i64))
+        value = value + 1
+    assert(base16_decode("aa").unwrap().get(0) == 170 as u8)
+    assert(base16_decode("bb").unwrap().get(0) == 187 as u8)
+    assert(base16_decode("cc").unwrap().get(0) == 204 as u8)
+    assert(base16_decode("dd").unwrap().get(0) == 221 as u8)
+    assert(base16_decode("ee").unwrap().get(0) == 238 as u8)
+    assert(base16_decode("ff").unwrap().get(0) == 255 as u8)
+    let expected = ascii_bytes("foo")
+    let decoded = base16_decode("666f6f").unwrap()
+    assert_bytes_eq(&decoded, &expected)
+    assert(base16_encode(decoded) == "666F6F")
+
+fn test_base16_all_octets:
+    var value: i32 = 0
+    while value < 256:
+        let input = [value as u8]
+        let encoded = base16_encode(input)
+        let decoded = base16_decode(encoded).unwrap()
+        assert(encoded.len() == 2)
+        assert(decoded.len() == 1)
+        assert(decoded.get(0) == value as u8)
+        value = value + 1
+
+fn main:
+    test_base16_vectors()
+    test_base16_alphabet_and_case()
+    test_base16_all_octets()
+    print("ok")

--- a/test/behavior/behav_std_encoding_rfc4648_vectors.w
+++ b/test/behavior/behav_std_encoding_rfc4648_vectors.w
@@ -5,6 +5,8 @@ use std.encoding.base16
 use std.string
 use std.encoding.base32
 use std.encoding.base32hex
+use std.encoding.base64
+use std.encoding.base64url
 
 fn ascii_bytes(text: &str):
     let out = Vec[u8].with_capacity(text.len())
@@ -127,6 +129,62 @@ fn test_base32_terminal_quanta_and_case:
     assert(base32_encode(decoded) == "MZXW6===")
     assert(base32hex_encode(decoded_hex) == "CPNMU===")
 
+fn assert_base64_vector(input: &str, encoded: &str):
+    let bytes = ascii_bytes(input)
+    assert(base64_encode(bytes) == encoded)
+    assert(base64url_encode(bytes) == encoded)
+    assert_bytes_eq(&base64_decode(encoded).unwrap(), &bytes)
+    assert_bytes_eq(&base64url_decode(encoded).unwrap(), &bytes)
+
+fn test_base64_vectors:
+    assert_base64_vector("", "")
+    assert_base64_vector("f", "Zg==")
+    assert_base64_vector("fo", "Zm8=")
+    assert_base64_vector("foo", "Zm9v")
+    assert_base64_vector("foob", "Zm9vYg==")
+    assert_base64_vector("fooba", "Zm9vYmE=")
+    assert_base64_vector("foobar", "Zm9vYmFy")
+
+fn test_base64_alphabets:
+    let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    let alphabet_url = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    var value: i32 = 0
+    while value < 64:
+        let input = [(value << 2) as u8]
+        assert(base64_encode(input).byte_at(0) == alphabet.byte_at(value as i64))
+        assert(base64url_encode(input).byte_at(0) == alphabet_url.byte_at(value as i64))
+        value = value + 1
+
+fn test_base64_terminal_quanta_and_examples:
+    let one = ascii_bytes("f")
+    let two = ascii_bytes("fo")
+    let three = ascii_bytes("foo")
+    assert(base64_encode(one).ends_with("=="))
+    assert(base64url_encode(one).ends_with("=="))
+    assert(base64_encode(two).ends_with("="))
+    assert(base64url_encode(two).ends_with("="))
+    assert(not base64_encode(three).contains("="))
+    assert(not base64url_encode(three).contains("="))
+
+    let full = [20 as u8, 251 as u8, 156 as u8, 3 as u8, 217 as u8, 126 as u8]
+    let tail_two = [20 as u8, 251 as u8, 156 as u8, 3 as u8, 217 as u8]
+    let tail_one = [20 as u8, 251 as u8, 156 as u8, 3 as u8]
+    assert(base64_encode(full) == "FPucA9l+")
+    assert(base64_encode(tail_two) == "FPucA9k=")
+    assert(base64_encode(tail_one) == "FPucAw==")
+
+    let distinct = [251 as u8, 255 as u8]
+    assert(base64_encode(distinct) == "+/8=")
+    assert(base64url_encode(distinct) == "-_8=")
+    let decoded = base64_decode("+/8=").unwrap()
+    let decoded_url = base64url_decode("-_8=").unwrap()
+    assert(decoded.len() == 2)
+    assert(decoded_url.len() == 2)
+    assert(decoded.get(0) == 251 as u8)
+    assert(decoded.get(1) == 255 as u8)
+    assert(decoded_url.get(0) == 251 as u8)
+    assert(decoded_url.get(1) == 255 as u8)
+
 fn main:
     test_base16_vectors()
     test_base16_alphabet_and_case()
@@ -134,4 +192,7 @@ fn main:
     test_base32_vectors()
     test_base32_alphabets()
     test_base32_terminal_quanta_and_case()
+    test_base64_vectors()
+    test_base64_alphabets()
+    test_base64_terminal_quanta_and_examples()
     print("ok")


### PR DESCRIPTION
## What changed

Adds `std.encoding` with separate modules for:

- Base16
- Base32
- Base32hex
- Base64
- Base64URL

Encoders always produce canonical RFC 4648 output. Base32 and Base64 include padding; Base16 uses uppercase characters.

Decoding is deliberately strict. It rejects whitespace, CRLF, embedded NUL and other non-ASCII bytes, mixed alphabets, malformed or missing padding, and non-zero unused bits. Length errors are reported before character errors, and output allocation happens only after the complete input has been validated.

Each alphabet is a separate leaf module instead of a mode flag. That keeps Base64 distinct from Base64URL and Base32 distinct from Base32hex at the call site.

`std.crypto.sha256.sha256_hex` is unchanged and continues to return lowercase hexadecimal. The new RFC Base16 encoder returns uppercase.

## Verification

- RFC 4648 published vectors for all five modules
- Every alphabet value and terminal quantum
- Exhaustive one- and two-byte round trips
- Input lengths 0 through 257 and a 65,536-byte corpus
- Malformed-input cases with exact error offsets
- Focused runs under the native debug allocator: zero leaks
- `with build`
- `with build :fixpoint`
- `with build :test`
- `with build :last-green`

The API, errata treatment, and requirement-to-test checklist are documented in `docs/std-encoding-rfc4648.md`.
