### PR TITLE
std/re, std/zlib: division-free 128-bit overflow helpers (fixes windows link)

### DIFF
--- a/lib/std/re/defs.w
+++ b/lib/std/re/defs.w
@@ -210,10 +210,31 @@ pub unsafe fn __with_builtin_sub_overflow_i128(a: i128, b: i128, out: *mut i128)
     unsafe { (*out = result) }
     ((a ^ b) & (result ^ a)) < 0
 }
+// The 128-bit overflow checks stay division-free on purpose: `/` on i128/u128
+// lowers to the __divti3/__udivti3 compiler-rt libcalls, and this shim is
+// compiled into freestanding runtime objects whose COFF link has no builtins
+// library to resolve them from. Limb decomposition keeps the check to multiplies
+// and shifts, which lower inline on every target and at every -O level.
+fn u128_mul_would_overflow(a: u128, b: u128) -> bool {
+    let a_hi = (a >> 64) as u64
+    let b_hi = (b >> 64) as u64
+    if a_hi != 0 and b_hi != 0: return true
+    let a_lo = (a as u64) as u128
+    let b_lo = (b as u64) as u128
+    let cross = (a_hi as u128) *% b_lo +% (b_hi as u128) *% a_lo
+    if (cross >> 64) != 0: return true
+    let low = a_lo *% b_lo
+    ((low >> 64) +% cross) >> 64 != 0
+}
 pub unsafe fn __with_builtin_mul_overflow_i128(a: i128, b: i128, out: *mut i128) -> bool {
-    let result = a *% b
-    unsafe { (*out = result) }
-    if a == 0 or b == 0: false else if a == -1: result == b else if b == -1: result == a else: result / b != a
+    unsafe { (*out = a *% b) }
+    if a == 0 or b == 0: return false
+    let neg = (a < 0) != (b < 0)
+    let ua = if a < 0: (0 as u128) -% (a as u128) else: a as u128
+    let ub = if b < 0: (0 as u128) -% (b as u128) else: b as u128
+    if u128_mul_would_overflow(ua, ub): return true
+    let limit = if neg: (1 as u128) << 127 else: ((1 as u128) << 127) -% 1
+    ua *% ub > limit
 }
 pub unsafe fn __with_builtin_add_overflow_u128(a: u128, b: u128, out: *mut u128) -> bool {
     let result = a +% b
@@ -226,9 +247,8 @@ pub unsafe fn __with_builtin_sub_overflow_u128(a: u128, b: u128, out: *mut u128)
     a < b
 }
 pub unsafe fn __with_builtin_mul_overflow_u128(a: u128, b: u128, out: *mut u128) -> bool {
-    let result = a *% b
-    unsafe { (*out = result) }
-    if b == 0: false else: result / b != a
+    unsafe { (*out = a *% b) }
+    u128_mul_would_overflow(a, b)
 }
 pub extern fn with_clz(x: i32) -> i32
 pub extern fn with_ctz(x: i32) -> i32

--- a/lib/std/zlib/defs.w
+++ b/lib/std/zlib/defs.w
@@ -206,10 +206,31 @@ pub unsafe fn __with_builtin_sub_overflow_i128(a: i128, b: i128, out: *mut i128)
     unsafe { (*out = result) }
     ((a ^ b) & (result ^ a)) < 0
 }
+// The 128-bit overflow checks stay division-free on purpose: `/` on i128/u128
+// lowers to the __divti3/__udivti3 compiler-rt libcalls, and this shim is
+// compiled into freestanding runtime objects whose COFF link has no builtins
+// library to resolve them from. Limb decomposition keeps the check to multiplies
+// and shifts, which lower inline on every target and at every -O level.
+fn u128_mul_would_overflow(a: u128, b: u128) -> bool {
+    let a_hi = (a >> 64) as u64
+    let b_hi = (b >> 64) as u64
+    if a_hi != 0 and b_hi != 0: return true
+    let a_lo = (a as u64) as u128
+    let b_lo = (b as u64) as u128
+    let cross = (a_hi as u128) *% b_lo +% (b_hi as u128) *% a_lo
+    if (cross >> 64) != 0: return true
+    let low = a_lo *% b_lo
+    ((low >> 64) +% cross) >> 64 != 0
+}
 pub unsafe fn __with_builtin_mul_overflow_i128(a: i128, b: i128, out: *mut i128) -> bool {
-    let result = a *% b
-    unsafe { (*out = result) }
-    if a == 0 or b == 0: false else if a == -1: result == b else if b == -1: result == a else: result / b != a
+    unsafe { (*out = a *% b) }
+    if a == 0 or b == 0: return false
+    let neg = (a < 0) != (b < 0)
+    let ua = if a < 0: (0 as u128) -% (a as u128) else: a as u128
+    let ub = if b < 0: (0 as u128) -% (b as u128) else: b as u128
+    if u128_mul_would_overflow(ua, ub): return true
+    let limit = if neg: (1 as u128) << 127 else: ((1 as u128) << 127) -% 1
+    ua *% ub > limit
 }
 pub unsafe fn __with_builtin_add_overflow_u128(a: u128, b: u128, out: *mut u128) -> bool {
     let result = a +% b
@@ -222,9 +243,8 @@ pub unsafe fn __with_builtin_sub_overflow_u128(a: u128, b: u128, out: *mut u128)
     a < b
 }
 pub unsafe fn __with_builtin_mul_overflow_u128(a: u128, b: u128, out: *mut u128) -> bool {
-    let result = a *% b
-    unsafe { (*out = result) }
-    if b == 0: false else: result / b != a
+    unsafe { (*out = a *% b) }
+    u128_mul_would_overflow(a, b)
 }
 pub extern fn with_clz(x: i32) -> i32
 pub extern fn with_ctz(x: i32) -> i32

