### PR TITLE
Windows: a project's default program path carries .exe

### DIFF
--- a/lib/std/build.w
+++ b/lib/std/build.w
@@ -2803,7 +2803,11 @@ fn ws_build_plan(state: &WsState, project_root: &str) -> WorkspaceCompilePlan:
     let output_kind = state.options.output_kind as i32
     var final_output = with_str_clone_ref(state.options.output_path)
     if final_output.len() == 0:
+        // Windows shells run a file only by its extension: the default
+        // program path carries `.exe` there (compiler.Runtime's rule).
         final_output = "out/bin/" ++ state.name
+        if with_sysinfo_os() == "Windows":
+            final_output = final_output ++ ".exe"
         if output_kind == 1:
             final_output = "out/obj/" ++ state.name ++ ".o"
         else if output_kind == 2:

--- a/src/BuildGraphSupport.w
+++ b/src/BuildGraphSupport.w
@@ -14,7 +14,7 @@ pub fn build_graph_output_path(root: &str, target: &BuildGraphTarget, output_pat
         return runtime_str_clone(output_path)
     if target.output.len() > 0:
         return build_graph_resolve_project_path(root, target.output)
-    resolve_join(resolve_join(root, "out/bin"), target.name)
+    runtime_program_path(resolve_join(resolve_join(root, "out/bin"), target.name))
 
 pub fn build_graph_library_output_path(root: &str, target: &BuildGraphTarget, output_path: &str, target_count: i32) -> str:
     if output_path.len() > 0:

--- a/src/ComptimeEval.w
+++ b/src/ComptimeEval.w
@@ -4738,7 +4738,7 @@ impl ComptimeEvaluator:
             return comptime_workspace_compile_plan_invalid()
         var final_output = output_path
         if final_output.len() == 0:
-            final_output = "out/bin/" ++ record.name
+            final_output = runtime_program_path("out/bin/" ++ record.name)
             if output_kind == 1:
                 final_output = "out/obj/" ++ record.name ++ ".o"
             else if output_kind == 2:
@@ -4904,7 +4904,7 @@ impl ComptimeEvaluator:
 
         var final_output = output_path
         if final_output.len() == 0:
-            final_output = "out/bin/" ++ out.name
+            final_output = runtime_program_path("out/bin/" ++ out.name)
         let absolute_output = self.workspace_path(capability.project_root, final_output)
         let obj_path = absolute_output ++ ".o"
         let output_dir = link_stage_dirname(absolute_output)

--- a/src/compiler/Runtime.w
+++ b/src/compiler/Runtime.w
@@ -146,3 +146,12 @@ pub fn runtime_path_root_prefix(path: &str) -> str:
     if path[0] == 47 or path[0] == 92:
         return "/"
     ""
+
+// A program's path on this host: Windows shells run a file only by its
+// extension (`out\bin\app` is "not recognized as an internal or external
+// command" to cmd.exe and PowerShell), so a default executable output gets
+// `.exe` there. An explicit `-o` or `output:` is the user's and is kept.
+pub fn runtime_program_path(path: &str) -> str:
+    if runtime_sysinfo_os() == "Windows" and not path.ends_with(".exe"):
+        return path ++ ".exe"
+    path ++ ""

--- a/src/main.w
+++ b/src/main.w
@@ -2870,7 +2870,7 @@ fn run_build_command(options: BuildCommandOptions, graph_options: &BuildGraphCom
         actual_source = if with_fs_file_exists(root_main) != 0: root_main else: root ++ "/src/main.w"
         actual_options.source_path = actual_source
         if actual_options.output_path == "" and cfg.package_name.len() > 0:
-            actual_options.output_path = "out/bin/" ++ cfg.package_name
+            actual_options.output_path = runtime_program_path("out/bin/" ++ cfg.package_name)
     else:
         let cfg = project_config_load_for_source(actual_source)
         if cfg.manifest_error.len() > 0:

--- a/test/behavior/behav_project_exe_suffix.w
+++ b/test/behavior/behav_project_exe_suffix.w
@@ -1,0 +1,24 @@
+//! expect-stdout: ok
+
+use pre_d_build_runner
+use std.fs
+use std.sysinfo
+
+// A project's default program path carries `.exe` on Windows: cmd.exe and
+// PowerShell run a file only by its extension, so `out\bin\app` was "not
+// recognized as an internal or external command" although `with run` could
+// launch it by absolute path. Elsewhere the name is bare, as before.
+
+fn main:
+    let dir = p7_prepare_case("exe_suffix", "p7exesuffix")
+    p7_write(dir, "with.toml", "[package]\nname = \"p7exesuffix\"\nversion = \"0.1.0\"\n")
+    p7_write(dir, "src/main.w", "fn main:\n    print(\"exe suffix\")\n")
+    p7_assert_success(p7_run(dir, "exe-suffix-build", p7_build_args()), "build")
+    let bare = p7_join(dir, "out/bin/p7exesuffix")
+    if os() == "Windows":
+        assert(file_exists(bare ++ ".exe"))
+        assert(not file_exists(bare))
+    else:
+        assert(file_exists(bare))
+        assert(not file_exists(bare ++ ".exe"))
+    print("ok")


### PR DESCRIPTION
cmd.exe and PowerShell run a file only by its extension, so a project's `out/bin/<name>` was unusable from either shell on Windows. The four project defaults now read one rule (`runtime_program_path` in compiler.Runtime) and lib/std/build.w's Workspace.compile applies the same one; an explicit output path is kept as written. `behav_project_exe_suffix.w` asserts the name per platform. Found while running the raylib UAT by hand from the Windows box's console session (#1094).