### PR TITLE
Windows: pin .wi fixtures to LF + define __std*p via __acrt_iob_func

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,11 @@ test/behavior/**/*.txt text eol=lf
 # project-root check. Pin LF so the hash is stable and the record parses cleanly.
 *.w text eol=lf
 docs/with-abi.sha256 text eol=lf
+
+# .wi interface fixtures (test/bundle_interface/*.wi) are compared byte-for-byte
+# against the compiler's freshly-emitted interface. Under core.autocrlf=true a
+# native Windows checkout rewrites the checked-in fixture's LF to CRLF, so each
+# read line carries a trailing "\r" the emitted (LF) interface never has, and the
+# byte-exact comparison fails on every line — reddening bundle-interface-tests on
+# Windows only. Pin LF so the fixture matches emitted output on every platform.
+*.wi text eol=lf

--- a/rt/windows_aarch64.w
+++ b/rt/windows_aarch64.w
@@ -57,6 +57,9 @@ extern fn with_str_from_cstr(s: *const u8) -> str
 extern fn with_alloc(size: i64) -> *mut u8
 extern fn with_free(ptr: *mut u8) -> Unit
 extern fn with_memcpy(dst: *mut u8, src: *const u8, len: i64) -> *mut u8
+// UCRT has no stdin/stdout/stderr global variables; the FILE* streams come from
+// __acrt_iob_func(0/1/2) (the UCRT `#define stdin (__acrt_iob_func(0))` macros).
+extern fn __acrt_iob_func(index: u32) -> *mut c_void
 
 let INVALID_HANDLE_VALUE: i64 = -1
 let STD_INPUT_HANDLE: i32 = -10
@@ -95,6 +98,16 @@ type RtSysInfo:
     cpu_cores: i32
     memory_total: i64
     page_size: i64
+
+// Darwin-migrated C reads the preprocessed stdio globals __std{in,out,err}p;
+// Windows/UCRT has neither those symbols nor stdin/stdout/stderr globals -- the
+// FILE* streams come from __acrt_iob_func(0/1/2). Define the Darwin-spelled
+// symbols here and bind them to the UCRT stream table at startup (rt_store_args,
+// the pre-main entry hook) so a Darwin-migrated harness (pcre2test.w) links and
+// runs unchanged on Windows. See rt/linux_x86_64.w for the glibc analogue.
+pub var __stdinp: *mut c_void = 0 as *mut c_void
+pub var __stdoutp: *mut c_void = 0 as *mut c_void
+pub var __stderrp: *mut c_void = 0 as *mut c_void
 
 var rt_argc: i32 = 0
 var rt_argv_raw: i64 = 0
@@ -187,6 +200,9 @@ fn win_alloc_fd(handle: i64) -> i32:
 pub fn rt_store_args(argc_val: i32, argv_val: *const *const u8) -> Unit:
     rt_argc = argc_val
     rt_argv_raw = argv_val as i64
+    __stdinp = __acrt_iob_func(0 as u32)
+    __stdoutp = __acrt_iob_func(1 as u32)
+    __stderrp = __acrt_iob_func(2 as u32)
 
 pub fn rt_args() -> (*const *const u8, i32):
     (rt_argv_raw as *const *const u8, rt_argc)

--- a/rt/windows_x86_64.w
+++ b/rt/windows_x86_64.w
@@ -52,6 +52,9 @@ extern fn with_str_from_cstr(s: *const u8) -> str
 extern fn with_alloc(size: i64) -> *mut u8
 extern fn with_free(ptr: *mut u8) -> Unit
 extern fn with_memcpy(dst: *mut u8, src: *const u8, len: i64) -> *mut u8
+// UCRT has no stdin/stdout/stderr global variables; the FILE* streams come from
+// __acrt_iob_func(0/1/2) (the UCRT `#define stdin (__acrt_iob_func(0))` macros).
+extern fn __acrt_iob_func(index: u32) -> *mut c_void
 
 let INVALID_HANDLE_VALUE: i64 = -1
 let STD_INPUT_HANDLE: i32 = -10
@@ -90,6 +93,16 @@ type RtSysInfo:
     cpu_cores: i32
     memory_total: i64
     page_size: i64
+
+// Darwin-migrated C reads the preprocessed stdio globals __std{in,out,err}p;
+// Windows/UCRT has neither those symbols nor stdin/stdout/stderr globals -- the
+// FILE* streams come from __acrt_iob_func(0/1/2). Define the Darwin-spelled
+// symbols here and bind them to the UCRT stream table at startup (rt_store_args,
+// the pre-main entry hook) so a Darwin-migrated harness (pcre2test.w) links and
+// runs unchanged on Windows. See rt/linux_x86_64.w for the glibc analogue.
+pub var __stdinp: *mut c_void = 0 as *mut c_void
+pub var __stdoutp: *mut c_void = 0 as *mut c_void
+pub var __stderrp: *mut c_void = 0 as *mut c_void
 
 var rt_argc: i32 = 0
 var rt_argv_raw: i64 = 0
