### PR TITLE
Windows: fiber stack-overflow diagnostic + un-skip its test (#369)

### DIFF
--- a/rt/fiber_core_windows.w
+++ b/rt/fiber_core_windows.w
@@ -64,6 +64,15 @@ let RT_SIGSEGV: i32 = 11
 
 let FIBER_ALT_STACK_SIZE: i64 = 131072
 
+// Committed room reserved *below* the guard page. Windows has no sigaltstack:
+// when the guard page faults, KiUserExceptionDispatcher builds the CONTEXT and
+// RtlDispatchException walks the VEH list on the *faulting* fiber stack — which
+// is exhausted. Without headroom below the guard, that dispatch (plus our
+// handler's WriteFile/ExitProcess calls) runs off the bottom into unmapped
+// memory, producing a nested 0xC0000005 before the diagnostic prints. This
+// committed slack is the Windows analogue of the POSIX alt stack.
+let FIBER_GUARD_HEADROOM: i64 = 65536
+
 var current_fiber: i64 = 0
 var scheduler_ctx: [328]u8 = [0 as u8; 328]
 var free_pool_head: i64 = 0
@@ -367,13 +376,16 @@ fn fiber_effective_pool_limit() -> i32:
 
 fn allocate_stack_region(size: i64) -> *mut u8:
     let page_sz = guard_page_size()
-    let total = page_sz + size
+    let total = FIBER_GUARD_HEADROOM + page_sz + size
     let _ = rt_fiber_mmap_flags()
     let region = rt_mmap(total)
     if region as i64 == 0 or region as i64 == MAP_FAILED:
         return 0 as *mut u8
-    rt_fiber_protect_guard(region, page_sz)
-    (region as i64 + page_sz) as *mut u8
+    // Guard page sits above the committed headroom: [region+headroom, +page_sz).
+    // Usable stack is above the guard; the returned pointer is its low end, so
+    // the guard region stays `stack-page_sz .. stack` (with_fiber_veh unchanged).
+    rt_fiber_protect_guard((region as i64 + FIBER_GUARD_HEADROOM) as *mut u8, page_sz)
+    (region as i64 + FIBER_GUARD_HEADROOM + page_sz) as *mut u8
 
 fn acquire_fiber() -> i64:
     if free_pool_head != 0:
@@ -411,8 +423,8 @@ fn free_fiber_stack(f: i64):
     if stack as i64 == 0:
         return
     let page_sz = guard_page_size()
-    let region = (stack as i64 - page_sz) as *mut u8
-    rt_munmap(region, page_sz + fiber_stack_size(f))
+    let region = (stack as i64 - page_sz - FIBER_GUARD_HEADROOM) as *mut u8
+    rt_munmap(region, FIBER_GUARD_HEADROOM + page_sz + fiber_stack_size(f))
     fiber_set_stack(f, 0 as *mut u8)
 
 fn recycle_fiber(f: i64):

--- a/runtime/fiber_asm_windows_x86_64.s
+++ b/runtime/fiber_asm_windows_x86_64.s
@@ -21,6 +21,27 @@
 //   216 xmm13
 //   232 xmm14
 //   248 xmm15
+//   264 NT_TIB FiberData          (TEB+0x20)
+//   272 NT_TIB DeallocationStack  (TEB+0x1478)
+//   280 NT_TIB StackLimit         (TEB+0x10)
+//   288 NT_TIB StackBase          (TEB+0x08)
+//
+// Every context switch swaps the four NT_TIB stack-description fields
+// through the TEB (%gs:[0x30]). Without this, Windows believes the thread
+// is still on its OS stack while a fiber runs: __chkstk probes (every
+// function with a frame over one page), SEH/VEH dispatch, and OS callbacks
+// all consult the wrong bounds, and a guard-page fault on the fiber stack
+// degrades to an unhandled access violation before the vectored handler
+// that produces the "fiber stack overflow" diagnostic can run.
+//
+// The outgoing thread's TEB fields are saved into the save context and the
+// incoming context's fields are installed into the TEB. A switch never
+// changes thread, so %gs:[0x30] is stable across both phases and %r10 (the
+// TEB pointer) is loaded once and reused.
+//   TEB+0x08  StackBase          (high end of the usable stack)
+//   TEB+0x10  StackLimit         (low end)
+//   TEB+0x20  FiberData
+//   TEB+0x1478 DeallocationStack (low end)
 
         .text
         .globl with_fiber_switch
@@ -47,6 +68,18 @@ with_fiber_switch:
         movdqu %xmm14, 232(%rcx)
         movdqu %xmm15, 248(%rcx)
 
+        // Save the outgoing NT_TIB stack fields into the save context.
+        // %r10 = TEB; reused by the restore phase (same thread).
+        movq %gs:0x30, %r10
+        movq 0x20(%r10), %rax
+        movq %rax, 264(%rcx)
+        movq 0x1478(%r10), %rax
+        movq %rax, 272(%rcx)
+        movq 0x10(%r10), %rax
+        movq %rax, 280(%rcx)
+        movq 0x08(%r10), %rax
+        movq %rax, 288(%rcx)
+
         movq (%rsp), %rax
         movq %rax, 88(%rcx)
         leaq 8(%rsp), %rax
@@ -71,6 +104,17 @@ with_fiber_switch:
         movdqu 232(%rdx), %xmm14
         movdqu 248(%rdx), %xmm15
 
+        // Install the incoming NT_TIB stack fields into the TEB. %r10 still
+        // holds the TEB from the save phase (the switch never changes thread).
+        movq 264(%rdx), %rax
+        movq %rax, 0x20(%r10)
+        movq 272(%rdx), %rax
+        movq %rax, 0x1478(%r10)
+        movq 280(%rdx), %rax
+        movq %rax, 0x10(%r10)
+        movq 288(%rdx), %rax
+        movq %rax, 0x08(%r10)
+
         movq 96(%rdx), %rsp
         movq 88(%rdx), %rax
         jmp *%rax
@@ -88,6 +132,15 @@ with_fiber_prepare_initial_context:
         leaq with_fiber_start(%rip), %r9
         movq %r9, 88(%rcx)
         movq %rax, 96(%rcx)
+        // Seed the NT_TIB stack fields so the first switch into this fiber
+        // installs its bounds. StackBase = top of the usable stack; StackLimit
+        // and DeallocationStack sit at the low end (the guard page + committed
+        // handler headroom live just below, owned by the guard fault path).
+        movq $0, 264(%rcx)
+        movq %rdx, 272(%rcx)
+        movq %rdx, 280(%rcx)
+        leaq (%rdx,%r8), %r10
+        movq %r10, 288(%rcx)
         ret
 
         .globl with_fiber_start

--- a/test/behavior/behav_async_fiber_large_frame.w
+++ b/test/behavior/behav_async_fiber_large_frame.w
@@ -1,0 +1,34 @@
+//! expect-exit: 0
+//! args: -O0
+
+// A single stack frame larger than one page, exercised on a fiber. On
+// Windows x64 the compiler must probe every page of a frame this size as
+// it is established; those probes read the thread's stack bounds. While a
+// fiber runs those bounds only describe the fiber stack if the context
+// switch installs them, so this returns normally on a correct backend and
+// faults on one that leaves the OS's stack bounds pointing at the main
+// thread. Elsewhere a large frame is unremarkable; the check is portable.
+
+fn big(seed: i32) -> i32:
+    var buf: [16384]i32 = [0; 16384]
+    var i = 0
+    while i < 16384:
+        buf[i] = seed + i as i32
+        i = i + 1
+    var sum = 0
+    i = 0
+    while i < 16384:
+        sum = sum + buf[i]
+        i = i + 1
+    sum
+
+@[stack_size(262144)]
+async fn run() -> i32:
+    big(1)
+
+async fn main:
+    let t = run()
+    let got = t.await
+    // sum of (1 + k) for k in 0..16384 = 16384 + 16383*16384/2 = 134225920
+    if got != 134225920:
+        panic("wrong checksum")

--- a/test/behavior/behav_async_stack_overflow.w
+++ b/test/behavior/behav_async_stack_overflow.w
@@ -1,4 +1,3 @@
-//! skip-on: windows issue #369: Windows custom fiber stack overflow diagnostic awaits async backend migration
 //! expect-exit: 134
 //! expect-stderr: fiber stack overflow
 //! args: -O0


### PR DESCRIPTION
Re-lands the #369 Windows fiber stack-overflow diagnostic on current `main`.

The original PR #907 was merged into the interim stacking base branch `fix-compiler-main-source-budget` (now stale — based on pre-rfc4648 main), so the change never reached `main`. This is the same commit rebased onto current `main` (`31f77937`); the interim CRLF-budget fix commit drops out by patch-id (already in main via #910).

Windows-x86_64 only: adds VEH-based headroom below the fiber guard page so a stack overflow on a small fiber stack raises the `fiber stack overflow` diagnostic (exit 134), plus a large-frame regression test, and un-skips `behav_async_stack_overflow`.