### PR TITLE
Windows release UAT: DLL C runtime, spiral on the raw surface, UAT in the nightly on every platform

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -168,6 +168,12 @@ jobs:
       - name: Verify fixpoint
         run: ./out/release/bin/with build :fixpoint
 
+      - name: Green battery (build :test)
+        # The release UAT gate requires last-green, and last-green requires the
+        # test-green evidence `:test` records: the asset this job publishes is
+        # the one the battery blessed, not merely the one that fixpointed.
+        run: ./out/release/bin/with build :test
+
       - name: Record last-green (the release UAT gate reads it)
         run: ./out/release/bin/with build :last-green
 
@@ -356,6 +362,11 @@ jobs:
         # no member imports, so a poison binary aborts and this step fails instead
         # of packaging it green.
         run: ./out/release/bin/with.exe check test/behavior/behav_regex_language_semantics.w
+
+      - name: Green battery (build :test)
+        # last-green requires the test-green evidence `:test` records; driven
+        # with the seed as the selfhost lane does.
+        run: ./src/main.exe build :test
 
       - name: Record last-green (the release UAT gate reads it)
         run: ./out/release/bin/with.exe build :last-green
@@ -556,6 +567,10 @@ jobs:
       - name: Verify fixpoint
         run: ./src/main build :fixpoint
 
+      - name: Green battery (build :test)
+        # last-green requires the test-green evidence `:test` records.
+        run: ./src/main build :test
+
       - name: Record last-green (the release UAT gate reads it)
         run: ./out/release/bin/with build :last-green
 
@@ -717,6 +732,11 @@ jobs:
 
       - name: Verify fixpoint
         run: ./src/main.exe build :fixpoint
+
+      - name: Green battery (build :test)
+        # last-green requires the test-green evidence `:test` records; driven
+        # with the seed as the selfhost lane does.
+        run: ./src/main.exe build :test
 
       - name: Record last-green (the release UAT gate reads it)
         run: ./out/release/bin/with.exe build :last-green

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -168,6 +168,29 @@ jobs:
       - name: Verify fixpoint
         run: ./out/release/bin/with build :fixpoint
 
