### PR TITLE
Build: keep build-driver files seed-compatible (revert comptime str-index sweep)

### DIFF
--- a/build.w
+++ b/build.w
@@ -19,7 +19,7 @@ fn build_owned_text(s: &str): s ++ ""
 fn build_project_dirname(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     if last_slash < 0:
         return "."
@@ -539,18 +539,18 @@ fn target_with_compiler_source_inputs(target: Target, ctx: &BuildCtx) -> Target:
 fn build_project_trim_line(text: &str) -> str:
     var end = 0
     while end < text.len() as i32:
-        let ch = text[end]
+        let ch = text.byte_at(end as i64)
         if ch == 10 or ch == 13:
             break
         end = end + 1
     var start = 0
     while start < end:
-        let ch = text[start]
+        let ch = text.byte_at(start as i64)
         if ch != 9 and ch != 32:
             break
         start = start + 1
     while end > start:
-        let ch = text[(end - 1)]
+        let ch = text.byte_at((end - 1) as i64)
         if ch != 9 and ch != 32:
             break
         end = end - 1
@@ -960,14 +960,14 @@ fn build_project_join(left: &str, right: &str) -> str:
     left ++ "/" ++ right
 
 fn build_project_abs(root: &str, path: &str) -> str:
-    if path.len() > 0 and path[0] == 47:
+    if path.len() > 0 and path.byte_at(0) == 47:
         return build_owned_text(path)
     build_project_join(root, path)
 
 fn build_trim_trailing_line_endings(text: &str) -> str:
     var end = text.len()
     while end > 0:
-        let ch = text[end - 1]
+        let ch = text.byte_at(end - 1)
         if ch != 10 and ch != 13:
             break
         end = end - 1
@@ -1044,7 +1044,7 @@ fn issue61_regression_action(ctx: ActionCtx) -> i32:
     if marker_at < 0:
         return issue61_fail(ctx, "missing insertion point in " ++ sema_path)
     var indent_start = marker_at
-    while indent_start > 0 and sema_text[(indent_start - 1)] != 10:
+    while indent_start > 0 and sema_text.byte_at((indent_start - 1) as i64) != 10:
         indent_start = indent_start - 1
     let indent = sema_text.slice(indent_start as i64, marker_at as i64)
     let marker = indent ++ marker_comment

--- a/build/abi.w
+++ b/build/abi.w
@@ -15,7 +15,7 @@ fn abi_split_lines(text: &str) -> Vec[str]:
     var start: i64 = 0
     var i: i64 = 0
     while i < text.len():
-        if text[i] == '\n':
+        if text.byte_at(i) == '\n':
             out.push(text.slice(start, i))
             start = i + 1
         i = i + 1

--- a/build/clang_resource.w
+++ b/build/clang_resource.w
@@ -20,7 +20,7 @@ fn cr_fail(ctx: &ActionCtx, message: &str) -> i32:
 fn cr_dirname(path: &str) -> str:
     var last = -1
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 47 or ch == 92:
             last = i
     if last <= 0:
@@ -30,7 +30,7 @@ fn cr_dirname(path: &str) -> str:
 fn cr_basename(path: &str) -> str:
     var last = -1
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 47 or ch == 92:
             last = i
     if last < 0:
@@ -40,7 +40,7 @@ fn cr_basename(path: &str) -> str:
 fn cr_normalize_path_separators(path: &str) -> str:
     var out = ""
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 92:
             out = out ++ "/"
         else:
@@ -51,8 +51,8 @@ fn cr_str_compare(a: &str, b: &str) -> i32:
     let n = if a.len() < b.len(): a.len() else: b.len()
     var i = 0
     while i < n as i32:
-        let ac = a[i] as i32
-        let bc = b[i] as i32
+        let ac = a.byte_at(i as i64)
+        let bc = b.byte_at(i as i64)
         if ac != bc:
             return ac - bc
         i = i + 1
@@ -88,7 +88,7 @@ fn cr_contains_delimiter(text: &str, hashes: &str) -> bool:
         var j = 0
         var matched = true
         while j < needle.len() as i32:
-            if text[(i + j)] != needle[j]:
+            if text.byte_at((i + j) as i64) != needle.byte_at(j as i64):
                 matched = false
                 break
             j = j + 1

--- a/build/compiler.w
+++ b/build/compiler.w
@@ -51,12 +51,12 @@ fn comp_join(left: &str, right: &str) -> str:
 fn comp_is_absolute_path(path: &str) -> bool:
     if path.len() == 0:
         return false
-    if path[0] == 47 or path[0] == 92:
+    if path.byte_at(0) == 47 or path.byte_at(0) == 92:
         return true
     if os() == "Windows" and path.len() >= 3:
-        let drive = path[0]
-        let colon = path[1]
-        let slash = path[2]
+        let drive = path.byte_at(0)
+        let colon = path.byte_at(1)
+        let slash = path.byte_at(2)
         if colon == 58 and (slash == 47 or slash == 92):
             if (drive >= 65 and drive <= 90) or (drive >= 97 and drive <= 122):
                 return true
@@ -70,7 +70,7 @@ fn comp_abs(root: &str, path: &str) -> str:
 fn comp_dirname(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 47 or ch == 92:
             last_slash = i
     if last_slash < 0:
@@ -82,7 +82,7 @@ fn comp_dirname(path: &str) -> str:
 pub fn comp_path_basename(path: &str) -> str:
     var last_slash: i64 = -1
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 47 or ch == 92:
             last_slash = i as i64
     if last_slash >= 0:
@@ -137,12 +137,12 @@ fn comp_trim(text: &str) -> str:
     var start = 0
     var end = text.len() as i32
     while start < end:
-        let ch = text[start]
+        let ch = text.byte_at(start as i64)
         if ch != 9 and ch != 10 and ch != 13 and ch != 32:
             break
         start = start + 1
     while end > start:
-        let ch = text[(end - 1)]
+        let ch = text.byte_at((end - 1) as i64)
         if ch != 9 and ch != 10 and ch != 13 and ch != 32:
             break
         end = end - 1
@@ -151,7 +151,7 @@ fn comp_trim(text: &str) -> str:
 fn comp_first_trimmed_line(text: &str) -> str:
     var end = text.len() as i32
     for i in 0..text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         if ch == 10 or ch == 13:
             end = i
             break
@@ -166,7 +166,7 @@ fn comp_index_of(text: &str, needle: &str) -> i32:
     for i in 0..(last + 1):
         var matched = true
         for j in 0..needle.len() as i32:
-            if text[(i + j)] != needle[j]:
+            if text.byte_at((i + j) as i64) != needle.byte_at(j as i64):
                 matched = false
                 break
         if matched:
@@ -195,7 +195,7 @@ fn comp_replace_all(text: &str, needle: &str, replacement: &str) -> str:
 fn comp_normalize_line_endings(text: &str) -> str:
     var has_cr = false
     for ci in 0..text.len() as i32:
-        if text[ci] == 13:
+        if text.byte_at(ci as i64) == 13:
             has_cr = true
             break
     if not has_cr:
@@ -209,11 +209,11 @@ fn comp_normalize_line_endings(text: &str) -> str:
     var start = 0
     var i = 0
     while i < text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         if ch == 13:
             if i > start:
                 out.push_str(text.slice(start as i64, i as i64))
-            if i + 1 < text.len() as i32 and text[(i + 1)] == 10:
+            if i + 1 < text.len() as i32 and text.byte_at((i + 1) as i64) == 10:
                 i = i + 1
             out.push_str("\n")
             start = i + 1
@@ -353,7 +353,7 @@ fn comp_step_timeout_ms() -> i32:
     let raw = env("WITH_BUILD_STEP_TIMEOUT_MS")
     var parsed = 0
     for i in 0..raw.len() as i32:
-        let ch = raw[i]
+        let ch = raw.byte_at(i as i64)
         if ch < 48 or ch > 57:
             parsed = 0
             break
@@ -388,7 +388,7 @@ fn comp_resolve_seed_compiler(ctx: &ActionCtx) -> str:
         var start = 0
         for i in 0..path_env.len() as i32 + 1:
             let at_end = i == path_env.len() as i32
-            let is_sep = not at_end and path_env[i] == comp_path_separator()
+            let is_sep = not at_end and path_env.byte_at(i as i64) == comp_path_separator()
             if is_sep or at_end:
                 if i > start:
                     let dir = path_env.slice(start as i64, i as i64)
@@ -527,7 +527,7 @@ fn comp_parse_nonnegative_i32(text: &str) -> i32:
         return -1
     var value = 0
     for i in 0..text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         if ch < 48 or ch > 57:
             return -1
         value = value * 10 + (ch - 48)
@@ -563,13 +563,13 @@ fn comp_stack_collect_after_marker(text: &str, marker: &str, sizes: Vec[i32]) ->
             break
         var pos = at + marker.len() as i32
         while pos < text.len() as i32:
-            let ch = text[pos]
+            let ch = text.byte_at(pos as i64)
             if ch != 9 and ch != 32:
                 break
             pos = pos + 1
         var sign = 1
         if pos < text.len() as i32:
-            let sign_ch = text[pos]
+            let sign_ch = text.byte_at(pos as i64)
             if sign_ch == 43:
                 pos = pos + 1
             else if sign_ch == 45:
@@ -578,7 +578,7 @@ fn comp_stack_collect_after_marker(text: &str, marker: &str, sizes: Vec[i32]) ->
         var value = 0
         var seen_digit = false
         while pos < text.len() as i32:
-            let ch = text[pos]
+            let ch = text.byte_at(pos as i64)
             if ch < 48 or ch > 57:
                 break
             value = value * 10 + (ch - 48)
@@ -642,18 +642,18 @@ fn comp_count_actual_c_export_attrs(text: &str) -> i32:
     var i: i64 = 0
     while i <= text.len():
         let at_end = i == text.len()
-        if at_end or text[i] == 10:
+        if at_end or text.byte_at(i) == 10:
             var p = line_start
             while p < i:
-                let ch = text[p]
+                let ch = text.byte_at(p)
                 if ch != 9 and ch != 32:
                     break
                 p = p + 1
-            if p + 11 <= i and text[p] == 64:
-                if text[p + 1] == 91 and text[p + 2] == 99 and text[p + 3] == 95 and
-                    text[p + 4] == 101 and text[p + 5] == 120 and text[p + 6] == 112 and
-                    text[p + 7] == 111 and text[p + 8] == 114 and text[p + 9] == 116 and
-                    text[p + 10] == 40:
+            if p + 11 <= i and text.byte_at(p) == 64:
+                if text.byte_at(p + 1) == 91 and text.byte_at(p + 2) == 99 and text.byte_at(p + 3) == 95 and
+                    text.byte_at(p + 4) == 101 and text.byte_at(p + 5) == 120 and text.byte_at(p + 6) == 112 and
+                    text.byte_at(p + 7) == 111 and text.byte_at(p + 8) == 114 and text.byte_at(p + 9) == 116 and
+                    text.byte_at(p + 10) == 40:
                     count = count + 1
             line_start = i + 1
         i = i + 1
@@ -712,9 +712,9 @@ fn comp_split_lines(text: &str) -> Vec[str]:
     var i: i64 = 0
     while i <= text.len():
         let at_end = i == text.len()
-        if at_end or text[i] == 10:
+        if at_end or text.byte_at(i) == 10:
             var end = i
-            if end > start and text[end - 1] == 13:
+            if end > start and text.byte_at(end - 1) == 13:
                 end = end - 1
             lines.push(text.slice(start, end))
             start = i + 1
@@ -755,7 +755,7 @@ fn comp_add_words(items: Vec[str], text: &str) -> Vec[str]:
     var out = items
     var start = -1
     for i in 0..text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         let ws = ch == 9 or ch == 10 or ch == 13 or ch == 32
         if ws:
             if start >= 0:
@@ -792,7 +792,7 @@ fn comp_spec_subsection(text: &str, heading: &str) -> str:
     var end = text.len() as i32
     var i = start + 1
     while i < text.len() as i32:
-        if text[i] == 10:
+        if text.byte_at(i as i64) == 10:
             if i + 4 < text.len() as i32 and text.slice((i + 1) as i64, (i + 4) as i64) == "## ":
                 end = i
                 break
@@ -837,9 +837,9 @@ fn comp_collect_attr_names(items: Vec[str], text: &str) -> Vec[str]:
         if at < 0:
             break
         let name_start = at + 2
-        if name_start < text.len() as i32 and comp_is_ident_start(text[name_start]):
+        if name_start < text.len() as i32 and comp_is_ident_start(text.byte_at(name_start as i64)):
             var name_end = name_start + 1
-            while name_end < text.len() as i32 and comp_is_ident_continue(text[name_end]):
+            while name_end < text.len() as i32 and comp_is_ident_continue(text.byte_at(name_end as i64)):
                 name_end = name_end + 1
             let item = text.slice(name_start as i64, name_end as i64)
             if item.len() > 0 and not comp_vec_contains(out, item):
@@ -863,7 +863,7 @@ fn comp_spec_public_attributes(spec: &str) -> Vec[str]:
         if line.starts_with("| `@["):
             var end = -1
             for ci in 1..line.len() as i32:
-                if line[ci] == 124:
+                if line.byte_at(ci as i64) == 124:
                     end = ci
                     break
             if end > 1:
@@ -914,7 +914,7 @@ fn comp_strip_comment(text: &str) -> str:
 fn comp_first_shell_word(text: &str) -> str:
     let trimmed = comp_trim(text)
     for i in 0..trimmed.len() as i32:
-        let ch = trimmed[i]
+        let ch = trimmed.byte_at(i as i64)
         if ch == 9 or ch == 32:
             return trimmed.slice(0, i as i64)
     trimmed
@@ -933,7 +933,7 @@ fn comp_spec_cli_commands(spec: &str) -> Vec[str]:
         var part_start = 0
         var pi = 0
         while pi <= body.len() as i32:
-            if pi == body.len() as i32 or body[pi] == 124:
+            if pi == body.len() as i32 or body.byte_at(pi as i64) == 124:
                 var part = comp_trim(body.slice(part_start as i64, pi as i64))
                 if part.starts_with("with "):
                     part = comp_trim(part.slice(5, part.len()))
@@ -983,12 +983,12 @@ fn comp_collect_string_literal_flags(items: Vec[str], text: &str) -> Vec[str]:
     var flags = items
     var i = 0
     while i < text.len() as i32:
-        if text[i] != 34:
+        if text.byte_at(i as i64) != 34:
             i = i + 1
             continue
         var j = i + 1
         while j < text.len() as i32:
-            let ch = text[j]
+            let ch = text.byte_at(j as i64)
             if ch == 92:
                 j = j + 2
                 continue
@@ -998,14 +998,14 @@ fn comp_collect_string_literal_flags(items: Vec[str], text: &str) -> Vec[str]:
         if j >= text.len() as i32:
             break
         let literal = text.slice((i + 1) as i64, j as i64)
-        if literal.len() >= 2 and literal[0] == 45:
+        if literal.len() >= 2 and literal.byte_at(0) == 45:
             var hyphens = 1
-            if literal.len() >= 3 and literal[1] == 45:
+            if literal.len() >= 3 and literal.byte_at(1) == 45:
                 hyphens = 2
-            if literal.len() > hyphens and comp_is_ident_continue(literal[hyphens]):
+            if literal.len() > hyphens and comp_is_ident_continue(literal.byte_at(hyphens as i64)):
                 var end = hyphens + 1
                 while end < literal.len() as i32:
-                    let ch = literal[end]
+                    let ch = literal.byte_at(end as i64)
                     if not ((ch >= 65 and ch <= 90) or (ch >= 97 and ch <= 122) or (ch >= 48 and ch <= 57) or ch == 45):
                         break
                     end = end + 1
@@ -1050,7 +1050,7 @@ fn comp_std_module_from_path(path: &str) -> str:
         return ""
     var first = compiler_owned_text(rest)
     for i in 0..rest.len() as i32:
-        if rest[i] == 47:
+        if rest.byte_at(i as i64) == 47:
             first = rest.slice(0, i as i64)
             break
     if first.len() == 0 or first.starts_with("."):
@@ -1283,7 +1283,7 @@ pub fn run_stack_budget_check_action(ctx: ActionCtx) -> i32:
 fn comp_json_escape(text: &str) -> str:
     var out = ""
     for i in 0..text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         if ch == 34:
             out = out ++ "\\\""
         else if ch == 92:
@@ -1380,16 +1380,16 @@ fn comp_find_packed_ref(fs: &ToolFs, root: &str, ref_path: &str) -> str:
         return ""
     var line_start: i64 = 0
     for i in 0..packed.len() as i32:
-        if packed[i] == 10:
+        if packed.byte_at(i as i64) == 10:
             let line = packed.slice(line_start, i as i64)
-            if line.len() > 41 and line[0] != 35:
+            if line.len() > 41 and line.byte_at(0) != 35:
                 let ref_in_line = line.slice(41, line.len())
                 if ref_in_line == ref_path:
                     return line.slice(0, 9)
             line_start = i as i64 + 1
     if line_start < packed.len():
         let line = packed.slice(line_start, packed.len())
-        if line.len() > 41 and line[0] != 35:
+        if line.len() > 41 and line.byte_at(0) != 35:
             let ref_in_line = line.slice(41, line.len())
             if ref_in_line == ref_path:
                 return line.slice(0, 9)
@@ -1907,7 +1907,7 @@ fn comp_check_manifest(fs: &ToolFs, manifest: &str) -> str:
     var changed = ""
     var line_start: i64 = 0
     for i in 0..manifest.len() as i32:
-        if manifest[i] == 10:
+        if manifest.byte_at(i as i64) == 10:
             let line = manifest.slice(line_start, i as i64)
             if line.len() > 0:
                 let sep = comp_last_colon_pos(line)
@@ -1924,22 +1924,22 @@ fn comp_check_manifest(fs: &ToolFs, manifest: &str) -> str:
 fn comp_fnv1a(s: &str) -> i64:
     var h: i64 = -3750763034362895579
     for i in 0..s.len() as i32:
-        h = h ^ (s[i] as i64)
+        h = h ^ (s.byte_at(i as i64) as i64)
         h = h *% 1099511628211
     h
 
 fn comp_last_colon_pos(line: &str) -> i64:
     var pos: i64 = -1
     for i in 0..line.len() as i32:
-        if line[i] == 58:
+        if line.byte_at(i as i64) == 58:
             pos = i as i64
     pos
 
 fn comp_str_compare(a: &str, b: &str) -> i32:
     let min_len = if a.len() < b.len(): a.len() else: b.len()
     for i in 0..min_len as i32:
-        let ac = a[i] as i32
-        let bc = b[i] as i32
+        let ac = a.byte_at(i as i64)
+        let bc = b.byte_at(i as i64)
         if ac != bc:
             return ac - bc
     if a.len() == b.len():

--- a/build/emit_c.w
+++ b/build/emit_c.w
@@ -32,14 +32,14 @@ fn emitc_join(left: &str, right: &str) -> str:
     left ++ "/" ++ right
 
 fn emitc_abs(root: &str, path: &str) -> str:
-    if path.len() > 0 and path[0] == 47:
+    if path.len() > 0 and path.byte_at(0) == 47:
         return emit_c_owned_text(path)
     emitc_join(root, path)
 
 fn emitc_dirname(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     if last_slash < 0:
         return "."
@@ -50,7 +50,7 @@ fn emitc_dirname(path: &str) -> str:
 fn emitc_basename(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     path.slice((last_slash + 1) as i64, path.len())
 
@@ -63,12 +63,12 @@ fn emitc_trim(text: &str) -> str:
     var start = 0
     var end = text.len() as i32
     while start < end:
-        let ch = text[start]
+        let ch = text.byte_at(start as i64)
         if ch != 9 and ch != 10 and ch != 13 and ch != 32:
             break
         start = start + 1
     while end > start:
-        let ch = text[(end - 1)]
+        let ch = text.byte_at((end - 1) as i64)
         if ch != 9 and ch != 10 and ch != 13 and ch != 32:
             break
         end = end - 1
@@ -224,7 +224,7 @@ fn emitc_index_of(text: &str, needle: &str) -> i32:
         var j = 0
         var matched = true
         while j < needle.len() as i32:
-            if text[(i + j)] != needle[j]:
+            if text.byte_at((i + j) as i64) != needle.byte_at(j as i64):
                 matched = false
                 break
             j = j + 1
@@ -239,9 +239,9 @@ fn emitc_split_lines(text: &str) -> Vec[str]:
     var i = 0
     while i <= text.len() as i32:
         let at_end = i == text.len() as i32
-        if at_end or text[i] == 10:
+        if at_end or text.byte_at(i as i64) == 10:
             var line = text.slice(start as i64, i as i64)
-            if line.len() > 0 and line[line.len() - 1] == 13:
+            if line.len() > 0 and line.byte_at(line.len() - 1) == 13:
                 line = line.slice(0, line.len() - 1)
             lines.push(line)
             start = i + 1
@@ -256,7 +256,7 @@ fn emitc_c_export_symbol(line: &str) -> str:
     let symbol_start = start + prefix.len() as i32
     var i = symbol_start
     while i < line.len() as i32:
-        if line[i] == 34:
+        if line.byte_at(i as i64) == 34:
             return line.slice(symbol_start as i64, i as i64)
         i = i + 1
     ""
@@ -265,7 +265,7 @@ fn emitc_find_matching_paren(text: &str, open_at: i32) -> i32:
     var depth = 0
     var i = open_at
     while i < text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         if ch == 40:
             depth = depth + 1
         else if ch == 41:
@@ -312,7 +312,7 @@ fn emitc_parse_param(param_text: &str) -> EmitCParam:
     let trimmed = emitc_trim(param_text)
     var colon = -1
     for i in 0..trimmed.len() as i32:
-        if trimmed[i] == 58:
+        if trimmed.byte_at(i as i64) == 58:
             colon = i
             break
     if colon < 0:
@@ -327,7 +327,7 @@ fn emitc_parse_params(text: &str) -> Vec[EmitCParam]:
     var i = 0
     while i <= text.len() as i32:
         let at_end = i == text.len() as i32
-        if at_end or text[i] == 44:
+        if at_end or text.byte_at(i as i64) == 44:
             let piece = emitc_trim(text.slice(start as i64, i as i64))
             if piece.len() > 0:
                 params.push(emitc_parse_param(piece))
@@ -343,7 +343,7 @@ fn emitc_parse_export_function(symbol: &str, line: &str) -> EmitCFunction:
     var open_at = -1
     var i = fn_at
     while i < line.len() as i32:
-        if line[i] == 40:
+        if line.byte_at(i as i64) == 40:
             open_at = i
             break
         i = i + 1
@@ -370,7 +370,7 @@ fn emitc_parse_export_function(symbol: &str, line: &str) -> EmitCFunction:
         let after_arrow = rest.slice((arrow + 2) as i64, rest.len())
         var colon = -1
         for ci in 0..after_arrow.len() as i32:
-            if after_arrow[ci] == 58:
+            if after_arrow.byte_at(ci as i64) == 58:
                 colon = ci
                 break
         if colon < 0:
@@ -417,7 +417,7 @@ fn emitc_public_function_name(line: &str) -> str:
         return ""
     var i = start
     while i < line.len() as i32:
-        let ch = line[i]
+        let ch = line.byte_at(i as i64)
         if ch == 40 or ch == 32 or ch == 58:
             break
         i = i + 1
@@ -823,7 +823,7 @@ fn emitc_compare_files(ctx: &ActionCtx, left_path: &str, right_path: &str) -> i3
     var diff_at = -1
     var i = 0
     while i < min_len:
-        if left[i] != right[i]:
+        if left.byte_at(i as i64) != right.byte_at(i as i64):
             diff_at = i
             break
         i = i + 1

--- a/build/package.w
+++ b/build/package.w
@@ -22,7 +22,7 @@ fn pkg_join(left: &str, right: &str) -> str:
 fn pkg_dirname(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 47 or ch == 92:
             last_slash = i
     if last_slash < 0:
@@ -39,12 +39,12 @@ fn pkg_abs(root: &str, path: &str) -> str:
 fn pkg_is_abs(path: &str) -> bool:
     if path.len() == 0:
         return false
-    if path[0] == 47 or path[0] == 92:
+    if path.byte_at(0) == 47 or path.byte_at(0) == 92:
         return true
     if os() == "Windows" and path.len() >= 3:
-        let drive = path[0]
-        let colon = path[1]
-        let slash = path[2]
+        let drive = path.byte_at(0)
+        let colon = path.byte_at(1)
+        let slash = path.byte_at(2)
         if colon == 58 and (slash == 47 or slash == 92):
             return (drive >= 65 and drive <= 90) or (drive >= 97 and drive <= 122)
     false
@@ -52,18 +52,18 @@ fn pkg_is_abs(path: &str) -> bool:
 fn pkg_trim_line(text: &str) -> str:
     var end = 0
     while end < text.len() as i32:
-        let ch = text[end]
+        let ch = text.byte_at(end as i64)
         if ch == 10 or ch == 13:
             break
         end = end + 1
     var start = 0
     while start < end:
-        let ch = text[start]
+        let ch = text.byte_at(start as i64)
         if ch != 9 and ch != 32:
             break
         start = start + 1
     while end > start:
-        let ch = text[(end - 1)]
+        let ch = text.byte_at((end - 1) as i64)
         if ch != 9 and ch != 32:
             break
         end = end - 1
@@ -72,7 +72,7 @@ fn pkg_trim_line(text: &str) -> str:
 fn pkg_normalize_path(path: &str) -> str:
     var out = ""
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 92:
             out = out ++ "/"
         else:
@@ -83,8 +83,8 @@ fn pkg_str_compare(a: &str, b: &str) -> i32:
     let n = if a.len() < b.len(): a.len() else: b.len()
     var i = 0
     while i < n as i32:
-        let ac = a[i] as i32
-        let bc = b[i] as i32
+        let ac = a.byte_at(i as i64)
+        let bc = b.byte_at(i as i64)
         if ac != bc:
             return ac - bc
         i = i + 1
@@ -130,7 +130,7 @@ fn pkg_rel_path(root: &str, path: &str) -> str:
 fn pkg_add_parent_dirs(dirs: Vec[str], top_dir: &str, rel_path: &str) -> Vec[str]:
     var out = pkg_add_unique(move dirs, top_dir)
     for i in 0..rel_path.len() as i32:
-        if rel_path[i] == 47:
+        if rel_path.byte_at(i as i64) == 47:
             out = pkg_add_unique(move out, top_dir ++ "/" ++ rel_path.slice(0, i as i64))
     out
 
@@ -187,7 +187,7 @@ fn pkg_process_path(root: &str, path: &str) -> str:
 fn pkg_ascii_lower(text: &str) -> str:
     var out = StringBuilder.with_capacity(text.len())
     for i in 0..text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         if ch >= 65 and ch <= 90:
             out.push_byte((ch + 32) as u8)
         else:

--- a/build/pcre2.w
+++ b/build/pcre2.w
@@ -19,7 +19,7 @@ fn pcre2_join(left: &str, right: &str) -> str:
 fn pcre2_safe_label(text: &str) -> str:
     var out = ""
     for i in 0..text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         let keep = (ch >= 48 and ch <= 57) or (ch >= 65 and ch <= 90) or (ch >= 97 and ch <= 122) or ch == 45 or ch == 46 or ch == 95
         if keep:
             out = out ++ text.slice(i as i64, (i + 1) as i64)
@@ -35,7 +35,7 @@ fn pcre2_scratch_dir(ctx: &ActionCtx) -> str:
 fn pcre2_dirname(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     if last_slash < 0:
         return "."
@@ -46,12 +46,12 @@ fn pcre2_dirname(path: &str) -> str:
 fn pcre2_basename(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     path.slice((last_slash + 1) as i64, path.len())
 
 fn pcre2_abs(root: &str, path: &str) -> str:
-    if path.len() > 0 and path[0] == 47:
+    if path.len() > 0 and path.byte_at(0) == 47:
         return pcre2_owned_text(path)
     pcre2_join(root, path)
 
@@ -61,9 +61,9 @@ fn pcre2_split_lines(text: &str) -> Vec[str]:
     var i = 0
     while i <= text.len() as i32:
         let at_end = i == text.len() as i32
-        if at_end or text[i] == 10:
+        if at_end or text.byte_at(i as i64) == 10:
             var line = text.slice(start as i64, i as i64)
-            if line.len() > 0 and line[line.len() - 1] == 13:
+            if line.len() > 0 and line.byte_at(line.len() - 1) == 13:
                 line = line.slice(0, line.len() - 1)
             lines.push(line)
             start = i + 1
@@ -229,7 +229,7 @@ fn pcre2_insert_after_defs_import(text: &str, insertion: &str) -> str:
     var inserted = false
     var line_start = 0
     for i in 0..text.len() as i32:
-        if text[i] == 10:
+        if text.byte_at(i as i64) == 10:
             let line = text.slice(line_start as i64, (i + 1) as i64)
             out = out ++ line
             if not inserted and line == marker:
@@ -261,7 +261,7 @@ fn pcre2_add_imports(ctx: &ActionCtx, path: &str, sentinel: &str, insertion: &st
 fn pcre2_line_starts_with_fn_main(line: &str) -> bool:
     var j = 0
     while j < line.len() as i32:
-        let ch = line[j]
+        let ch = line.byte_at(j as i64)
         if ch != 32 and ch != 9:
             break
         j = j + 1
@@ -270,7 +270,7 @@ fn pcre2_line_starts_with_fn_main(line: &str) -> bool:
 fn pcre2_module_defines_main(text: &str) -> bool:
     var line_start = 0
     for i in 0..text.len() as i32:
-        if text[i] == 10:
+        if text.byte_at(i as i64) == 10:
             if pcre2_line_starts_with_fn_main(text.slice(line_start as i64, i as i64)):
                 return true
             line_start = i + 1
@@ -287,7 +287,7 @@ fn pcre2_module_body_for_synthetic_check(text: &str) -> str:
     var line_start = 0
     var line_no = 1
     for i in 0..text.len() as i32:
-        if text[i] == 10:
+        if text.byte_at(i as i64) == 10:
             let line = text.slice(line_start as i64, (i + 1) as i64)
             if line_no > 2 and not line.starts_with("use std.re."):
                 out.push_str(line)
@@ -302,12 +302,12 @@ fn pcre2_module_body_for_synthetic_check(text: &str) -> str:
 fn pcre2_first_function_name(text: &str) -> str:
     var line_start = 0
     for i in 0..text.len() as i32:
-        if text[i] == 10:
+        if text.byte_at(i as i64) == 10:
             let line = text.slice(line_start as i64, i as i64)
             if line.starts_with("fn "):
                 var end = 3
                 while end < line.len() as i32:
-                    let ch = line[end]
+                    let ch = line.byte_at(end as i64)
                     if ch == 40 or ch == 58 or ch == 32 or ch == 9:
                         break
                     end = end + 1
@@ -318,7 +318,7 @@ fn pcre2_first_function_name(text: &str) -> str:
         if line.starts_with("fn "):
             var end = 3
             while end < line.len() as i32:
-                let ch = line[end]
+                let ch = line.byte_at(end as i64)
                 if ch == 40 or ch == 58 or ch == 32 or ch == 9:
                     break
                 end = end + 1

--- a/build/release_uat.w
+++ b/build/release_uat.w
@@ -26,13 +26,13 @@ fn ruat_join(left: &str, right: &str) -> str:
 fn ruat_is_abs(path: &str) -> bool:
     if path.len() == 0:
         return false
-    let first = path[0]
+    let first = path.byte_at(0)
     if first == 47 or first == 92:
         return true
     if os() == "Windows" and path.len() >= 3:
-        let drive = path[0]
-        let colon = path[1]
-        let slash = path[2]
+        let drive = path.byte_at(0)
+        let colon = path.byte_at(1)
+        let slash = path.byte_at(2)
         if colon == 58 and (slash == 47 or slash == 92):
             return (drive >= 65 and drive <= 90) or (drive >= 97 and drive <= 122)
     false
@@ -45,7 +45,7 @@ fn ruat_abs(root: &str, path: &str) -> str:
 fn ruat_dirname(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 47 or ch == 92:
             last_slash = i
     if last_slash < 0:
@@ -57,7 +57,7 @@ fn ruat_dirname(path: &str) -> str:
 fn ruat_trim_trailing_line_endings(text: &str) -> str:
     var end = text.len()
     while end > 0:
-        let ch = text[end - 1]
+        let ch = text.byte_at(end - 1)
         if ch != 10 and ch != 13:
             break
         end = end - 1

--- a/build/retention.w
+++ b/build/retention.w
@@ -34,14 +34,14 @@ fn ret_join(left: &str, right: &str) -> str:
     left ++ "/" ++ right
 
 fn ret_abs(root: &str, path: &str) -> str:
-    if path.len() > 0 and path[0] == 47:
+    if path.len() > 0 and path.byte_at(0) == 47:
         return retention_owned_text(path)
     ret_join(root, path)
 
 fn ret_dirname(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     if last_slash < 0:
         return "."
@@ -52,7 +52,7 @@ fn ret_dirname(path: &str) -> str:
 fn ret_basename(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     if last_slash < 0:
         return retention_owned_text(path)
@@ -62,12 +62,12 @@ fn ret_trim(text: &str) -> str:
     var start = 0
     var end = text.len() as i32
     while start < end:
-        let ch = text[start]
+        let ch = text.byte_at(start as i64)
         if ch != 9 and ch != 10 and ch != 13 and ch != 32:
             break
         start = start + 1
     while end > start:
-        let ch = text[(end - 1)]
+        let ch = text.byte_at((end - 1) as i64)
         if ch != 9 and ch != 10 and ch != 13 and ch != 32:
             break
         end = end - 1
@@ -76,7 +76,7 @@ fn ret_trim(text: &str) -> str:
 fn ret_first_line(text: &str) -> str:
     var end = text.len() as i32
     for i in 0..text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         if ch == 10 or ch == 13:
             end = i
             break
@@ -86,7 +86,7 @@ fn ret_split_lines(text: &str) -> Vec[str]:
     let out: Vec[str] = Vec.new()
     var start = 0
     for i in 0..text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         if ch == 10 or ch == 13:
             let line = ret_trim(text.slice(start as i64, i as i64))
             if line.len() > 0:
@@ -101,7 +101,7 @@ fn ret_split_lines(text: &str) -> Vec[str]:
 fn ret_json_escape(text: &str) -> str:
     var out = ""
     for i in 0..text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         if ch == 34:
             out = out ++ "\\\""
         else if ch == 92:
@@ -119,7 +119,7 @@ fn ret_json_escape(text: &str) -> str:
 fn ret_safe_label(text: &str) -> str:
     var out = ""
     for i in 0..text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         let keep = (ch >= 48 and ch <= 57) or (ch >= 65 and ch <= 90) or (ch >= 97 and ch <= 122) or ch == 45 or ch == 46 or ch == 95
         if keep:
             out = out ++ text.slice(i as i64, (i + 1) as i64)
@@ -204,8 +204,8 @@ fn ret_sha256_text(ctx: &ActionCtx, label: &str, text: &str) -> str:
 fn ret_str_compare(a: &str, b: &str) -> i32:
     let min_len = if a.len() < b.len(): a.len() else: b.len()
     for i in 0..min_len as i32:
-        let ac = a[i] as i32
-        let bc = b[i] as i32
+        let ac = a.byte_at(i as i64)
+        let bc = b.byte_at(i as i64)
         if ac != bc:
             return ac - bc
     if a.len() == b.len():
@@ -239,7 +239,7 @@ fn ret_release_version_component(version: &str, part: i32) -> i32:
     while current < part:
         var dot = -1
         for i in start..version.len() as i32:
-            if version[i] == 46:
+            if version.byte_at(i as i64) == 46:
                 dot = i
                 break
         if dot < 0:
@@ -248,14 +248,14 @@ fn ret_release_version_component(version: &str, part: i32) -> i32:
         current = current + 1
     var end = version.len() as i32
     for i in start..version.len() as i32:
-        if version[i] == 46:
+        if version.byte_at(i as i64) == 46:
             end = i
             break
     if end <= start:
         return -1
     var value = 0
     for i in start..end:
-        let ch = version[i]
+        let ch = version.byte_at(i as i64)
         if ch < 48 or ch > 57:
             return -1
         value = value * 10 + (ch - 48)
@@ -660,7 +660,7 @@ fn ret_json_field(manifest: &str, key: &str) -> str:
         return ""
     let start = at + marker.len()
     var end = start
-    while end < manifest.len() and manifest[end] != 34:
+    while end < manifest.len() and manifest.byte_at(end) != 34:
         end = end + 1
     if end >= manifest.len():
         return ""

--- a/build/runtime.w
+++ b/build/runtime.w
@@ -60,7 +60,7 @@ pub fn run_prepare_bootstrap_link_root_action(ctx: ActionCtx) -> i32:
 fn br_join(base: &str, child: &str) -> str:
     if child.len() == 0:
         return runtime_owned_text(base)
-    if child[0] == 47:
+    if child.byte_at(0) == 47:
         return runtime_owned_text(child)
     if base.len() == 0 or base.ends_with("/"):
         return base ++ child
@@ -69,7 +69,7 @@ fn br_join(base: &str, child: &str) -> str:
 fn br_dirname(path: &str) -> str:
     var last = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last = i
     if last <= 0:
         return "."
@@ -79,7 +79,7 @@ fn br_split_nonempty_lines(text: &str) -> Vec[str]:
     let lines: Vec[str] = Vec.new()
     var start = 0
     for i in 0..text.len() as i32:
-        if text[i] == 10:
+        if text.byte_at(i as i64) == 10:
             if i > start:
                 lines.push(text.slice(start as i64, i as i64))
             start = i + 1
@@ -90,7 +90,7 @@ fn br_split_nonempty_lines(text: &str) -> Vec[str]:
 fn br_normalize_path_separators(path: &str) -> str:
     var out = ""
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 92:
             out = out ++ "/"
         else:
@@ -101,8 +101,8 @@ fn br_str_compare(a: &str, b: &str) -> i32:
     let n = if a.len() < b.len(): a.len() else: b.len()
     var i = 0
     while i < n as i32:
-        let ac = a[i] as i32
-        let bc = b[i] as i32
+        let ac = a.byte_at(i as i64)
+        let bc = b.byte_at(i as i64)
         if ac != bc:
             return ac - bc
         i = i + 1
@@ -159,7 +159,7 @@ fn br_contains_delimiter(text: &str, hashes: &str) -> bool:
         var j = 0
         var matched = true
         while j < needle.len() as i32:
-            if text[(i + j)] != needle[j]:
+            if text.byte_at((i + j) as i64) != needle.byte_at(j as i64):
                 matched = false
                 break
             j = j + 1
@@ -177,7 +177,7 @@ fn br_raw_string_literal(text: &str) -> str:
 fn br_normalize_embedded_source(text: &str) -> str:
     var has_cr = false
     for ci in 0..text.len() as i32:
-        if text[ci] == 13:
+        if text.byte_at(ci as i64) == 13:
             has_cr = true
             break
     if not has_cr:
@@ -186,11 +186,11 @@ fn br_normalize_embedded_source(text: &str) -> str:
     var start = 0
     var i = 0
     while i < text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         if ch == 13:
             if i > start:
                 out.push_str(text.slice(start as i64, i as i64))
-            if i + 1 < text.len() as i32 and text[(i + 1)] == 10:
+            if i + 1 < text.len() as i32 and text.byte_at((i + 1) as i64) == 10:
                 i = i + 1
             out.push_str("\n")
             start = i + 1

--- a/build/sdk.w
+++ b/build/sdk.w
@@ -28,7 +28,7 @@ fn sdk_join(left: &str, right: &str) -> str:
 fn sdk_dirname(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 47 or ch == 92:
             last_slash = i
     if last_slash < 0:
@@ -40,12 +40,12 @@ fn sdk_dirname(path: &str) -> str:
 fn sdk_is_abs(path: &str) -> bool:
     if path.len() == 0:
         return false
-    if path[0] == 47 or path[0] == 92:
+    if path.byte_at(0) == 47 or path.byte_at(0) == 92:
         return true
     if os() == "Windows" and path.len() >= 3:
-        let drive = path[0]
-        let colon = path[1]
-        let slash = path[2]
+        let drive = path.byte_at(0)
+        let colon = path.byte_at(1)
+        let slash = path.byte_at(2)
         if colon == 58 and (slash == 47 or slash == 92):
             return (drive >= 65 and drive <= 90) or (drive >= 97 and drive <= 122)
     false
@@ -58,7 +58,7 @@ fn sdk_abs(root: &str, path: &str) -> str:
 fn sdk_normalize(path: &str) -> str:
     var out = StringBuilder.with_capacity(path.len())
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 92:
             out.push_byte(47 as u8)
         else:
@@ -68,7 +68,7 @@ fn sdk_normalize(path: &str) -> str:
 fn sdk_basename(path: &str) -> str:
     var last_slash: i64 = -1
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 47 or ch == 92:
             last_slash = i as i64
     if last_slash >= 0:
@@ -190,8 +190,8 @@ fn sdk_str_compare(a: &str, b: &str) -> i32:
     let n = if a.len() < b.len(): a.len() else: b.len()
     var i = 0
     while i < n as i32:
-        let ac = a[i]
-        let bc = b[i]
+        let ac = a.byte_at(i as i64)
+        let bc = b.byte_at(i as i64)
         if ac != bc:
             return ac - bc
         i = i + 1
@@ -229,7 +229,7 @@ fn sdk_add_unique(items: Vec[str], item: &str) -> Vec[str]:
 fn sdk_add_parent_dirs(dirs: Vec[str], top_dir: &str, rel_path: &str) -> Vec[str]:
     var out = sdk_add_unique(move dirs, top_dir)
     for i in 0..rel_path.len() as i32:
-        if rel_path[i] == 47:
+        if rel_path.byte_at(i as i64) == 47:
             out = sdk_add_unique(move out, top_dir ++ "/" ++ rel_path.slice(0, i as i64))
     out
 
@@ -260,7 +260,7 @@ fn sdk_split_lines(text: &str) -> Vec[str]:
     let out: Vec[str] = Vec.new()
     var start = 0
     for i in 0..text.len() as i32:
-        if text[i] == 10:
+        if text.byte_at(i as i64) == 10:
             out.push(text.slice(start as i64, i as i64))
             start = i + 1
     if start <= text.len() as i32:

--- a/build/seed.w
+++ b/build/seed.w
@@ -16,7 +16,7 @@ fn seed_join(left: &str, right: &str) -> str:
 fn seed_dirname(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     if last_slash < 0:
         return "."
@@ -25,7 +25,7 @@ fn seed_dirname(path: &str) -> str:
     path.slice(0, last_slash as i64)
 
 fn seed_abs(root: &str, path: &str) -> str:
-    if path.len() > 0 and path[0] == 47:
+    if path.len() > 0 and path.byte_at(0) == 47:
         return seed_owned_text(path)
     seed_join(root, path)
 
@@ -37,7 +37,7 @@ fn seed_split_nonempty_lines(text: &str) -> Vec[str]:
     let lines: Vec[str] = Vec.new()
     var start = 0
     for i in 0..text.len() as i32:
-        if text[i] == 10:
+        if text.byte_at(i as i64) == 10:
             if i > start:
                 lines.push(text.slice(start as i64, i as i64))
             start = i + 1
@@ -57,25 +57,25 @@ fn seed_json_line_value(line: &str, key: &str) -> str:
     if pos < 0:
         return ""
     while pos < line.len() as i32:
-        let ch = line[pos]
+        let ch = line.byte_at(pos as i64)
         if ch != 32 and ch != 9:
             break
         pos = pos + 1
-    if pos >= line.len() as i32 or line[pos] != 58:
+    if pos >= line.len() as i32 or line.byte_at(pos as i64) != 58:
         return ""
     pos = pos + 1
     while pos < line.len() as i32:
-        let ch = line[pos]
+        let ch = line.byte_at(pos as i64)
         if ch != 32 and ch != 9:
             break
         pos = pos + 1
-    if pos >= line.len() as i32 or line[pos] != 34:
+    if pos >= line.len() as i32 or line.byte_at(pos as i64) != 34:
         return ""
     let start = pos + 1
     var end = start
     var escaped = false
     while end < line.len() as i32:
-        let ch = line[end]
+        let ch = line.byte_at(end as i64)
         if escaped:
             escaped = false
         else if ch == 92:
@@ -165,11 +165,11 @@ fn seed_is_hex(ch: i32) -> bool:
 
 fn seed_parse_sha256_sidecar(text: &str) -> str:
     var start = 0
-    while start < text.len() as i32 and seed_is_space(text[start]):
+    while start < text.len() as i32 and seed_is_space(text.byte_at(start as i64)):
         start = start + 1
     var end = start
-    while end < text.len() as i32 and not seed_is_space(text[end]):
-        if not seed_is_hex(text[end]):
+    while end < text.len() as i32 and not seed_is_space(text.byte_at(end as i64)):
+        if not seed_is_hex(text.byte_at(end as i64)):
             return ""
         end = end + 1
     if end - start != 64:

--- a/build/selfhost.w
+++ b/build/selfhost.w
@@ -43,7 +43,7 @@ fn bs_join(left: &str, right: &str) -> str:
 fn bs_dirname(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     if last_slash < 0:
         return "."
@@ -54,19 +54,19 @@ fn bs_dirname(path: &str) -> str:
 fn bs_basename(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     path.slice((last_slash + 1) as i64, path.len())
 
 fn bs_abs(root: &str, path: &str) -> str:
-    if path.len() > 0 and path[0] == 47:
+    if path.len() > 0 and path.byte_at(0) == 47:
         return selfhost_owned_text(path)
     bs_join(root, path)
 
 fn bs_with_string_literal(value: &str) -> str:
     var out = "\""
     for i in 0..value.len() as i32:
-        let ch = value[i]
+        let ch = value.byte_at(i as i64)
         if ch == 34:
             out = out ++ "\\\""
         else if ch == 92:
@@ -310,7 +310,7 @@ fn bs_run_cli_expect_success(ctx: &ActionCtx, compiler_path: &str, label: &str, 
 fn bs_trim_trailing_line_endings(text: &str) -> str:
     var end = text.len()
     while end > 0:
-        let ch = text[end - 1]
+        let ch = text.byte_at(end - 1)
         if ch != 10 and ch != 13:
             break
         end = end - 1
@@ -359,7 +359,7 @@ fn bs_assert_count_between(ctx: &ActionCtx, text: &str, needle: &str, min_count:
 fn bs_json_string(value: &str) -> str:
     var out = "\""
     for i in 0..value.len() as i32:
-        let ch = value[i]
+        let ch = value.byte_at(i as i64)
         if ch == 34:
             out = out ++ "\\\""
         else if ch == 92:
@@ -3781,7 +3781,7 @@ fn bs_index_of(text: &str, needle: &str) -> i32:
     for i in 0..(max_start + 1):
         var matched = true
         for j in 0..needle.len() as i32:
-            if text[(i + j)] != needle[j]:
+            if text.byte_at((i + j) as i64) != needle.byte_at(j as i64):
                 matched = false
                 break
         if matched:
@@ -5114,15 +5114,15 @@ fn bs_check_migrate_prefer_brace_ws(ctx: &ActionCtx, compiler_path: &str, case_d
     var line_start = 0
     while line_start < out_text.len() as i32:
         var line_end = line_start
-        while line_end < out_text.len() as i32 and out_text[line_end] != 10:
+        while line_end < out_text.len() as i32 and out_text.byte_at(line_end as i64) != 10:
             line_end = line_end + 1
         if line_end > line_start:
-            let last = out_text[(line_end - 1)]
+            let last = out_text.byte_at((line_end - 1) as i64)
             if last == 32 or last == 9:
                 return bs_fail(ctx, "prefer_brace_ws emitted trailing whitespace")
         var trimmed_start = line_start
         while trimmed_start < line_end:
-            let ch = out_text[trimmed_start]
+            let ch = out_text.byte_at(trimmed_start as i64)
             if ch != 32 and ch != 9:
                 break
             trimmed_start = trimmed_start + 1
@@ -5303,7 +5303,7 @@ fn bs_blob_to_args(blob: &str) -> Vec[str]:
     let args: Vec[str] = Vec.new()
     var start = 0
     for i in 0..blob.len() as i32:
-        if blob[i] == 0:
+        if blob.byte_at(i as i64) == 0:
             if i > start:
                 args.push(blob.slice(start as i64, i as i64))
             start = i + 1
@@ -7239,7 +7239,7 @@ fn bs_drop_first_lines(text: &str, count: i32) -> str:
     var line_start = 0
     var line_no = 1
     for i in 0..text.len() as i32:
-        if text[i] == 10:
+        if text.byte_at(i as i64) == 10:
             if line_no == count:
                 return text.slice((i + 1) as i64, text.len())
             line_no = line_no + 1
@@ -7509,7 +7509,7 @@ fn bs_split_words(line: &str) -> Vec[str]:
     var i = 0
     while i <= line.len() as i32:
         let at_end = i == line.len() as i32
-        let ch = if at_end: 32 else: line[i]
+        let ch = if at_end: 32 else: line.byte_at(i as i64)
         let is_space = ch == 32 or ch == 9
         if at_end or is_space:
             if in_word:
@@ -7528,9 +7528,9 @@ fn bs_split_nonempty_lines(text: &str) -> Vec[str]:
     var i = 0
     while i <= text.len() as i32:
         let at_end = i == text.len() as i32
-        if at_end or text[i] == 10:
+        if at_end or text.byte_at(i as i64) == 10:
             var end = i
-            if end > start and text[(end - 1)] == 13:
+            if end > start and text.byte_at((end - 1) as i64) == 13:
                 end = end - 1
             if end > start:
                 lines.push(text.slice(start as i64, end as i64))
@@ -7539,11 +7539,11 @@ fn bs_split_nonempty_lines(text: &str) -> Vec[str]:
     lines
 
 fn bs_strip_mach_o_underscore(name: &str) -> str:
-    if name.len() >= 3 and name[0] == 95 and name[1] == 95 and name[2] == 95:
+    if name.len() >= 3 and name.byte_at(0) == 95 and name.byte_at(1) == 95 and name.byte_at(2) == 95:
         return name.slice(1, name.len())
-    if name.len() >= 2 and name[0] == 95 and name[1] == 95:
+    if name.len() >= 2 and name.byte_at(0) == 95 and name.byte_at(1) == 95:
         return selfhost_owned_text(name)
-    if name.len() > 0 and name[0] == 95:
+    if name.len() > 0 and name.byte_at(0) == 95:
         return name.slice(1, name.len())
     selfhost_owned_text(name)
 

--- a/build/wo.w
+++ b/build/wo.w
@@ -70,7 +70,7 @@ fn wo_fail(ctx: &ActionCtx, message: &str) -> i32:
     1
 
 fn wo_abs(root: &str, path: &str) -> str:
-    if path.len() > 0 and path[0] == '/':
+    if path.len() > 0 and path.byte_at(0) == '/':
         return wo_owned_text(path)
     root ++ "/" ++ path
 
@@ -89,7 +89,7 @@ fn wo_sha256_text(text: &str) -> str:
 fn wo_dirname(path: &str) -> str:
     var last: i64 = -1
     for i in 0..path.len():
-        if path[i] == '/':
+        if path.byte_at(i) == '/':
             last = i
     if last < 0:
         return "."
@@ -97,7 +97,7 @@ fn wo_dirname(path: &str) -> str:
 
 fn wo_first_line(text: &str) -> str:
     var end: i64 = 0
-    while end < text.len() and text[end] != '\n' and text[end] != '\r':
+    while end < text.len() and text.byte_at(end) != '\n' and text.byte_at(end) != '\r':
         end = end + 1
     wo_owned_text(text.slice(0, end))
 
@@ -107,13 +107,13 @@ pub fn wo_manifest_field(manifest: &str, key: &str) -> str:
     var start: i64 = 0
     while start < manifest.len():
         var end = start
-        while end < manifest.len() and manifest[end] != '\n':
+        while end < manifest.len() and manifest.byte_at(end) != '\n':
             end = end + 1
         let line = manifest.slice(start, end)
         if line.starts_with(want):
             let rest = line.slice(want.len(), line.len())
             var sp: i64 = 0
-            while sp < rest.len() and rest[sp] != ' ':
+            while sp < rest.len() and rest.byte_at(sp) != ' ':
                 sp = sp + 1
             return wo_owned_text(rest.slice(0, sp))
         start = end + 1
@@ -218,7 +218,7 @@ fn wo_target_stem(plan: &WoBundle) -> str:
 // "linux_x86_64" -> "linux-x86_64"
 fn wo_target_label(target: &str) -> str:
     for i in 0..target.len():
-        if target[i] == '_':
+        if target.byte_at(i) == '_':
             return target.slice(0, i) ++ "-" ++ target.slice(i + 1, target.len())
     wo_owned_text(target)
 
@@ -314,11 +314,11 @@ pub fn wo_drift_harness_bin(plan: &WoBundle, harness: &str) -> str:
 fn wo_basename_no_ext(path: &str) -> str:
     var start: i64 = 0
     for i in 0..path.len():
-        if path[i] == '/':
+        if path.byte_at(i) == '/':
             start = i + 1
     var end = path.len()
     for j in start..path.len():
-        if path[j] == '.':
+        if path.byte_at(j) == '.':
             end = j
     wo_owned_text(path.slice(start, end))
 

--- a/build/zlib.w
+++ b/build/zlib.w
@@ -18,7 +18,7 @@ fn zlib_join(left: &str, right: &str) -> str:
 fn zlib_safe_label(text: &str) -> str:
     var out = ""
     for i in 0..text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         let keep = (ch >= 48 and ch <= 57) or (ch >= 65 and ch <= 90) or (ch >= 97 and ch <= 122) or ch == 45 or ch == 46 or ch == 95
         if keep:
             out = out ++ text.slice(i as i64, (i + 1) as i64)
@@ -34,7 +34,7 @@ fn zlib_scratch_dir(ctx: &ActionCtx) -> str:
 fn zlib_dirname(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     if last_slash < 0:
         return "."
@@ -45,12 +45,12 @@ fn zlib_dirname(path: &str) -> str:
 fn zlib_basename(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     path.slice((last_slash + 1) as i64, path.len())
 
 fn zlib_abs(root: &str, path: &str) -> str:
-    if path.len() > 0 and path[0] == 47:
+    if path.len() > 0 and path.byte_at(0) == 47:
         return zlib_owned_text(path)
     zlib_join(root, path)
 

--- a/build/zlib_gunzip.w
+++ b/build/zlib_gunzip.w
@@ -12,7 +12,7 @@ fn bytes_from_str(data: &str) -> Vec[u8]:
     let out: Vec[u8] = Vec.new()
     var i: i64 = 0
     while i < data.len():
-        out.push(data[i] as u8)
+        out.push(data.byte_at(i) as u8)
         i = i + 1
     out
 

--- a/build/zlib_gzip.w
+++ b/build/zlib_gzip.w
@@ -8,7 +8,7 @@ fn bytes_from_str(data: &str) -> Vec[u8]:
     let out: Vec[u8] = Vec.new()
     var i: i64 = 0
     while i < data.len():
-        out.push(data[i] as u8)
+        out.push(data.byte_at(i) as u8)
         i = i + 1
     out
 

--- a/build/zlib_http_fetch.w
+++ b/build/zlib_http_fetch.w
@@ -14,7 +14,7 @@ fn zlib_index_of(text: &str, needle: &str) -> i32:
         var j: i32 = 0
         var matched = true
         while j < needle.len() as i32:
-            if text[(i + j)] != needle[j]:
+            if text.byte_at((i + j) as i64) != needle.byte_at(j as i64):
                 matched = false
                 break
             j = j + 1

--- a/lib/std/build.w
+++ b/lib/std/build.w
@@ -487,7 +487,7 @@ fn tool_capability_require(token: &str, name: &str):
 fn tool_safe_label(text: &str) -> str:
     var out = StringBuilder.with_capacity(text.len())
     for i in 0..text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         let keep = (ch >= 48 and ch <= 57) or (ch >= 65 and ch <= 90) or (ch >= 97 and ch <= 122) or ch == 45 or ch == 46 or ch == 95
         if keep:
             out.push_byte(ch)
@@ -662,12 +662,12 @@ pub fn Diagnostics.error(self: &Self, message: str) -> Unit:
 fn tool_path_is_project_relative(path: &str) -> bool:
     if path.len() == 0:
         return false
-    if path[0] == 47:
+    if path.byte_at(0) == 47:
         return false
     if path.contains(".."):
         return false
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 0 or ch == 9 or ch == 10 or ch == 13:
             return false
     true
@@ -680,7 +680,7 @@ fn tool_path_require_project_relative(path: &str):
 fn tool_path_dirname(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     if last_slash < 0:
         return "."
@@ -693,9 +693,9 @@ fn tool_path_normalize(path: &str) -> str:
         return "."
     let parts: Vec[str] = Vec.new()
     var start = 0
-    var is_absolute = path[0] == 47 or path[0] == 92
+    var is_absolute = path.byte_at(0) == 47 or path.byte_at(0) == 92
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 47 or ch == 92:
             if i > start:
                 let part = path.slice(start as i64, i as i64)
@@ -733,7 +733,7 @@ fn tool_split_by_slash(path: &str) -> Vec[str]:
     let parts: Vec[str] = Vec.new()
     var start = 0
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 47 or ch == 92:
             if i > start:
                 parts.push(path.slice(start as i64, i as i64))
@@ -745,7 +745,7 @@ fn tool_split_by_slash(path: &str) -> Vec[str]:
 fn tool_glob_segment_matches(pattern: &str, name: &str) -> bool:
     var star = -1
     for i in 0..pattern.len() as i32:
-        if pattern[i] == 42:
+        if pattern.byte_at(i as i64) == 42:
             if star >= 0:
                 return false
             star = i
@@ -784,8 +784,8 @@ fn tool_glob_str_compare(a: &str, b: &str) -> i32:
     let min_len = if a.len() < b.len(): a.len() else: b.len()
     var i = 0
     while i < min_len as i32:
-        let ac = a[i] as i32
-        let bc = b[i] as i32
+        let ac = a.byte_at(i as i64)
+        let bc = b.byte_at(i as i64)
         if ac != bc:
             return ac - bc
         i = i + 1
@@ -826,12 +826,12 @@ fn tool_path_is_same_or_child(path: &str, root: &str) -> bool:
         return true
     if path.len() <= root.len():
         return false
-    path.starts_with(root) and path[root.len()] == 47
+    path.starts_with(root) and path.byte_at(root.len() as i64) == 47
 
 fn tool_path_is_parent_of(parent: &str, child: &str) -> bool:
     if parent.len() >= child.len():
         return false
-    child.starts_with(parent) and child[parent.len()] == 47
+    child.starts_with(parent) and child.byte_at(parent.len() as i64) == 47
 
 fn ToolFs.write_file_allowed(self: &Self, path: &str) -> bool:
     if not self.write_scoped:
@@ -866,7 +866,7 @@ fn tool_split_nonempty_lines(text: &str) -> Vec[str]:
     let lines: Vec[str] = Vec.new()
     var start = 0
     for i in 0..text.len() as i32:
-        if text[i] == 10:
+        if text.byte_at(i as i64) == 10:
             if i > start:
                 lines.push(text.slice(start as i64, i as i64))
             start = i + 1
@@ -934,7 +934,7 @@ pub fn ToolFs.read_binary(self: &Self, path: &str) -> Vec[u8]:
     let data = with_fs_read_file(resolved)
     let result: Vec[u8] = Vec.new()
     for i in 0..data.len() as i32:
-        result.push(data[i] as u8)
+        result.push(data.byte_at(i as i64) as u8)
     result
 
 pub fn ToolFs.list_files(self: &Self, path: &str) -> Vec[str]:
@@ -949,7 +949,7 @@ pub fn ToolFs.glob(self: &Self, pattern: &str) -> Vec[str]:
     var last_clean_slash = -1
     var has_glob = false
     for i in 0..pattern.len() as i32:
-        let c = pattern[i]
+        let c = pattern.byte_at(i as i64)
         if c == 42:
             has_glob = true
             break
@@ -1004,7 +1004,7 @@ fn tool_tar_append_str_padded(out: Vec[u8], value: &str, width: i64) -> Vec[u8]:
     if value.len() > width:
         return Vec.new()
     for i in 0..value.len() as i32:
-        out.push(value[i] as u8)
+        out.push(value.byte_at(i as i64) as u8)
     var pad = value.len()
     while pad < width:
         out.push(0 as u8)
@@ -1024,7 +1024,7 @@ fn tool_tar_octal_digits(value: i64) -> str:
     var i = reversed.len()
     while i > 0:
         i = i - 1
-        out.push_byte(reversed[i] as u8)
+        out.push_byte(reversed.byte_at(i) as u8)
     out.to_str()
 
 fn tool_tar_append_octal_nul(out: Vec[u8], value: i64, width: i64) -> Vec[u8]:
@@ -1038,7 +1038,7 @@ fn tool_tar_append_octal_nul(out: Vec[u8], value: i64, width: i64) -> Vec[u8]:
         out.push(48 as u8)
         pad = pad + 1
     for i in 0..digits.len() as i32:
-        out.push(digits[i] as u8)
+        out.push(digits.byte_at(i as i64) as u8)
     out.push(0 as u8)
     out
 
@@ -1051,7 +1051,7 @@ fn tool_tar_append_checksum(out: Vec[u8], checksum: i64) -> Vec[u8]:
         out.push(48 as u8)
         pad = pad + 1
     for i in 0..digits.len() as i32:
-        out.push(digits[i] as u8)
+        out.push(digits.byte_at(i as i64) as u8)
     out.push(0 as u8)
     out.push(32 as u8)
     out
@@ -1084,12 +1084,12 @@ fn tool_tar_link_name(target: &str) -> str:
 fn tool_tar_link_target_safe(output_dir: &str, output_path: &str, target: &str) -> bool:
     if target.len() == 0:
         return false
-    if target[0] == 47 or target[0] == 92:
+    if target.byte_at(0) == 47 or target.byte_at(0) == 92:
         return false
-    if target.len() >= 3 and target[1] == 58 and (target[2] == 47 or target[2] == 92):
+    if target.len() >= 3 and target.byte_at(1) == 58 and (target.byte_at(2) == 47 or target.byte_at(2) == 92):
         return false
     for i in 0..target.len() as i32:
-        let ch = target[i]
+        let ch = target.byte_at(i as i64)
         if ch == 0 or ch == 9 or ch == 10 or ch == 13:
             return false
     let parent = tool_path_dirname(output_path)
@@ -1326,7 +1326,7 @@ fn tool_tar_payload_text(bytes: &Vec[u8], offset: i64, size: i64) -> str:
 fn tool_tar_trim_payload_name(text: &str) -> str:
     var end = text.len() as i32
     while end > 0:
-        let ch = text[(end - 1)]
+        let ch = text.byte_at((end - 1) as i64)
         if ch != 0 and ch != 10 and ch != 13:
             break
         end = end - 1
@@ -1338,7 +1338,7 @@ fn tool_pax_parse_decimal(text: &str, start: i32, end: i32) -> i32:
     var value = 0
     var i = start
     while i < end:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         if ch < 48 or ch > 57:
             return -1
         value = value * 10 + (ch - 48)
@@ -1349,7 +1349,7 @@ fn tool_pax_value(text: &str, key: &str) -> str:
     var pos = 0
     while pos < text.len() as i32:
         var space = pos
-        while space < text.len() as i32 and text[space] != 32:
+        while space < text.len() as i32 and text.byte_at(space as i64) != 32:
             space = space + 1
         if space >= text.len() as i32:
             return ""
@@ -1359,14 +1359,14 @@ fn tool_pax_value(text: &str, key: &str) -> str:
         let record_start = space + 1
         let record_end = pos + record_len
         var eq = record_start
-        while eq < record_end and text[eq] != 61:
+        while eq < record_end and text.byte_at(eq as i64) != 61:
             eq = eq + 1
         if eq < record_end:
             let name = text.slice(record_start as i64, eq as i64)
             if name == key:
                 var value_end = record_end
                 while value_end > eq + 1:
-                    let ch = text[(value_end - 1)]
+                    let ch = text.byte_at((value_end - 1) as i64)
                     if ch != 10 and ch != 13:
                         break
                     value_end = value_end - 1
@@ -1590,7 +1590,7 @@ fn tool_process_restore_env(saved: SavedProcessEnv):
 fn tool_effect_escape(text: &str) -> str:
     var out = StringBuilder.with_capacity(text.len())
     for i in 0..text.len() as i32:
-        let ch = text[i]
+        let ch = text.byte_at(i as i64)
         if ch == 92:
             out.push_str("\\\\")
         else if ch == 9:
@@ -1613,7 +1613,7 @@ fn tool_effect_join_argv(parts: &Vec[str]) -> str:
 
 fn tool_effect_contains_slash(text: &str) -> bool:
     for i in 0..text.len() as i32:
-        if text[i] == 47:
+        if text.byte_at(i as i64) == 47:
             return true
     false
 
@@ -1628,7 +1628,7 @@ fn tool_effect_resolve_executable(exe: &str) -> str:
     var start = 0
     var i = 0
     while i <= path.len() as i32:
-        if i == path.len() as i32 or path[i] == 58:
+        if i == path.len() as i32 or path.byte_at(i as i64) == 58:
             let dir = path.slice(start as i64, i as i64)
             let candidate = if dir.len() == 0: with_str_clone_ref(exe) else: dir ++ "/" ++ exe
             if with_fs_file_exists(candidate) != 0:
@@ -1799,7 +1799,7 @@ pub fn ProcessRunner.wait(self: &Self, pid: i32, timeout_ms: i32) -> i32:
 fn tool_process_basename(path: &str) -> str:
     var start = 0
     for i in 0..path.len() as i32:
-        let ch = path[i]
+        let ch = path.byte_at(i as i64)
         if ch == 47 or ch == 92:
             start = i + 1
     path.slice(start as i64, path.len())
@@ -1947,7 +1947,7 @@ pub fn ActionCtx.env_input(self: &Self, name: &str) -> str:
 fn build_graph_escape(value: &str) -> str:
     var out = StringBuilder.with_capacity(value.len())
     for i in 0..value.len() as i32:
-        let ch = value[i]
+        let ch = value.byte_at(i as i64)
         if ch == 92:
             out.push_str("\\\\")
         else if ch == 9:
@@ -2182,7 +2182,7 @@ pub fn Build.extract_tar_gz(move self: Self, name: str, archive: str, output_dir
 fn build_path_dirname(path: &str) -> str:
     var last_slash = -1
     for i in 0..path.len() as i32:
-        if path[i] == 47:
+        if path.byte_at(i as i64) == 47:
             last_slash = i
     if last_slash < 0:
         return "."
@@ -2226,7 +2226,7 @@ fn build_zlib_gunzip_source() -> str:
     "    let out: Vec[u8] = Vec.new()\n" ++
     "    var i: i64 = 0\n" ++
     "    while i < data.len():\n" ++
-    "        out.push(data[i] as u8)\n" ++
+    "        out.push(data.byte_at(i) as u8)\n" ++
     "        i = i + 1\n" ++
     "    out\n\n" ++
     "fn bytes_to_str(data: &Vec[u8]) -> str:\n" ++
@@ -2543,12 +2543,12 @@ fn wp_parse_i32(s: &str, default_value: i32) -> i32:
     var v = 0
     var sign = 1
     var i: i64 = 0
-    if s[0] == 45:
+    if s.byte_at(0) == 45:
         sign = -1
         i = 1
     if i >= s.len(): return default_value
     while i < s.len():
-        let ch = s[i]
+        let ch = s.byte_at(i)
         if ch < 48 or ch > 57: return default_value
         v = v * 10 + (ch - 48)
         i = i + 1
@@ -2560,7 +2560,7 @@ impl WpCursor:
             return ""
         var end = self.pos
         let n = self.text.len()
-        while end < n and self.text[end] != 10:
+        while end < n and self.text.byte_at(end) != 10:
             end = end + 1
         if end >= n:
             self.ok = 0
@@ -2741,7 +2741,7 @@ fn ws_alloc_id(name: &str) -> i32:
     if text.len() > 0:
         var i: i64 = 0
         while i < text.len():
-            let ch = text[i]
+            let ch = text.byte_at(i)
             if ch < 48 or ch > 57: break
             id = id * 10 + (ch - 48)
             i = i + 1
@@ -2759,7 +2759,7 @@ fn ws_needs_evaluator(what: &str) -> Never:
 fn ws_path(root: &str, path: &str) -> str:
     if path.len() == 0:
         return with_str_clone_ref(path)
-    if path[0] == 47:
+    if path.byte_at(0) == 47:
         return with_str_clone_ref(path)
     let clean_root = if root.ends_with("/"): root.slice(0, root.len() - 1) else: with_str_clone_ref(root)
     if clean_root.len() == 0 or clean_root == ".":


### PR DESCRIPTION
## Problem

`withlang-dev/main` is red on the pinned-seed self-host lanes (**linux
x86_64**, **windows x86_64**, **windows aarch64**). Each dies ~2s in, at
build-graph materialization, before any stage compiles:

```
error: comptime index requires an array, tuple, or vec
```

The newer-seed lanes (linux aarch64, macOS arm64) are unaffected — their seed
already accepts comptime `str` indexing.

## Root cause

`0173d08e` ("least-ceremony sweep, build-driver files") rewrote
`str.byte_at(i)` → `s[i]` across `build.w`, `build/*.w`, and `lib/std/build.w`
(232 sites). Those files are **comptime-evaluated by the pinned seed compiler**
when `with build` materializes the build graph — *before* any stage
compilation.

Comptime `str` indexing is a compiler feature **newer than the pinned seed**.
Verified against the CI-pinned seed (`v0.15.1.3`): it rejects `s[i]` with
`comptime index requires an array, tuple, or vec`, whereas current
`src/ComptimeEval.w` accepts `array, tuple, vec, or str`. The seed cannot
materialize the graph, so those lanes never reach stage compilation.

This is the exact bootstrap-ordering invariant in AGENTS.md: build-driver code
reached at comptime must not use a language feature the pinned seed lacks —
*"if a change needs a newer seed, tag a release to be that seed first."*

## Fix

Revert the `str.byte_at(i)` → `s[i]` sweep **for build-driver files only**
(exact content inverse of `0173d08e`; 232 insertions / 232 deletions across the
same 19 files). The later `.get(i) → v[i]` **Vec** sweep that landed on main is
untouched — Vec indexing *is* supported by the pinned seed; only `str` indexing
is not. The `str` style sweep can re-land once a released seed supports comptime
`str` indexing.

No compiler/stdlib source is touched — this changes only comptime-evaluated
build-graph code, so it cannot affect stage codegen or fixpoint determinism.

## Verification

From the CI-pinned `v0.15.1.3` seed on linux x86_64, on this branch:
- `with build` → **green**, all targets (pristine main head dies at ~2s
  materialization with `comptime index requires an array, tuple, or vec`).
- `with build :fixpoint` → **stage2 == stage3** byte-identical.

Bootstrappable from the already-tagged `v0.15.1.3` seed; no new seed required.
Base rung of the stack that greens every self-host lane.
