### PR TITLE
rt: define Darwin stdio globals (__std{in,out,err}p) on non-Darwin backends

### DIFF
--- a/docs/with-abi.sha256
+++ b/docs/with-abi.sha256
@@ -1,2 +1,2 @@
-51c0fc69fdc9fdb5c3d5e72b99674747a98fa1caee61136bc429ab2d2ea857c6  src/FnAbi.w
+5e8bf31dafa42514ba8c456f79cd80124a1430904dfb1ed2afb5486bb6dfd28f  src/FnAbi.w
 b2815db8ace780ad6c8b41469da6b017921d51f6bf0298a50bbfddb0969620b5  src/TypeLayout.w

--- a/rt/linux_aarch64.w
+++ b/rt/linux_aarch64.w
@@ -43,6 +43,16 @@ extern var stdin: *mut c_void
 extern var stdout: *mut c_void
 extern var stderr: *mut c_void
 
+// Darwin-migrated C reads the preprocessed stdio globals __std{in,out,err}p;
+// glibc exports the streams as stdin/stdout/stderr instead. Define the
+// Darwin-spelled symbols here and bind them to the glibc streams at startup
+// (rt_store_args, the pre-main entry hook) so a Darwin-migrated harness links
+// and runs unchanged on Linux. Darwin's libSystem provides these directly, so
+// its backend does not define them.
+pub var __stdinp: *mut c_void = 0 as *mut c_void
+pub var __stdoutp: *mut c_void = 0 as *mut c_void
+pub var __stderrp: *mut c_void = 0 as *mut c_void
+
 fn get_errno() -> i32:
     let p = rt_libc_errno_location()
     unsafe *p
@@ -62,6 +72,9 @@ var rt_argv_raw: i64 = 0
 pub fn rt_store_args(argc_val: i32, argv_val: *const *const u8) -> Unit:
     rt_argc = argc_val
     rt_argv_raw = argv_val as i64
+    __stdinp = stdin
+    __stdoutp = stdout
+    __stderrp = stderr
 
 fn rt_random_fail():
     let msg = "fatal: could not read OS randomness\n" as *const u8

--- a/rt/linux_x86_64.w
+++ b/rt/linux_x86_64.w
@@ -43,6 +43,16 @@ extern var stdin: *mut c_void
 extern var stdout: *mut c_void
 extern var stderr: *mut c_void
 
+// Darwin-migrated C reads the preprocessed stdio globals __std{in,out,err}p;
+// glibc exports the streams as stdin/stdout/stderr instead. Define the
+// Darwin-spelled symbols here and bind them to the glibc streams at startup
+// (rt_store_args, the pre-main entry hook) so a Darwin-migrated harness links
+// and runs unchanged on Linux. Darwin's libSystem provides these directly, so
+// its backend does not define them.
+pub var __stdinp: *mut c_void = 0 as *mut c_void
+pub var __stdoutp: *mut c_void = 0 as *mut c_void
+pub var __stderrp: *mut c_void = 0 as *mut c_void
+
 fn get_errno() -> i32:
     let p = rt_libc_errno_location()
     unsafe *p
@@ -62,6 +72,9 @@ var rt_argv_raw: i64 = 0
 pub fn rt_store_args(argc_val: i32, argv_val: *const *const u8) -> Unit:
     rt_argc = argc_val
     rt_argv_raw = argv_val as i64
+    __stdinp = stdin
+    __stdoutp = stdout
+    __stderrp = stderr
 
 fn rt_random_fail():
     let msg = "fatal: could not read OS randomness\n" as *const u8

--- a/src/FnAbi.w
+++ b/src/FnAbi.w
@@ -103,6 +103,8 @@ pub fn codegen_is_runtime_abi_symbol(base_name: &str) -> bool:
     if base_name.starts_with("with_") or base_name.starts_with("rt_") or base_name.starts_with("wl_"):
         return true
     base_name == "__error" or base_name == "__open" or
+        base_name == "__stdinp" or base_name == "__stdoutp" or
+        base_name == "__stderrp" or
         base_name == "gethostname" or base_name == "pthread_self" or
         base_name == "mkstemp" or base_name == "realpath" or
         base_name == "i32_to_str" or base_name == "i64_to_string" or


### PR DESCRIPTION
## What

Fixes the `pcre2-wo-drift` lane failing to link the corpus harness on every
glibc Linux lane (linux-x86_64, linux-aarch64), while it passed on darwin.

Stacked on #997.

## Root cause

A `.wo` corpus harness is migrated once from the host's preprocessed C and
checked in for all platforms. `lib/std/re/pcre2test.w` was migrated on darwin,
whose `<stdio.h>` does `#define stderr __stderrp` (also `__stdoutp` /
`__stdinp`), so the checked-in harness references the bare symbols `__stdinp` /
`__stdoutp` / `__stderrp` (91 sites). glibc exports the streams as
`stdin` / `stdout` / `stderr` instead, so on Linux those three symbols had **no
producer** — the harness link (against both the stored embedded bundle and the
freshly-rebuilt one) failed with `undefined reference to '__stderrp'` etc.

## Fix

Mirrors the existing `__error` / `__open` darwin-compat precedent already in the
tree:

- **`rt/linux_x86_64.w`, `rt/linux_aarch64.w`**: define `pub var __stdinp /
  __stdoutp / __stderrp` and bind them to the glibc streams
  `stdin` / `stdout` / `stderr` in `rt_store_args`, the guaranteed pre-main
  entry hook. Darwin's libSystem provides these directly, so the darwin backend
  does not define them and is unaffected.
- **`src/FnAbi.w`**: add the three names to `codegen_is_runtime_abi_symbol`'s
  whitelist so a runtime-source `pub var` definition keeps its **bare** link
  name in module-object mode (it otherwise mangles to `__with_mod_<hash>__<base>`
  and never satisfies the harness's bare reference) — exactly as `__error` /
  `__open` already do.
- **`docs/with-abi.sha256`**: `FnAbi.w` is an ABI-defining source, so its hash
  is re-recorded. The pcre2 bundle re-keys and rebuilds once into its new slot;
  the object is byte-identical (the symbol-naming change does not touch pcre2
  codegen). The naming convention is unchanged — a whitelist extension, like the
  prior `__error` / `__open` entries — so `WITH_ABI_VERSION` stays 1.

No platform gate, no skip: the Darwin-spelled globals now resolve on every
target.

## Verification

On linux-x86_64 (glibc):
- `with build` + `with build :fixpoint` green (stage2 == stage3).
- `with build :pcre2-wo-drift` green: `survey: all targets green`;
  `harness-build-stored.stderr` clean of undefined-symbol errors (was
  `undefined reference to '__stderrp'/'__stdoutp'/'__stdinp'`).
- `nm out/lib/rt_linux_x86_64.o` shows `__stdinp` / `__stdoutp` / `__stderrp`
  as bare BSS symbols.
