### PR TITLE
README: build status badges per platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: selfhost+tests
+name: macOS arm64
 
 on:
   # Restrict push to main so a PR-branch push does not trigger BOTH a push run
@@ -9,9 +9,9 @@ on:
   pull_request:
 
 # Cancel a superseded in-progress run when the same PR branch is re-pushed.
-# Hardcode the platform token (not ${{ github.workflow }}) so the three
-# same-named "selfhost+tests" workflows get distinct groups and do not cancel
-# each other across platforms.
+# Hardcode the platform token (not ${{ github.workflow }}) so a workflow
+# rename can never merge two platforms into one group and cancel each
+# other.
 concurrency:
   group: selfhost-tests-macos-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/selfhost-linux-aarch64.yml
+++ b/.github/workflows/selfhost-linux-aarch64.yml
@@ -1,4 +1,4 @@
-name: selfhost+tests
+name: linux aarch64
 
 on:
   # Restrict push to main so a PR-branch push does not trigger BOTH a push run
@@ -9,9 +9,9 @@ on:
   pull_request:
 
 # Cancel a superseded in-progress run when the same PR branch is re-pushed.
-# Hardcode the platform token (not ${{ github.workflow }}) so the same-named
-# "selfhost+tests" workflows get distinct groups and do not cancel each other
-# across platforms.
+# Hardcode the platform token (not ${{ github.workflow }}) so a workflow
+# rename can never merge two platforms into one group and cancel each
+# other.
 concurrency:
   group: selfhost-tests-linux-aarch64-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/selfhost-linux.yml
+++ b/.github/workflows/selfhost-linux.yml
@@ -1,4 +1,4 @@
-name: selfhost+tests
+name: linux x86_64
 
 on:
   # Restrict push to main so a PR-branch push does not trigger BOTH a push run
@@ -9,9 +9,9 @@ on:
   pull_request:
 
 # Cancel a superseded in-progress run when the same PR branch is re-pushed.
-# Hardcode the platform token (not ${{ github.workflow }}) so the three
-# same-named "selfhost+tests" workflows get distinct groups and do not cancel
-# each other across platforms.
+# Hardcode the platform token (not ${{ github.workflow }}) so a workflow
+# rename can never merge two platforms into one group and cancel each
+# other.
 concurrency:
   group: selfhost-tests-linux-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/selfhost-windows-aarch64.yml
+++ b/.github/workflows/selfhost-windows-aarch64.yml
@@ -1,4 +1,4 @@
-name: selfhost+tests
+name: windows aarch64
 
 on:
   # Restrict push to main so a PR-branch push does not trigger BOTH a push run
@@ -9,9 +9,9 @@ on:
   pull_request:
 
 # Cancel a superseded in-progress run when the same PR branch is re-pushed.
-# Hardcode the platform token (not ${{ github.workflow }}) so the same-named
-# "selfhost+tests" workflows get distinct groups and do not cancel each other
-# across platforms.
+# Hardcode the platform token (not ${{ github.workflow }}) so a workflow
+# rename can never merge two platforms into one group and cancel each
+# other.
 concurrency:
   group: selfhost-tests-windows-arm64-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/selfhost-windows.yml
+++ b/.github/workflows/selfhost-windows.yml
@@ -1,4 +1,4 @@
-name: selfhost+tests
+name: windows x86_64
 
 on:
   # Restrict push to main so a PR-branch push does not trigger BOTH a push run
@@ -9,9 +9,9 @@ on:
   pull_request:
 
 # Cancel a superseded in-progress run when the same PR branch is re-pushed.
-# Hardcode the platform token (not ${{ github.workflow }}) so the three
-# same-named "selfhost+tests" workflows get distinct groups and do not cancel
-# each other across platforms.
+# Hardcode the platform token (not ${{ github.workflow }}) so a workflow
+# rename can never merge two platforms into one group and cancel each
+# other.
 concurrency:
   group: selfhost-tests-windows-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # The With Programming Language
 
+[![linux x86_64](https://github.com/withlang-dev/with/actions/workflows/selfhost-linux.yml/badge.svg?branch=main)](https://github.com/withlang-dev/with/actions/workflows/selfhost-linux.yml)
+[![linux aarch64](https://github.com/withlang-dev/with/actions/workflows/selfhost-linux-aarch64.yml/badge.svg?branch=main)](https://github.com/withlang-dev/with/actions/workflows/selfhost-linux-aarch64.yml)
+[![macOS arm64](https://github.com/withlang-dev/with/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/withlang-dev/with/actions/workflows/ci.yml)
+[![windows x86_64](https://github.com/withlang-dev/with/actions/workflows/selfhost-windows.yml/badge.svg?branch=main)](https://github.com/withlang-dev/with/actions/workflows/selfhost-windows.yml)
+[![windows aarch64](https://github.com/withlang-dev/with/actions/workflows/selfhost-windows-aarch64.yml/badge.svg?branch=main)](https://github.com/withlang-dev/with/actions/workflows/selfhost-windows-aarch64.yml)
+[![release](https://github.com/withlang-dev/with/actions/workflows/nightly-release.yml/badge.svg)](https://github.com/withlang-dev/with/actions/workflows/nightly-release.yml)
+
 A systems programming language that compiles to native code via LLVM.
 Fast, safe, and designed to feel less hostile than existing native languages.
 


### PR DESCRIPTION
One badge per self-host workflow (pinned to `main`) plus the release workflow, under the README title. The five self-host workflows are named by platform so the badges label themselves; PR check names come from the job names and are unchanged.