@@ -182,6 +195,9 @@ fn win_alloc_fd(handle: i64) -> i32:
 pub fn rt_store_args(argc_val: i32, argv_val: *const *const u8) -> Unit:
     rt_argc = argc_val
     rt_argv_raw = argv_val as i64
+    __stdinp = __acrt_iob_func(0 as u32)
+    __stdoutp = __acrt_iob_func(1 as u32)
+    __stderrp = __acrt_iob_func(2 as u32)
 
 pub fn rt_args() -> (*const *const u8, i32):
     (rt_argv_raw as *const *const u8, rt_argc)


### PR DESCRIPTION
## What

Fixes the two remaining Windows-only reds in the pcre2/bundle-interface red wave,
on **both** Windows lanes (x86_64 and aarch64). Stacked on #1016.

- **`bundle-interface-tests`** — CRLF on an unpinned `.wi` fixture.
- **`pcre2-wo-drift`** — the Darwin-migrated stdio globals `__std{in,out,err}p`
  have no producer on Windows.

Both are architecture-independent: they fail identically on windows-x86_64 and
windows-aarch64, and pass on Linux and macOS.

## Rung D — pin `.wi` interface fixtures to LF

`test/bundle_interface/*.wi` fixtures are compared byte-for-byte against the
compiler's freshly-emitted interface. Under `core.autocrlf=true` (GitHub's
Windows runners' default) a native Windows checkout rewrites the checked-in
fixture's LF to CRLF, so every read line carries a trailing `\r` the emitted (LF)
interface never has — the byte-exact comparison then fails on every line and reds
`bundle-interface-tests` on Windows only.

The `.wi` fixtures were simply never covered by an `eol=lf` attribute, unlike
`*.w` and `docs/with-abi.sha256` (#942). Fix: add `*.wi text eol=lf` to
`.gitattributes`. No `.wi` blob has CRLF today, so the pin is a no-op on
Linux/mac and only corrects the Windows checkout. Same class as #942.

## Rung E — define `__std{in,out,err}p` on Windows backends

The `pcre2test.w` `.wo` corpus harness is migrated once from the host's
preprocessed C and checked in for every platform. It was migrated on Darwin,
whose `<stdio.h>` does `#define stderr __stderrp` (also `__stdoutp` / `__stdinp`),
so the checked-in harness references the bare symbols `__stdinp` / `__stdoutp` /
`__stderrp` (91 sites). Windows/UCRT has neither those symbols nor
`stdin`/`stdout`/`stderr` global variables — the `FILE*` streams come from
`__acrt_iob_func(0/1/2)` — so on Windows those three symbols had **no producer**
and the harness link failed. #1016 fixed the same class for glibc; this is its
Windows twin.

Fix mirrors the glibc analogue now in `rt/linux_x86_64.w` and the existing
`__error` / `__open` darwin-compat precedent:

- **`rt/windows_x86_64.w`, `rt/windows_aarch64.w`**: declare
  `extern fn __acrt_iob_func(index: u32)`, define `pub var __stdinp / __stdoutp /
  __stderrp`, and bind them to `__acrt_iob_func(0/1/2)` in `rt_store_args`, the
  guaranteed pre-main entry hook.
- **No `src/FnAbi.w` change**: `codegen_is_runtime_abi_symbol` already whitelists
  the three names (added with the glibc fix in #1016) and
  `codegen_is_runtime_source_file` already matches `rt/` and `rt\` paths, so the
  `pub var` definitions keep their **bare** link names in module-object mode and
  satisfy the harness's bare references. `docs/with-abi.sha256` is therefore
  unchanged and no bundle re-keys.

No platform gate, no skip: the Darwin-spelled globals now resolve on every target.

## Verification

- Rung D: `git check-attr text eol -- test/bundle_interface/wi_demo.wi` →
  `text: set` / `eol: lf`; no `.wi` blob contains CRLF.
- Rung E: cross-emitted `rt/windows_x86_64.w` to a COFF object; `nm` shows
  `__stdinp` / `__stdoutp` / `__stderrp` as bare BSS symbols, `__acrt_iob_func`
  as an undefined UCRT import, and `rt_store_args` (the binder) defined. The
  edits are structurally identical for aarch64.
- Host (Linux/mac) build/fixpoint are unaffected by construction: neither
  `.gitattributes` nor `rt/windows_*.w` is compiled into the host compiler.
