### PR TITLE
Build: fix compiler-main-source comptime budget overflow on Windows (CRLF normalize)

### DIFF
--- a/build/compiler.w
+++ b/build/compiler.w
@@ -3,6 +3,7 @@ module build.compiler
 use std.build
 use std.process
 use std.sysinfo
+use std.string.StringBuilder
 fn compiler_owned_text(s: &str): s ++ ""
 
 const COMPILER_LLVM_VERSION: str = "22.1.6"
@@ -191,22 +192,27 @@ fn comp_normalize_line_endings(text: &str) -> str:
             break
     if not has_cr:
         return compiler_owned_text(text)
-    var out = ""
+    // StringBuilder, not `out ++ slice` in a loop: src/main.w is the whole
+    // amalgamated compiler (~200KB+), and a CRLF checkout (GitHub's Windows
+    // runners default to core.autocrlf=true) trips this path. Repeated `++`
+    // recopies the growing buffer every line, which blows the comptime string
+    // budget (>1 GiB of cumulative copies). Mirrors br_normalize_embedded_source.
+    var out = StringBuilder.with_capacity(text.len())
     var start = 0
     var i = 0
     while i < text.len() as i32:
         let ch = text.byte_at(i as i64)
         if ch == 13:
             if i > start:
-                out = out ++ text.slice(start as i64, i as i64)
+                out.push_str(text.slice(start as i64, i as i64))
             if i + 1 < text.len() as i32 and text.byte_at((i + 1) as i64) == 10:
                 i = i + 1
-            out = out ++ "\n"
+            out.push_str("\n")
             start = i + 1
         i = i + 1
     if start < text.len() as i32:
-        out = out ++ text.slice(start as i64, text.len())
-    out
+        out.push_str(text.slice(start as i64, text.len()))
+    out.to_str()
 
 fn comp_tool_from_env(primary: &str, legacy: &str, fallback: &str) -> str:
     let explicit = env(compiler_owned_text(primary))


### PR DESCRIPTION
## Problem

`with build` fails before stage1 on GitHub's Windows runners (both `windows
x86_64` and `windows aarch64`), and now also reds `main` itself:

```
error: action target 'compiler-main-source' failed during comptime evaluation:
comptime string construction budget exceeded (1073873897 bytes > 1073741824 bytes);
repeated `++` in a loop copies prior content, use StringBuilder or collect pieces
```

Every downstream error (`missing out/stage/bin/with-stage2.exe` for the bridge,
cimport-stubs, runtime, regex-IR objects, etc.) is a cascade from stage1 never
being produced.

## Root cause

`comp_normalize_line_endings` (`build/compiler.w`) built its result with
`out = out ++ slice` in a loop over the whole input. `src/main.w` is the
amalgamated compiler source (~220 KB), and GitHub's Windows runners check out
with CRLF (`core.autocrlf=true` by default). That trips the CR-rewrite path,
which recopies the growing buffer on every line — O(n²) in bytes copied. As
the compiler source grew it crossed the 1 GiB comptime string-construction
budget (over by ~129 KB), so the `compiler-main-source` action now fails.

Linux/macOS check out with LF, so `has_cr` is false and the function returns
early — which is why only the Windows lanes fail.

## Fix

Build the result with a `StringBuilder`, matching the sibling normalizers that
already do this for exactly this reason (`br_normalize_embedded_source` in
`build/runtime.w`, plus the pcre2 / package / sdk source generators). The LF
path is byte-for-byte unchanged (early return before the loop).

## Verification

- `with build :compiler-main-source` runs green; `out/gen/main.w` is
  byte-identical to `src/main.w` on the LF path (unchanged behavior).
- The CRLF→LF rewrite is verbatim from the shipping `br_normalize_embedded_source`,
  which normalizes embedded sources on every build.
- Windows CI on this branch is the CRLF gate.

`build/*.w` is interpreted by the seed at build time, so this takes effect with
no reseed; the seed already supports these `StringBuilder` calls (the twin in
`build/runtime.w` uses them on every build).