--- a/rt/windows_aarch64.w
+++ b/rt/windows_aarch64.w
@@ -227,7 +227,7 @@ pub fn rt_close(fd: i32) -> i32:
         return 0
     if fd < 0 or fd >= 256:
         return -6
-    let h = rt_handles[fd]
+    let h: i64 = rt_handles[fd]
     rt_handles[fd] = 0
     if h == 0:
         return -6
@@ -773,7 +773,7 @@ fn win_process_alloc(handle: i64, pid: i32) -> i32:
 fn win_wait_process_slot(slot: i32, timeout_ms: i32, consume: bool) -> i32:
     if slot <= 0 or slot >= 256:
         return -1
-    let h = process_handles[slot]
+    let h: i64 = process_handles[slot]
     if h == 0:
         return -1
     let wait_ms = if timeout_ms > 0: timeout_ms as u32 else: INFINITE

--- a/rt/windows_x86_64.w
+++ b/rt/windows_x86_64.w
@@ -222,7 +222,7 @@ pub fn rt_close(fd: i32) -> i32:
         return 0
     if fd < 0 or fd >= 256:
         return -6
-    let h = rt_handles[fd]
+    let h: i64 = rt_handles[fd]
     rt_handles[fd] = 0
     if h == 0:
         return -6
@@ -768,7 +768,7 @@ fn win_process_alloc(handle: i64, pid: i32) -> i32:
 fn win_wait_process_slot(slot: i32, timeout_ms: i32, consume: bool) -> i32:
     if slot <= 0 or slot >= 256:
         return -1
-    let h = process_handles[slot]
+    let h: i64 = process_handles[slot]
     if h == 0:
         return -1
     let wait_ms = if timeout_ms > 0: timeout_ms as u32 else: INFINITE


### PR DESCRIPTION
## The red

Both windows selfhost jobs (x86_64 and aarch64) have failed at the **stage1 link** since `87df3b31` promoted the re-migrated pcre2. Every main push since 2026-08-30 04:04 is red on windows; darwin and linux are green.

```
lld-link: error: undefined symbol: __divti3
>>> referenced by out/bootstrap-lib/regex_runtime.o:(__with_builtin_mul_overflow_i128)
lld-link: error: undefined symbol: __udivti3
>>> referenced by out/bootstrap-lib/regex_runtime.o:(__with_builtin_mul_overflow_u128)
```

## Root cause

`__with_builtin_mul_overflow_{i,u}128` in the migrated-pcre2 shim checked overflow the C way:

```
if b == 0: false else: result / b != a
```

A 128-bit divide has no native instruction, so instruction selection lowers it to the `__divti3`/`__udivti3` **compiler-rt libcalls**. darwin and linux resolve those from the platform runtime and never noticed. The COFF link has no builtins library to resolve them from — and `tools/build-static-llvm.sh` builds only `clang;lld`, so no `libclang_rt.builtins` exists on any target to link.

Nothing in the tree calls these helpers; they exist so migrated C using `__builtin_mul_overflow` on 128-bit types keeps working. But they are `pub`, so they are emitted into the linked object regardless.

## The fix

The helpers now decompose into 64-bit limbs and check overflow with multiplies, shifts and compares only. No 128-bit division is emitted, so the libcall cannot appear **on any target at any optimization level**. The two shims were byte-identical in this region; both are updated.

## Verification (run with the pinned CI seed, v0.15.1.3)

| check | result |
|---|---|
| new vs old helpers over 289 boundary pairs (`0, 1, 2^32, 2^63, 2^64±1, 2^100, 2^126, 2^127, 2^127-1, U128_MAX`), read as both `u128` and `i128` | 0 mismatches |
| helpers compiled at `-O0`, `nm -u` for `divti3` | 0 refs |
| real `with ir rt/regex_runtime.w --no-prelude overflow=wrap` | **2 → 0** 128-bit divisions |
| `with check` on both shims vs HEAD | identical diagnostics |

I could not run `with build` / `:fixpoint` / `:test` locally (no darwin LLVM SDK tools in this checkout), so the full battery is on CI.

## Follow-up (deliberately not in this PR)

`-O1` also folds this division into a widening-multiply overflow check — which is *why* only the regex runtime broke. It is the one runtime object built through the whole-module IR path, and `wl_compile_ir_to_object` (`src/compiler/LlvmBridge.w`) runs **no optimization pipeline**, only `globaldce`. Every other runtime object goes through `with_object_target(..., "-O1", ...)`.

That unoptimized IR→object path is a real violation of the `-O1`-everywhere invariant, but it **cannot be fixed in this PR**: `CompileLlvmIrObject` runs in-process in the build driver (`BuildGraphRuntime.w:105`), and the driver is the pinned seed — so a source fix there does not take effect until a reseed. (Confirmed: `strings` on the seed shows the baked-in `globaldce`.) I have the one-line patch (`wl_optimize(m as i64, tm as i64, 1)`) ready for a separate, isolated PR per the codegen isolation rule.

Also worth filing separately: with no compiler-rt builtins on the windows link path, **any** 128-bit division in user code is currently unlinkable on windows. `-O1` only happens to remove this one.