+      - name: Record last-green (the release UAT gate reads it)
+        run: ./out/release/bin/with build :last-green
+
+      - name: Provide a display and software OpenGL (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          # xvfb: a virtual X display. libgl1-mesa-dri: Mesa's llvmpipe, the
+          # software OpenGL 4.5 the raylib spiral UAT renders through.
+          sudo apt-get install -y --no-install-recommends xvfb libgl1-mesa-dri
+
+      - name: Release UAT (Linux, under Xvfb)
+        if: runner.os == 'Linux'
+        env:
+          LIBGL_ALWAYS_SOFTWARE: "1"
+        run: xvfb-run -a -s "-screen 0 1280x800x24" ./out/release/bin/with build :release-uat
+
+      - name: Release UAT (macOS)
+        # The runner's session has a WindowServer; the spiral opens a real window.
+        if: runner.os == 'macOS'
+        run: ./out/release/bin/with build :release-uat
+
       - name: Package fixpoint-verified release asset
         run: |
           set -euo pipefail
@@ -333,6 +356,28 @@ jobs:
         # no member imports, so a poison binary aborts and this step fails instead
         # of packaging it green.
         run: ./out/release/bin/with.exe check test/behavior/behav_regex_language_semantics.w
+
+      - name: Record last-green (the release UAT gate reads it)
+        run: ./out/release/bin/with.exe build :last-green
+
+      - name: Provide software OpenGL (Mesa llvmpipe)
+        # The runner's stock driver stops at OpenGL 1.1; raylib needs 3.3. The
+        # spiral UAT places this opengl32.dll beside the program it builds
+        # (WITH_UAT_OPENGL32_DLL; Windows loads a DLL from the program's own
+        # directory first). Pinned llvmpipe build from mmozeiko/build-mesa.
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/mesa-llvmpipe-x64-26.2.2.7z"
+          curl -fL -o "$archive" \
+            "https://github.com/mmozeiko/build-mesa/releases/download/26.2.2/mesa-llvmpipe-x64-26.2.2.7z"
+          printf '%s  %s\n' "418f1938dc48d401538cf6440d3c718e2f456ef2023e44133105263f483e903f" "$archive" | sha256sum -c -
+          mkdir -p "$RUNNER_TEMP/mesa"
+          7z x -y -o"$RUNNER_TEMP/mesa" "$archive" opengl32.dll > /dev/null
+          test -f "$RUNNER_TEMP/mesa/opengl32.dll"
+          echo "WITH_UAT_OPENGL32_DLL=$(cygpath -m "$RUNNER_TEMP/mesa/opengl32.dll")" >> "$GITHUB_ENV"
+
+      - name: Release UAT
+        run: ./out/release/bin/with.exe build :release-uat
 
       - name: Package fixpoint-verified release asset
         run: |
@@ -511,6 +556,22 @@ jobs:
       - name: Verify fixpoint
         run: ./src/main build :fixpoint
 
+      - name: Record last-green (the release UAT gate reads it)
+        run: ./out/release/bin/with build :last-green
+
+      - name: Provide a display and software OpenGL
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          # xvfb: a virtual X display. libgl1-mesa-dri: Mesa's llvmpipe, the
+          # software OpenGL 4.5 the raylib spiral UAT renders through.
+          sudo apt-get install -y --no-install-recommends xvfb libgl1-mesa-dri
+
+      - name: Release UAT (under Xvfb)
+        env:
+          LIBGL_ALWAYS_SOFTWARE: "1"
+        run: xvfb-run -a -s "-screen 0 1280x800x24" ./out/release/bin/with build :release-uat
+
       - name: Package fixpoint-verified release asset
         run: |
           set -euo pipefail
@@ -656,6 +717,27 @@ jobs:
 
       - name: Verify fixpoint
         run: ./src/main.exe build :fixpoint
+
+      - name: Record last-green (the release UAT gate reads it)
+        run: ./out/release/bin/with.exe build :last-green
+
+      - name: Provide software OpenGL (Mesa llvmpipe, arm64)
+        # As on windows-x86_64: the spiral UAT places this opengl32.dll beside
+        # the program it builds (WITH_UAT_OPENGL32_DLL). Pinned arm64 llvmpipe
+        # build from mmozeiko/build-mesa.
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/mesa-llvmpipe-arm64-26.2.2.7z"
+          curl -fL -o "$archive" \
+            "https://github.com/mmozeiko/build-mesa/releases/download/26.2.2/mesa-llvmpipe-arm64-26.2.2.7z"
+          printf '%s  %s\n' "bd1c00a49504b3efe20037cf29fa437380cfb5cbe73f196272624b94938330f1" "$archive" | sha256sum -c -
+          mkdir -p "$RUNNER_TEMP/mesa"
+          7z x -y -o"$RUNNER_TEMP/mesa" "$archive" opengl32.dll > /dev/null
+          test -f "$RUNNER_TEMP/mesa/opengl32.dll"
+          echo "WITH_UAT_OPENGL32_DLL=$(cygpath -m "$RUNNER_TEMP/mesa/opengl32.dll")" >> "$GITHUB_ENV"
+
+      - name: Release UAT
+        run: ./out/release/bin/with.exe build :release-uat
 
       - name: Package fixpoint-verified release asset
         run: |

--- a/.github/workflows/seed-windows-aarch64.yml
+++ b/.github/workflows/seed-windows-aarch64.yml
@@ -264,6 +264,10 @@ jobs:
           # out/gen/main.w is the version-stamped CLI entry produced by `with build`;
           # it `use`s the src/ modules, so the full compiler is compiled in.
           test -f out/gen/main.w || { echo "out/gen/main.w missing (expected after build)"; exit 1; }
+          # The seed is self-contained: static CRT (libcmt), as the native
+          # compiler link in build/compiler.w. Programs link the DLL runtime
+          # by default (Link.w) because prebuilt Windows libraries expect it.
+          export WITH_WINDOWS_CRT_STATIC=1
           out/release/bin/with build --target "$CROSS_TRIPLE" out/gen/main.w -O1 \
             -o "$GITHUB_WORKSPACE/$SEED_ASSET"
 

--- a/build/compiler.w
+++ b/build/compiler.w
@@ -465,6 +465,12 @@ fn comp_run_compiler_capture(ctx: &ActionCtx, label: &str, argv: Vec[str], stdou
     let win_um_libdir = env("WITH_WINDOWS_UM_LIBDIR")
     if win_um_libdir.len() > 0:
         process_env = process_env.set("WITH_WINDOWS_UM_LIBDIR", win_um_libdir)
+    // The compiler is a self-contained binary: its stage links carry the
+    // static CRT (libcmt) in llvm_ld.rsp, so the child's Link.w must not add
+    // the DLL runtime it gives programs (msvcrt beside libcmt: "duplicate
+    // symbol: _invalid_parameter_noinfo" on stage2, nightly-release proving
+    // run of #1094).
+    process_env = process_env.set("WITH_WINDOWS_CRT_STATIC", "1")
     // Windows SDK / MSVC CRT include dirs, read by the child compiler's c_import
     // (ClangBridge with_cimport_add_windows_system_includes) so libclang can
     // resolve system headers. Include-side analog of the *_LIBDIR forwarding.

--- a/build/release_uat.w
+++ b/build/release_uat.w
@@ -397,6 +397,20 @@ pub fn run_release_raylib_spiral_uat_action(ctx: ActionCtx) -> i32:
     if ctx.fs().write_text(ruat_join(workdir, "src/main.w"), spiral_source) != 0:
         return ruat_fail(ctx, "could not write spiral UAT source")
 
+    // A headless Windows host has no OpenGL past 1.1 and raylib needs 3.3.
+    // WITH_UAT_OPENGL32_DLL names a software driver (Mesa llvmpipe); it goes
+    // beside the program `with run` builds (out/bin under the project), the
+    // first place Windows looks for a DLL, so the spiral renders through it.
+    // Proven on a GL-less Windows box: the same binary fails with "WGL: the
+    // driver does not appear to support OpenGL" without it and passes with it.
+    let gl_dll = ctx.env_input("WITH_UAT_OPENGL32_DLL")
+    if gl_dll.len() > 0:
+        let bin_dir = ruat_join(workdir, "out/bin")
+        if ctx.fs().mkdir_all(bin_dir) != 0:
+            return ruat_fail(ctx, "could not create " ++ bin_dir)
+        if ctx.fs().copy_file(gl_dll, ruat_join(bin_dir, "opengl32.dll")) != 0:
+            return ruat_fail(ctx, "could not copy WITH_UAT_OPENGL32_DLL (" ++ gl_dll ++ ") beside the spiral program")
+
     rc = ruat_expect_stdout(ctx, ruat_run_capture_cwd(ctx, compiler, workdir, "check", ruat_argv2(compiler, "check", "src/main.w"), 120000), "ok", "with check spiral")
     if rc != 0:
         return rc

--- a/build/release_uat_fixtures/raylib_spiral_main.w
+++ b/build/release_uat_fixtures/raylib_spiral_main.w
@@ -21,7 +21,13 @@ fn is_spiral_sample(c: Color) -> bool:
     (r > 70 or g > 70 or b > 70) and (r + g + b > 170)
 
 fn main:
-    InitWindow(900, 600, "with raylib spiral uat")
+    unsafe { InitWindow(900, 600, c"with raylib spiral uat".ptr) }
+    // No window means no GL context: every later call would run on nothing
+    // (LoadImageFromScreen crashed with exit 139 on a host whose driver stops
+    // at OpenGL 1.1). Say so and fail; a headless host needs a software GL.
+    if not IsWindowReady():
+        print("raylib spiral UAT failed: window not created (no OpenGL 3.3 context)")
+        return 1
     SetTargetFPS(60)
 
     let bg = Color { r: 14, g: 16, b: 26, a: 255 }
@@ -34,7 +40,7 @@ fn main:
         BeginDrawing()
         ClearBackground(bg)
         draw_spiral(cx, cy, t)
-        DrawText("with raylib spiral uat", 20, 20, 20, LIGHTGRAY)
+        unsafe { DrawText(c"with raylib spiral uat".ptr, 20, 20, 20, LIGHTGRAY) }
         EndDrawing()
         frame = frame + 1
 

--- a/docs/with-release-runbook.md
+++ b/docs/with-release-runbook.md
@@ -224,8 +224,9 @@ redone before upload.
 workflow runs it on every platform it publishes (darwin-aarch64,
 linux-x86_64, linux-aarch64, windows-x86_64, windows-aarch64) after fixpoint
 and before packaging, so a red UAT blocks that platform's asset. The gate
-needs the last-green manifest (`with build :last-green`, recorded after
-fixpoint) and a display with OpenGL 3.3 for the spiral: the macOS runner's
+needs the last-green manifest (`with build :last-green`, which requires the
+test-green evidence `with build :test` records, so each job runs the battery
+first) and a display with OpenGL 3.3 for the spiral: the macOS runner's
 session has one; Linux runs under `xvfb-run` with Mesa's llvmpipe
 (`LIBGL_ALWAYS_SOFTWARE=1`); Windows names a Mesa llvmpipe `opengl32.dll`
 in `WITH_UAT_OPENGL32_DLL`, which the spiral UAT places beside the program

--- a/docs/with-release-runbook.md
+++ b/docs/with-release-runbook.md
@@ -220,7 +220,18 @@ publishable binary, so run packaging after the final `:release-uat`; if UAT is
 re-run afterwards, the asset is regenerated unstripped and packaging must be
 redone before upload.
 
-`:release-uat` is mandatory for every release. It includes:
+`:release-uat` is mandatory for every release, and the nightly release
+workflow runs it on every platform it publishes (darwin-aarch64,
+linux-x86_64, linux-aarch64, windows-x86_64, windows-aarch64) after fixpoint
+and before packaging, so a red UAT blocks that platform's asset. The gate
+needs the last-green manifest (`with build :last-green`, recorded after
+fixpoint) and a display with OpenGL 3.3 for the spiral: the macOS runner's
+session has one; Linux runs under `xvfb-run` with Mesa's llvmpipe
+(`LIBGL_ALWAYS_SOFTWARE=1`); Windows names a Mesa llvmpipe `opengl32.dll`
+in `WITH_UAT_OPENGL32_DLL`, which the spiral UAT places beside the program
+it builds. A pass on one platform says nothing about another: the Windows
+gate found a C-runtime mismatch (prebuilt Conan libraries expect the DLL
+runtime) that macOS could never show. It includes:
 
 - `:release-artifact-smoke-uat`, which runs the platform-named release binary
   asset (`out/release/with-darwin-aarch64`, `with-linux-x86_64`, or
@@ -246,13 +257,16 @@ redone before upload.
   `curl_easy_setopt`, `curl_version_info`, and cleanup without network access.
 - `:release-install-layout-uat`, which copies the platform asset into a
   local install-style `bin/with` layout and runs it from there.
-- `:release-raylib-spiral-uat`, which must run on a GUI-capable Darwin release
-  host. It validates the user-facing C interop happy path end to end:
-  `with init`, `with get c.raylib`, writing the spiral program to the
-  initialized project's `src/main.w`, and `with run`. The generated raylib app
-  renders a deterministic spiral, reads back the rendered framebuffer, counts
-  bright non-background samples in the spiral annulus, and exits non-zero if the
-  visual check fails.
+- `:release-raylib-spiral-uat`, which needs a display with OpenGL 3.3 (a
+  headed host, or the software GL provisions above). It validates the
+  user-facing C interop path end to end: `with init`, `with get c.raylib`,
+  writing the spiral program to the initialized project's `src/main.w`, and
+  `with run`. The generated raylib app renders a deterministic spiral, reads
+  back the rendered framebuffer, counts bright non-background samples in the
+  spiral annulus, and exits non-zero if the visual check fails, or loudly if
+  no window could be created. raylib has no contract overlay, so its
+  `const char*` parameters are the raw surface (§16.3c, #379): the fixture
+  calls `InitWindow` and `DrawText` under `unsafe` with `c"..."` literals.
 - `:release-one-liner-uat`, which validates real shell one-liner workflows:
   `seq 100 | with -n 'if line =~ /^[0-9]$/: print(line)'`,
   `cat names.txt | with -p 'line = line.upper()'`, regex captures, numbered

--- a/src/compiler/Link.w
+++ b/src/compiler/Link.w
@@ -562,6 +562,8 @@ fn link_stage_windows_libpath(var_name: &str, fallback: &str) -> str:
 // dropped on the Windows link, not turned into a nonexistent `m.lib`.
 fn link_stage_windows_lib_is_crt_implicit(name: &str): name == "m" or name == "c"
 
+fn link_stage_windows_crt_static(): with_getenv_str("WITH_WINDOWS_CRT_STATIC") == "1"
+
 fn link_stage_make_windows_llvm_link_command(llvm_ld: &str, obj_path: &str, bin_path: &str, extras: &Vec[str], link_libs: &Vec[str], link_args: &Vec[str]) -> LinkStageCommand:
     let args: Vec[str] = Vec.new()
     let env: Vec[LinkStageEnvVar] = Vec.new()
@@ -608,8 +610,25 @@ fn link_stage_make_windows_llvm_link_command(llvm_ld: &str, obj_path: &str, bin_
         // genuinely missing library fails loudly rather than silently vanishing.
     for i in 0..link_args.len() as i32:
         args.push(with_str_clone_ref(link_args[i]))
-    args.push("libcpmt.lib")
-    args.push("libcmt.lib")
+    // The C runtime. A program links the DLL runtime (msvcrt + ucrt +
+    // vcruntime import libs, MSVC's own /MD default and Rust's on
+    // *-pc-windows-msvc) because that is the runtime every prebuilt Windows
+    // library expects: ConanCenter ships msvc binaries only as
+    // compiler.runtime=dynamic, and such a library's `__imp_realloc` /
+    // `__imp_fopen` references cannot resolve against the static libcmt
+    // (release-raylib-spiral-uat, and every `with get c.*` package, on
+    // Windows). The static runtime remains for a self-contained binary that
+    // links no such library, the cross-built compiler above all:
+    // WITH_WINDOWS_CRT_STATIC=1 selects libcmt, as build/compiler.w does for
+    // the native compiler's own link.
+    if link_stage_windows_crt_static():
+        args.push("libcpmt.lib")
+        args.push("libcmt.lib")
+    else:
+        args.push("msvcprt.lib")
+        args.push("msvcrt.lib")
+        args.push("ucrt.lib")
+        args.push("vcruntime.lib")
     // UCRT exports printf/scanf-family functions such as sprintf and
     // vfprintf only through this archive (they are inline in the headers
     // since VS 2015); Darwin-migrated C (pcre2test.w) calls them by name.


### PR DESCRIPTION
Root-causes and fixes the Windows release UAT, and makes `:release-uat` a gate the nightly runs on all five platforms.

**Why the UAT failed on Windows (three causes, in the order they surfaced):**

1. **The spiral fixture was broken everywhere since a88df01a (#379).** It passed With `str` literals to `InitWindow`/`DrawText`; a `const char*` parameter is modeled only with curated overlay evidence, raylib has none, so `with check` refused the fixture on every platform. It had not been run anywhere since June 17. Now the raw surface: `unsafe` + `c"..."`. It also fails loudly when no window is created (it used to segfault on a GL-less host).
2. **Windows-only: static CRT vs. Conan's dynamic-CRT binaries.** ConanCenter ships msvc binaries only as `compiler.runtime=dynamic`; With linked libcmt, so `__imp_realloc` etc. could never resolve. Programs now link the DLL runtime (MSVC's /MD default, Rust's default on msvc); `WITH_WINDOWS_CRT_STATIC=1` keeps libcmt for self-contained binaries (the cross-built seed sets it; the native compiler's own link already names libcmt in build/compiler.w).
3. **Windows-only: no OpenGL past 1.1 on a headless host.** raylib needs 3.3. The Windows nightly jobs fetch a pinned Mesa llvmpipe `opengl32.dll` (mmozeiko/build-mesa 26.2.2, x64 and arm64, sha256-checked) and name it in `WITH_UAT_OPENGL32_DLL`; the raylib UAT action copies it beside the program `with run` builds.

**Nightly:** every job records last-green after fixpoint and runs `:release-uat` before packaging: macOS natively, Linux under `xvfb-run` with llvmpipe, Windows with the DLL above. A red UAT blocks that platform's asset. Runbook updated.

**Verified on the Windows box** with a stage1 from this tree: `with get c.raylib` fetches (no Conan CLI needed), `with check` ok, the project links and runs under the DLL runtime, the spiral renders through llvmpipe in the interactive session ("raylib spiral UAT passed: 581/7342 bright spiral samples"), and a 69-file behavior slice passes under the new link line. A `test`-channel dispatch of the nightly on this branch is the proving run for all five platforms.
