### PR TITLE
Windows: with.toml is found for drive paths, and PWD is the runtime's (#1082)

### DIFF
--- a/rt/windows_aarch64.w
+++ b/rt/windows_aarch64.w
@@ -221,6 +221,10 @@ pub fn rt_store_args(argc_val: i32, argv_val: *const *const u8) -> Unit:
     __stdinp = __acrt_iob_func(0 as u32)
     __stdoutp = __acrt_iob_func(1 as u32)
     __stderrp = __acrt_iob_func(2 as u32)
+    // PWD is the runtime's on Windows (#1082; see windows_x86_64.w).
+    var cwd: [4096]u8 = [0 as u8; 4096]
+    if rt_getcwd(&raw mut cwd as *mut [4096]u8 as *mut u8, 4096) == 0:
+        let _pwd = win_setenv("PWD", with_str_from_cstr(&cwd as *const [4096]u8 as *const u8))
 
 pub fn rt_args() -> (*const *const u8, i32):
     (rt_argv_raw as *const *const u8, rt_argc)
@@ -974,7 +978,18 @@ fn win_spawn_argv(args: &str, stdout_path: &str, stderr_path: &str, stdin_path: 
     if cwd.len() > 0:
         let _ = win_str_to_utf16_buf(cwd, &raw mut cwdw as *mut [4096]u16 as *mut u16, 4096)
         cwdp = &cwdw as *const [4096]u16 as *const u16
+    // PWD follows the child's directory (#1082; see windows_x86_64.w).
+    var old_pwd = ""
+    var pwd_set = false
+    if cwd.len() > 0:
+        let prev = rt_getenv(c"PWD".ptr)
+        if prev as i64 != 0:
+            old_pwd = with_str_from_cstr(prev)
+        let _pwd = win_setenv("PWD", cwd)
+        pwd_set = true
     let ok = CreateProcessW(0 as *const u16, cmd as *mut u16, 0 as *mut u8, 0 as *mut u8, inherit, 0 as u32, 0 as *mut u8, cwdp, &raw mut startup as *mut [104]u8 as *mut u8, &raw mut proc_info as *mut [24]u8 as *mut u8)
+    if pwd_set:
+        let _restore = win_setenv("PWD", old_pwd)
     with_free(cmd)
     if has_stdin and stdin_h != 0 and stdin_h != INVALID_HANDLE_VALUE:
         let _ = CloseHandle(stdin_h)

--- a/rt/windows_x86_64.w
+++ b/rt/windows_x86_64.w
@@ -317,6 +317,16 @@ pub fn rt_store_args(argc_val: i32, argv_val: *const *const u8) -> Unit:
     __stdinp = __acrt_iob_func(0 as u32)
     __stdoutp = __acrt_iob_func(1 as u32)
     __stderrp = __acrt_iob_func(2 as u32)
+    // PWD is the runtime's on Windows. The driver reads it for its working
+    // directory (project root, absolutized paths, embed anchoring). No shell
+    // maintains it here the way POSIX shells do: a git-bash parent exports the
+    // POSIX spelling (/c/src/with, which Win32 resolves as C:\c\src\with) and
+    // a child spawned into another directory inherits its parent's value. Set
+    // it from the real directory at startup; win_spawn_argv sets it for
+    // children given a directory (#1082).
+    var cwd: [4096]u8 = [0 as u8; 4096]
+    if rt_getcwd(&raw mut cwd as *mut [4096]u8 as *mut u8, 4096) == 0:
+        let _pwd = win_setenv("PWD", with_str_from_cstr(&cwd as *const [4096]u8 as *const u8))
 
 pub fn rt_args() -> (*const *const u8, i32):
     (rt_argv_raw as *const *const u8, rt_argc)
@@ -1073,7 +1083,24 @@ fn win_spawn_argv(args: &str, stdout_path: &str, stderr_path: &str, stdin_path: 
     if cwd.len() > 0:
         let _ = win_str_to_utf16_buf(cwd, &raw mut cwdw as *mut [4096]u16 as *mut u16, 4096)
         cwdp = &cwdw as *const [4096]u16 as *const u16
+    // PWD follows the child's directory, as the unix spawners arrange by
+    // setenv("PWD", cwd) after chdir in the forked child: the driver reads PWD
+    // for its working directory (project root, absolutized paths, embed
+    // anchoring), and a child given lpCurrentDirectory otherwise inherits the
+    // parent's stale PWD and roots at the parent's project -- a test's nested
+    // `with build` in its case directory built the repo's graph (#1082). Set
+    // in the parent for the inherited block, restored after the spawn.
+    var old_pwd = ""
+    var pwd_set = false
+    if cwd.len() > 0:
+        let prev = rt_getenv(c"PWD".ptr)
+        if prev as i64 != 0:
+            old_pwd = with_str_from_cstr(prev)
+        let _pwd = win_setenv("PWD", cwd)
+        pwd_set = true
     let ok = CreateProcessW(0 as *const u16, cmd as *mut u16, 0 as *mut u8, 0 as *mut u8, inherit, 0 as u32, 0 as *mut u8, cwdp, &raw mut startup as *mut [104]u8 as *mut u8, &raw mut proc_info as *mut [24]u8 as *mut u8)
+    if pwd_set:
+        let _restore = win_setenv("PWD", old_pwd)
     with_free(cmd)
     if has_stdin and stdin_h != 0 and stdin_h != INVALID_HANDLE_VALUE:
         let _ = CloseHandle(stdin_h)

--- a/src/compiler/ProjectConfig.w
+++ b/src/compiler/ProjectConfig.w
@@ -700,8 +700,22 @@ fn project_config_resolve_path(root_dir: &str, path: &str) -> str:
         return project_config_absolutize_path(path)
     resolve_join(root_dir, path)
 
+// A POSIX root, a Windows drive (`C:/` or `C:\`), or a UNC path (`\\`).
+// This predicate decides whether a source path is joined onto PWD before
+// the with.toml walk: with only the POSIX form, every Windows drive path was
+// "relative", the join produced garbage, the walk never found with.toml, and
+// every [build] setting -- overflow mode among them -- was dropped on
+// Windows without a word (behav_project_overflow_modes, #1082).
 fn project_config_is_absolute_path(path: &str) -> bool:
-    path.len() > 0 and path[0] == 47
+    if path.len() == 0:
+        return false
+    if path[0] == 47:
+        return true
+    if path.len() >= 2 and path[0] == 92 and path[1] == 92:
+        return true
+    let drive = path[0]
+    let is_letter = (drive >= 65 and drive <= 90) or (drive >= 97 and drive <= 122)
+    path.len() >= 3 and is_letter and path[1] == 58 and (path[2] == 47 or path[2] == 92)
 
 fn project_config_normalize_absolute_path(path: &str) -> str:
     var out = with_str_clone_ref(path)


### PR DESCRIPTION
Closes #1082, closes #1083. The one red fixture on both Windows lanes of #1086 (behav_project_overflow_modes): (1) project_config_is_absolute_path only knew POSIX roots, so a drive path was joined onto PWD and with.toml was never found on Windows — every [build] setting silently dropped; (2) the driver trusts PWD and nothing on Windows kept it true (unix spawners set it in the child after chdir; a git-bash parent exports /c/src/with). The Windows runtime now owns PWD at startup and around CreateProcessW; the predicate accepts drive and UNC paths. Verified on the native box: the fixture passes under with test; the nested build under PWD=/c/src/with roots correctly; a spawned child reports its own directory as PWD. #1083's linker-env message came from the repo graph that the stale PWD had rooted.