### PR TITLE
docs: seed/release version-numbering convention (D40) — breaking seed = v0.15.2.0

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -10,6 +10,73 @@ decision supersedes an earlier one, say so in both.
 
 ---
 
+## D40 — Seed/release version numbering: `y` is a bootstrap-compatibility group; a bootstrap breakage bumps `y` and resets `z`
+
+**Date:** 2026-09-04
+**Status:** Proposed — pending Eric's ruling. This convention is not yet
+written down anywhere, so the digits of a release tag currently carry no agreed
+meaning. The live case that forces the question: the str-index bootstrap
+breakage (below) is being tagged `v0.15.1.9` on `release/v0.15.1.9`; this
+convention says it must be `v0.15.2.0`. The release runbook's version-bump step
+points here.
+
+**The convention.** A published `with` seed/release is tagged `vW.X.Y.Z`:
+
+- **`W.X`** — the product/language line.
+- **`Y`** — the **bootstrap-compatibility group**. Every seed tagged `vW.X.Y.*`
+  is *mutually* bootstrap-compatible: any `vW.X.Y.Z` seed can build the source
+  tree at any other `vW.X.Y.Z'` tag in the same group. Equivalently, every
+  commit released inside a group is bootstrappable by every seed of that group.
+- **`Z`** — a sequential cut *within* a group. A new `Z` is a **non-breaking**
+  release: bug fixes, or a compiler feature that is merely *added* (so the
+  group's existing seeds can still bootstrap the tree because build-driver code
+  does not yet *use* it).
+- **A "breakage"** is a commit the current group's seeds *cannot* bootstrap —
+  because build-graph / build-driver code (comptime-evaluated by the pinned
+  seed at graph materialization, before any stage compiles) uses a language or
+  compiler feature newer than those seeds. A breakage **must open a new group**:
+  bump `Y`, reset `Z = 0`.
+- **The seed chain never breaks.** The first seed of a new group, `vW.X.(Y+1).0`,
+  must be bootstrappable from the **immediately-preceding** seed (the last
+  `vW.X.Y.*`) — but it need *not* be buildable by the rest of the old group.
+  So the seed *lineage* is an unbroken chain N→N+1 (you can always walk one hop
+  forward from any published seed to head), while the *mutual*-compat guarantee
+  is scoped to a single `Y`.
+
+**Why.** Sharing `Y` is a *promise* of mutual bootstrap compatibility, and CI
+relies on it: each self-host lane pins a seed and expects any group seed to
+build any group commit. Numbering a breaking seed *within* the old group
+silently breaks that promise — the old seeds stay pinned, the tree now needs a
+feature they lack, and every pinned lane dies at graph materialization
+(`comptime index requires an array, tuple, or vec` — exactly the #956 failure).
+Resetting `Z=0` on a breakage makes the incompatibility legible in the number
+itself: "a `.2.0` tree cannot be built by a `.1.x` seed" is readable without
+archaeology. Keeping only the N→N+1 chain (rather than demanding whole-group
+compat across the break) is the *minimum* constraint that keeps bootstrap
+reproducible end to end.
+
+This is the same shape used by bootstrapped toolchains elsewhere — rustc's
+stage0 is always the *immediately* previous release, never an arbitrary older
+one; Go's bootstrap toolchain is a specific prior version — and it is the
+release-facing corollary of AGENTS.md's bootstrap invariant, *"if a change
+needs a newer seed, tag a release to be that seed first."* SemVer governs the
+`W.X` API line and is orthogonal; `Y`/`Z` describe *bootstrap* compatibility,
+which SemVer has no concept of.
+
+**Immediate application (the live case).** Comptime `str` indexing (`s[i]` where
+`s: str`) landed in `af7db8ce` (#1017, "a str's element is its byte, u8") and is
+then *used* in comptime-evaluated build-driver files by `0173d08e`. Seeds
+`v0.15.1.3`–`v0.15.1.8` do **not** support comptime `str` indexing, so they
+reject the materialized build graph of the tree at/after `0173d08e`. That tree
+is therefore a **breakage** relative to the `v0.15.1` group. The str-index-capable
+seed (cut from `af7db8ce`, buildable *by* `v0.15.1.8`) is the **first seed of a
+new group** and must be tagged **`v0.15.2.0`**, not `v0.15.1.9`: `v0.15.1.8`
+builds it (chain intact) while `v0.15.1.3`–`.7` cannot (correctly excluded —
+they are the old group). Tagging it `v0.15.1.9` would assert membership in the
+mutually-compatible `.1` group, which is false. If this convention is blessed,
+`release/v0.15.1.9` (`61b6e574`, currently bumping `src/version` to `v0.15.1.9`)
+should become `v0.15.2.0`.
+
 ## D39 — Bundle interfaces: a bundle-provided module is its `.wi`, and callable semantics are the declaration
 
 **Date:** 2026-09-02

--- a/docs/with-release-runbook.md
+++ b/docs/with-release-runbook.md
@@ -148,6 +148,14 @@ Set the release version explicitly for the rest of the flow:
 export WITH_VERSION=v0.14.3
 ```
 
+Choose the number by the bootstrap-compatibility rule (see `decisions.md` D40):
+`vW.X.Y.Z`, where **`Y` is a compatibility group** — every `vW.X.Y.*` seed can
+build every commit released in that group. A normal cut increments `Z`. A
+**bootstrap breakage** — a tree that the current group's seeds cannot
+materialize because build-driver code uses a compiler feature newer than those
+seeds — **must bump `Y` and reset `Z=0`**; that new `.0` seed need only be
+bootstrappable from the immediately-previous seed, not the whole old group.
+
 Bump `src/version` to the release tag and commit it:
 
 ```sh


### PR DESCRIPTION
## Why this PR

`vW.X.Y.Z` seed/release tags currently carry **no written meaning** — nothing in
the repo says what a digit change implies for bootstrap. That gap is live right
now: the str-index bootstrap breakage is being tagged `v0.15.1.9`
(`release/v0.15.1.9`, `61b6e574`), and I believe the compatibility rule the
chain already depends on says it must be **`v0.15.2.0`**. This PR writes the rule
down (decisions.md **D40**) and points the release runbook at it, so the number
is decided by a stated convention rather than case-by-case.

**This is a proposal pending your ruling** — I have not touched any tag. If you
bless the wording, `release/v0.15.1.9` should become `v0.15.2.0`.

## The convention (full text in D40)

- **`Y` = bootstrap-compatibility group.** Every `vW.X.Y.*` seed builds every
  commit released in that group (mutual bootstrap compatibility). CI pins one
  seed per lane and relies on exactly this.
- **`Z` = a non-breaking cut** within a group (fixes, or a feature merely
  *added* but not yet *used* by build-driver code).
- **A bootstrap breakage** — a tree the group's seeds cannot materialize because
  comptime-evaluated build-driver code uses a compiler feature newer than those
  seeds — **bumps `Y`, resets `Z=0`**. The new `.0` seed need only be
  bootstrappable from the *immediately-previous* seed, not the whole old group.
  So the seed lineage stays an unbroken N→N+1 chain, while mutual compat is
  scoped to one `Y`.

## The decision procedure

**1. What others do.** Bootstrapped toolchains chain seeds, they don't demand
whole-history compat: rustc's stage0 is always the *immediately previous*
release; Go's bootstrap is a specific prior toolchain version. Both match the
"chain never breaks, but a break scopes a new group" shape. SemVer governs the
`W.X` API line and has no concept of *bootstrap* compat, which is what `Y`/`Z`
encode — orthogonal, not a substitute.

**2. What the docs currently say.** Nothing — there is no version-numbering rule
anywhere; the runbook just `export WITH_VERSION=...`. The closest existing
normative statement is AGENTS.md's bootstrap invariant: *"if a change needs a
newer seed, tag a release to be that seed first."* D40 is the release-facing
corollary of that invariant.

**3. Mission fit.** "Don't make the user state what the tooling already knows."
A version number that shares `Y` is a *promise* of mutual bootstrap compat.
Numbering the breaking seed `.1.9` silently breaks that promise: the pinned
`.1.x` lanes stay pinned, the tree now needs comptime `str` indexing they lack,
and every lane dies at graph materialization with `comptime index requires an
array, tuple, or vec` (the #956 failure). `.2.0` makes the incompatibility
legible in the number itself — no archaeology to learn "a `.2.0` tree can't be
built by a `.1.x` seed."

**4. Prediction.** I predict you rule **for `.2.0`** (~80%). It costs one
one-time renumber and buys a rule that makes every future breakage self-labeling
and keeps the seed chain walkable one hop at a time — the smallest permanent
system, which is the shape you've favored (cf. D32). The main counter is if you
intend `Y` to track the language line and want a *different* digit to carry
bootstrap-compat; if so, D40's wording should bind to whichever digit you name —
the rule matters, the position doesn't.

## The live application

Comptime `str` indexing landed in `af7db8ce` (#1017) and is *used* in
build-driver files by `0173d08e`. Seeds `v0.15.1.3`–`v0.15.1.8` don't support
it → they reject that tree's build graph → breakage vs the `v0.15.1` group. The
str-index-capable seed (cut from `af7db8ce`, built *by* `v0.15.1.8`) is the
first seed of a new group: `v0.15.1.8` builds it (chain intact), `v0.15.1.3`–`.7`
cannot (correctly excluded). ⇒ **`v0.15.2.0`**, not `v0.15.1.9`.

Docs-only; no code, no build-graph, no tag touched.
