### PR TITLE
AGENTS/CLAUDE: every PR must be bootstrappable from a tagged seed release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -955,6 +955,11 @@ If any step fails, continue debugging until it passes.
 
 ## Bootstrap Rules
 
+### Every PR must be bootstrappable
+Each PR must be green and buildable from a tagged seed release that already
+exists in the repo before it merges — if a change needs a newer seed, tag a
+release to be that seed first.
+
 ### The seed compiler is frozen
 The installed compiler at ~/.local/bin/with has its own Link.w, its own
 embedded runtime objects, and its own codegen logic baked into the binary.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -988,6 +988,11 @@ If any step fails, continue debugging until it passes.
 
 ## Bootstrap Rules
 
+### Every PR must be bootstrappable
+Each PR must be green and buildable from a tagged seed release that already
+exists in the repo before it merges — if a change needs a newer seed, tag a
+release to be that seed first.
+
 ### The seed compiler is frozen
 The installed compiler at ~/.local/bin/with has its own Link.w, its own
 embedded runtime objects, and its own codegen logic baked into the binary.


### PR DESCRIPTION
One sentence under Bootstrap Rules, in both agent docs (they are drifted copies of the same document):

> Each PR must be green and buildable from a tagged seed release that already exists in the repo before it merges — if a change needs a newer seed, tag a release to be that seed first.

The compiler is self-hosting, so the pinned seed is the only thing that can build a PR; a change that only builds under a compiler that does not exist yet is unmergeable. This was never written down anywhere — the seed pins live as per-platform `(WITH_SEED_VERSION, WITH_SEED_ASSET, WITH_SEED_SHA256)` triples across the workflow files, and the rule governing them was tribal.