### PR TITLE
test(windows): re-skip async fiber stack-overflow diagnostic (#369)

### DIFF
--- a/test/behavior/behav_async_stack_overflow.w
+++ b/test/behavior/behav_async_stack_overflow.w
@@ -1,3 +1,4 @@
+//! skip-windows: issue #369: Windows custom fiber stack overflow diagnostic awaits async backend migration
 //! expect-exit: 134
 //! expect-stderr: fiber stack overflow
 //! args: -O0


### PR DESCRIPTION
## What

Restore the `skip-windows` gate on `test/behavior/behav_async_stack_overflow.w`.

## Why

The test was un-skipped on Windows on the premise that the vectored-exception-handler bridge produced the "fiber stack overflow" diagnostic and exit 134. It does not. The Windows green battery is red on `main` as a result:

```
error: exit code -1073741819, expected 134   (0xC0000005, STATUS_ACCESS_VIOLATION)
```

Root cause: a 16 KB fiber stack recursing with ~256-byte frames descends past the single `PAGE_GUARD` page. When the guard fault fires, Windows' exception dispatch + the VEH run **on the already-exhausted fiber stack** (VEH has no sigaltstack equivalent), with only the one auto-committed guard page of headroom. That nested overflow runs below the mapped region → `0xC0000005`, and the process dies before the diagnostic prints.

## Plan

This PR greens `main` by restoring the justified skip. The real fix (give the exception handler committed headroom below the guard page so the diagnostic can run) is a **follow-up "fixer" PR** that un-skips the test once the diagnostic genuinely produces `fiber stack overflow` + exit 134 on Windows. Tracked by #369.

The test continues to run (and assert the diagnostic) on Linux and macOS, where the POSIX sigaltstack path implements it. The VEH groundwork in `rt/` is retained for the follow-up.