### PR TITLE
Pin .w sources and the ABI-hash record to LF (fix Windows abi-hash-check red)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,13 @@ out/** linguist-generated
 # embed_file read "...\r\n" and break the byte-exact assertions (#801).
 test/behavior/*.txt text eol=lf
 test/behavior/**/*.txt text eol=lf
+
+# With source is content-hashed cross-platform: docs/with-abi.sha256 records the
+# sha256 of the ABI-defining sources (build/abi.w, docs/with-abi.md §7 / D38), and
+# that hash keys every .wo bundle, so the bytes fed to it must be identical on
+# every platform. Under core.autocrlf=true a Windows checkout rewrites LF to CRLF,
+# which both changes each source's hash (abi-hash-check mismatch) and leaves a
+# trailing "\r" on the record's path column that trips the comptime ToolFs
+# project-root check. Pin LF so the hash is stable and the record parses cleanly.
+*.w text eol=lf
+docs/with-abi.sha256 text eol=lf


### PR DESCRIPTION
## Problem

`main` is red on **both** Windows lanes (x86_64 and aarch64) at the green battery:

```
error: action target 'abi-hash-check' failed during comptime evaluation:
       ToolFs path escapes project root in sha256_file: src/FnAbi.w
```

## Root cause

GitHub's Windows runners check out with `core.autocrlf=true`, so any text file without an
`eol` attribute is rewritten LF→CRLF on checkout.

`run_abi_hash_check_action` (`build/abi.w`) reads `docs/with-abi.sha256`, splits it on `\n`
only, and hashes the path in each record line's second column. On a Windows (CRLF) checkout
every line keeps a trailing `\r`, so the path parses as `src/FnAbi.w\r`. The comptime ToolFs
project-root guard (`ComptimeEval.w` `comptime_tool_path_is_project_relative`) rejects any
path containing a control byte (byte 13 = CR), which is the failure above — the `\r` is
invisible in the log, so it reads as `src/FnAbi.w`.

Fixing only the path would then trade the error for a **hash mismatch**: the check hashes the
raw bytes of `src/FnAbi.w` and `src/TypeLayout.w`, whose recorded sha256s were taken from the
LF sources, while a CRLF checkout hashes different bytes. That hash keys every `.wo` bundle
(D38, `docs/with-abi.md` §7) and must be identical on every platform, so the sources feeding
it have to be byte-stable across platforms.

## Fix

Pin all `.w` source and `docs/with-abi.sha256` to `text eol=lf` in `.gitattributes`, so a
Windows checkout keeps LF — same mechanism as the existing `#801` pin for `test/behavior/*.txt`.

- No blob content changes: every tracked file is already LF in the index (`git add
  --renormalize .` stages only `.gitattributes`); this only enforces LF on future checkouts
  and commits.
- Linux/macOS are already LF, so they are unaffected (the linux lane on this commit is green).
- Verification is the Windows CI on this PR: the abi-hash-check now hashes LF bytes matching
  the recorded sha256s.