### PR TITLE
Codegen: run -O1 pipeline on the IR->object path (wl_compile_ir_to_object)

### DIFF
--- a/src/compiler/LlvmBridge.w
+++ b/src/compiler/LlvmBridge.w
@@ -1619,9 +1619,10 @@ pub fn wl_compile_ir_to_object(source_path: &str, output_path: &str) -> i32:
         LLVMDisposeMessage(default_triple)
         // `with ir` emits UNOPTIMIZED IR, so this path is the only place the
         // -O1 pipeline runs for an IR->object target (regex_runtime.o in every
-        // build). Run the full `default<O1>` pipeline — the same one the direct
-        // source->object path runs via wl_optimize(m, tm, 1) — so the invariant
-        // "-O1 everywhere" holds for this route too, not just codegen level.
+        // build). Run the one pipeline the direct source->object path runs —
+        // wl_optimize is the single pass-runner, so the two routes cannot
+        // drift — and the invariant "-O1 everywhere" holds here too, not just
+        // at codegen level.
         //
         // `default<O1>` also strips the dead module-level chain that globaldce
         // alone used to remove here: unoptimized IR leaves an internal,
@@ -1633,12 +1634,7 @@ pub fn wl_compile_ir_to_object(source_path: &str, output_path: &str) -> i32:
         // `.text`, so the dead `call` would otherwise reach the link as an
         // undefined symbol. The O1 module-simplification pipeline includes
         // GlobalDCE, removing the whole dead chain portably — matching darwin.
-        let opt_opts = LLVMCreatePassBuilderOptions()
-        let opt_err = LLVMRunPasses(m, to_cstr("default<O1>"), tm, opt_opts)
-        if opt_err as i64 != 0:
-            let omsg = LLVMGetErrorMessage(opt_err)
-            if omsg as i64 != 0: LLVMDisposeErrorMessage(omsg)
-        LLVMDisposePassBuilderOptions(opt_opts)
+        wl_optimize(m as i64, tm as i64, 1)
         var out_buf: [4096]u8 = [0 as u8; 4096]
         let out_cstr = path_to_cstr(output_path, &out_buf as *mut u8)
         var emit_err: *mut u8 = 0 as *mut u8

--- a/src/compiler/LlvmBridge.w
+++ b/src/compiler/LlvmBridge.w
@@ -1609,26 +1609,36 @@ pub fn wl_compile_ir_to_object(source_path: &str, output_path: &str) -> i32:
             LLVMDisposeModule(m)
             LLVMContextDispose(ctx)
             return 1
-        let tm = LLVMCreateTargetMachine(target, triple, c"generic".ptr, empty_cstr(), LLVM_CodeGenLevelDefault, LLVM_RelocDefault, LLVM_CodeModelDefault)
+        // -O1 codegen level, matching the direct source->object path
+        // (wl_init_target_machine -> codegen_level(1)); the IR->object route
+        // is not a licence to ship unoptimized objects.
+        let tm = LLVMCreateTargetMachine(target, triple, c"generic".ptr, empty_cstr(), codegen_level(1), LLVM_RelocDefault, LLVM_CodeModelDefault)
         let layout = LLVMCreateTargetDataLayout(tm)
         LLVMSetModuleDataLayout(m, layout)
         LLVMDisposeTargetData(layout)
         LLVMDisposeMessage(default_triple)
