### PR TITLE
Migrate: fold paste-suffix macros through glibc's "#  define" spelling

### DIFF
--- a/build/selfhost.w
+++ b/build/selfhost.w
@@ -343,6 +343,16 @@ fn bs_assert_not_contains(ctx: &ActionCtx, text: &str, needle: &str, label: &str
         return 0
     bs_fail(ctx, "found forbidden output for " ++ label ++ ": " ++ needle)
 
+// Passes when EITHER spelling is present. For assertions on migrated output
+// whose exact form is fixed by the system header text (glibc vs darwin
+// stdint.h spell the same const differently) yet is equally correct — both
+// alternatives must be a valid, intended output, never a way to accept a
+// wrong one.
+fn bs_assert_contains_either(ctx: &ActionCtx, text: &str, needle_a: &str, needle_b: &str, label: &str) -> i32:
+    if text.contains(needle_a) or text.contains(needle_b):
+        return 0
+    bs_fail(ctx, "missing expected output for " ++ label ++ ": " ++ needle_a ++ " (or " ++ needle_b ++ ")")
+
 fn bs_assert_count_at_least(ctx: &ActionCtx, text: &str, needle: &str, min_count: i32, label: &str) -> i32:
     let count = bs_count_occurrences(text, needle)
     if count >= min_count:
@@ -4733,7 +4743,11 @@ fn bs_check_migrate_paste_suffix_macros(ctx: &ActionCtx, compiler_path: &str, ca
     if rc != 0: return rc
     rc = bs_assert_contains(ctx, out_text, "let UINTMAX_MAX: c_ulong = 18446744073709551615u64", "paste_suffix_uintmax_max_literal")
     if rc != 0: return rc
-    rc = bs_assert_contains(ctx, out_text, "let INTMAX_MIN: c_long = ((0 - INTMAX_MAX) - 1)", "paste_suffix_intmax_min_folds_through_max")
+    // INTMAX_MIN folds to compile-time data either by reading INTMAX_MAX
+    // (darwin's `-INTMAX_MAX - 1`) or by re-pasting the same literal glibc's
+    // `-__INT64_C(9223372036854775807) - 1` spells inline — the system header
+    // decides, and both are the intended fold to i64::MIN, never a helper call.
+    rc = bs_assert_contains_either(ctx, out_text, "let INTMAX_MIN: c_long = ((0 - INTMAX_MAX) - 1)", "let INTMAX_MIN: c_long = ((0 - 9223372036854775807i64) - 1)", "paste_suffix_intmax_min_folds_through_max")
     if rc != 0: return rc
     rc = bs_assert_not_contains(ctx, out_text, "INTMAX_C(9223372036854775807", "paste_suffix_no_helper_call_for_literal")
     if rc != 0: return rc
@@ -4742,8 +4756,12 @@ fn bs_check_migrate_paste_suffix_macros(ctx: &ActionCtx, compiler_path: &str, ca
     // A use inside a function-like macro body takes the same route.
     rc = bs_assert_contains(ctx, out_text, "(1i64 << n)", "paste_suffix_literal_in_fn_macro_body")
     if rc != 0: return rc
-    // The generic helper remains the translation for a non-literal argument.
-    rc = bs_assert_contains(ctx, out_text, "fn INTMAX_C[T](v: T) -> i64", "paste_suffix_helper_kept")
+    // The generic helper remains the translation for a non-literal argument. Its
+    // parameter name is the system header's own macro parameter identifier —
+    // darwin spells `INTMAX_C(v)`, glibc spells `INTMAX_C(c)` — so both helper
+    // signatures are the identical intended `[T] -> i64` translation, differing
+    // only in that echoed name, never in whether the helper is kept.
+    rc = bs_assert_contains_either(ctx, out_text, "fn INTMAX_C[T](v: T) -> i64", "fn INTMAX_C[T](c: T) -> i64", "paste_suffix_helper_kept")
     if rc != 0: return rc
     rc = bs_assert_contains(ctx, out_text, "let X_MAX: c_longlong = 9223372036854775807", "paste_suffix_user_macro_probe_folds")
     if rc != 0: return rc

--- a/src/compiler/ClangBridge.w
+++ b/src/compiler/ClangBridge.w
@@ -2199,10 +2199,18 @@ unsafe fn macro_session_grow(ms: *mut MacroSession):
     (*ms).param_counts = npc as *mut i32
 
 fn macro_source_is_define_line(source: &str) -> bool:
+    // C permits whitespace between `#` and `define` (glibc writes `#  define`).
+    // Recognize it so the raw source line — which preserves token adjacency,
+    // unlike libclang's space-inserting spelling reconstruction — is used.
     var i = 0
     while i < source.len() as i32 and (source[i] == 32 or source[i] == 9):
         i = i + 1
-    i + 7 <= source.len() as i32 and source.slice(i as i64, (i + 7) as i64) == "#define"
+    if i >= source.len() as i32 or source.byte_at(i as i64) != 35:
+        return false
+    i = i + 1
+    while i < source.len() as i32 and (source.byte_at(i as i64) == 32 or source.byte_at(i as i64) == 9):
+        i = i + 1
+    i + 6 <= source.len() as i32 and source.slice(i as i64, (i + 6) as i64) == "define"
 
 unsafe fn macro_session_add_from_define_line(ms: *mut MacroSession, line_ptr: *const u8, loc_ptr: *const u8, is_system: i32):
     if line_ptr as i64 == 0:
@@ -2210,13 +2218,16 @@ unsafe fn macro_session_add_from_define_line(ms: *mut MacroSession, line_ptr: *c
     var define_start = line_ptr
     while *(define_start) == 32 or *(define_start) == 9:
         define_start = (define_start as i64 + 1) as *const u8
-    if c_strncmp(define_start, "#define\0" as *const u8, 7) == 0:
-        define_start = (define_start as i64 + 7) as *const u8
+    // `#` then optional whitespace then `define` (glibc's `#  define`).
+    if *define_start == 35:
+        define_start = (define_start as i64 + 1) as *const u8
+        while *(define_start) == 32 or *(define_start) == 9:
+            define_start = (define_start as i64 + 1) as *const u8
+        if c_strncmp(define_start, "define\0" as *const u8, 6) == 0:
+            define_start = (define_start as i64 + 6) as *const u8
     while *(define_start) == 32 or *(define_start) == 9:
         define_start = (define_start as i64 + 1) as *const u8
     if *define_start == 0:
-        return
-    if *define_start == 95 and *((define_start as i64 + 1) as *const u8) == 95:
         return
 
     var name_end = define_start


### PR DESCRIPTION
## What

Fixes the `c-migrator-core-tests` `paste_suffix_*` failures on glibc Linux
hosts. The paste-suffix macro folder (#945) only worked against darwin's
`<stdint.h>`; on a glibc host it left `INTMAX_MAX` / `UINTMAX_MAX` unfolded.

Stacked on #956.

## Root cause

The folder reads the token-paste suffix (`L`→`i64`, `UL`→`u64`, …) from a macro
session built out of the preprocessed `#define` lines. Two glibc `<stdint.h>`
facts defeated it:

- glibc writes `#  define` (whitespace between `#` and `define`); the
  define-line recognizer, keyed on a literal `#define`, did not match it.
- glibc routes the width constants through `__`-prefixed helpers — `INTMAX_MAX`
  is `__INT64_C(9223372036854775807)`, `UINTMAX_MAX` is `__UINT64_C(...)` —
  which the session builder dropped outright on its leading-underscore rule.

Together those made `__INT64_C` / `__INTMAX_C` / `__UINT64_C` invisible to the
folder, so those constants could not paste their suffix and stayed unfolded on
Linux while folding correctly on darwin.

## Fix

Commit 1 (compiler): recognize `#` + optional whitespace + `define`, and retain
`__`-prefixed paste macros in the session. Emission already filters
leading-underscore names, so a retained `__INT64_C` folds callers without ever
being emitted.

Commit 2 (tests): two fixture assertions were pinned to darwin's exact output.
The migrated form is fixed by the host header text and is equally correct either
way — INTMAX_MIN (`-INTMAX_MAX - 1` vs the literal inline) and the kept generic
helper's echoed parameter name (`INTMAX_C(v)` vs `INTMAX_C(c)`). Added
`bs_assert_contains_either` and accept both intended spellings — this loosens
the fixture to the set of correct results, not to accept a wrong one.

## Verification

`with build :c-migrator-core-tests` green on a glibc host (rebuilds + self-hosts
stage2, migrates the fixture, and runs it): `survey: all targets green`.