-        // `with ir` emits unoptimized IR, so dead module-level bindings survive as
-        // an internal, unreferenced __with_init_const_* -> __fn_thunk_* -> `call
-        // @<extern>` chain (e.g. the migration-cruft fn-ptr aliases coercing an
-        // unused `extern fn pcre2_regcomp` into a fat pointer). Darwin ld64
-        // `-dead_strip` drops such dead atoms; linux `--gc-sections` works at
-        // section granularity and cannot strip one dead function out of a
-        // monolithic `.text`, so the dead `call` reaches the link as an undefined
-        // symbol. globaldce removes the whole dead chain here, portably — matching
-        // darwin — and touches no live code (dead internal globals are unobservable).
-        let gdce_opts = LLVMCreatePassBuilderOptions()
-        let gdce_err = LLVMRunPasses(m, to_cstr("globaldce"), tm, gdce_opts)
-        if gdce_err as i64 != 0:
-            let gmsg = LLVMGetErrorMessage(gdce_err)
-            if gmsg as i64 != 0: LLVMDisposeErrorMessage(gmsg)
-        LLVMDisposePassBuilderOptions(gdce_opts)
+        // `with ir` emits UNOPTIMIZED IR, so this path is the only place the
+        // -O1 pipeline runs for an IR->object target (regex_runtime.o in every
+        // build). Run the full `default<O1>` pipeline — the same one the direct
+        // source->object path runs via wl_optimize(m, tm, 1) — so the invariant
+        // "-O1 everywhere" holds for this route too, not just codegen level.
+        //
+        // `default<O1>` also strips the dead module-level chain that globaldce
+        // alone used to remove here: unoptimized IR leaves an internal,
+        // unreferenced __with_init_const_* -> __fn_thunk_* -> `call @<extern>`
+        // chain (e.g. migration-cruft fn-ptr aliases coercing an unused
+        // `extern fn pcre2_regcomp` into a fat pointer). Darwin ld64 `-dead_strip`
+        // drops such dead atoms, but linux `--gc-sections` works at section
+        // granularity and cannot strip one dead function out of a monolithic
+        // `.text`, so the dead `call` would otherwise reach the link as an
+        // undefined symbol. The O1 module-simplification pipeline includes
+        // GlobalDCE, removing the whole dead chain portably — matching darwin.
+        let opt_opts = LLVMCreatePassBuilderOptions()
+        let opt_err = LLVMRunPasses(m, to_cstr("default<O1>"), tm, opt_opts)
+        if opt_err as i64 != 0:
+            let omsg = LLVMGetErrorMessage(opt_err)
+            if omsg as i64 != 0: LLVMDisposeErrorMessage(omsg)
+        LLVMDisposePassBuilderOptions(opt_opts)
         var out_buf: [4096]u8 = [0 as u8; 4096]
         let out_cstr = path_to_cstr(output_path, &out_buf as *mut u8)
         var emit_err: *mut u8 = 0 as *mut u8


### PR DESCRIPTION
## Problem

The IR→object emission route (`wl_compile_ir_to_object` in `src/compiler/LlvmBridge.w`) built its `TargetMachine` at `LLVM_CodeGenLevelDefault` and ran **only** a `globaldce` pass — it never ran the `default<O1>` module pipeline that the direct source→object path runs via `wl_optimize(m, tm, 1)`.

Because `with ir` emits **unoptimized** IR, this route is the *only* place -O1 can run for an IR→object target. Today the sole such target is **`regex_runtime.o`** (built whole-module through IR so the migrated pcre2 modules land in one object). As a result `regex_runtime.o` shipped **mid-level-unoptimized in every build** — native bootstrap, stage2, and all cross targets.

This is a silent hole in the project's **"-O1 everywhere"** invariant (CLAUDE.md: all stages, fixpoint stages, every runtime/bootstrap object, and the release binary are -O1). Every object obeyed it except this one, which slipped through at codegen level Default with no mid-level optimization.

## Fix

- Create the `TargetMachine` at `codegen_level(1)` (`Less`), matching `wl_init_target_machine`.
- Run the full `default<O1>` pipeline — the same one the direct path runs.

The O1 module-simplification pipeline includes `GlobalDCE`, so it **subsumes** the previous `globaldce`-only strip of the dead `__with_init_const_* -> __fn_thunk_* -> call @<extern>` pcre2 alias chain (an unused `extern fn pcre2_regcomp` coerced into a fat pointer). That dead chain must be removed portably because linux `--gc-sections` works at section granularity and cannot strip one dead function out of a monolithic `.text` (darwin ld64 `-dead_strip` handled it); the O1 pipeline still removes it.

## Verification (linux x86_64)

- `with build` — green (rc=0)
- `with build :fixpoint` — green (rc=0): **stage2 == stage3 byte-identical**

Isolated per D14 (single codegen/emission change, alone in its batch).