### PR TITLE
docs: update sourcing rulings and language plans [skip ci]

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -277,8 +277,20 @@ corpus contains, `void*`/`elem_size`/callback genericity, raw pointers)
 and adds no ownership modeling, generic lifting, or ergonomics. Every
 With-ism — views, transfers, drops, generic surfaces, complexity
 contracts — is the facade's. Native code is reserved for what migration
-provenance cannot beat: graph algorithms, union-find, SlotMap's free list,
-and the intrinsic-integrated Vec and str.
+provenance cannot beat: graph algorithms, union-find, and SlotMap's free
+list. The original native-Vec exception is superseded by the follow-on
+selection below; With's `str` semantics remain the public contract.
+
+**Follow-on selection (Eric, 2026-09-12).** The
+[facade map](stdlib_sourcing_plan.md#facade-and-engine-selection--erics-ruling-2026-09-12)
+selects STC for everyday containers and algorithms, including `Vec`,
+`hmap`/`hset` for the default owning hash collections, and `smap`/`sset`
+for `OrderedMap`/`OrderedSet`. STC's inline entries and compact Robin Hood
+metadata fit an owning generic map. M*LIB's B+ tree supplies
+`BTreeMap`/`BTreeSet`; c-algorithms supplies classical engines and
+references; TommyDS supplies specialized indexing/storage. Corpus names
+need not become public types. Benchmarks validate these selections and
+compare alternatives; they no longer leave the default engine undecided.
 
 **Context.** #936 (SlotMap O(n) insert, no free list) prompted a survey
 that found the same species in BTreeMap/BTreeSet (#937, linear lookup,

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -2,11 +2,11 @@
 
 ## Current integration (2026-09-12)
 
-PCRE2 C4 (#1101), SDK-macro hygiene (#1107), and target-correct va_list
-(#1108) have merged. Main is `00a2fc9c`. Their old blockers below are
+PCRE2 C4 (#1101), SDK-macro hygiene (#1107), target-correct va_list
+(#1108), and zlib (#1103) have merged. Main is `17109853`. Their old blockers below are
 historical, not current instructions to reproduce them again.
 
-Zlib #1103 is integrated with that main in the `zlib-1103-ready` worktree.
+Zlib #1103 was integrated in the `zlib-1103-ready` worktree and merged.
 The merge keeps main's populated stage2/stage3 embedding object and adds
 both bundles to it; only stage1 uses empty bundle slots. The renamed
 `std.zl` corpus retains the macro-hygiene and c_va_list re-promotion.
@@ -101,330 +101,377 @@ Debugger launches now work; a disabled DevToolsSecurity status did not
 establish an authorization blocker, and no approval popup was seen.
 Do not repeat the performance gate or
 use the earlier quiet-box requirement below; the local ratio ruling
-supersedes it. C4 is not yet merged or reseeded.
 
-You are picking up a campaign mid-flight. This note is self-contained: it
-tells you where every thread stands, exactly what is next, the gates that
-must hold, and the traps that cost days this week. Read `CLAUDE.md` first —
-the self-host discipline is binding, and the memory notes in
-`~/.claude/projects/-Users-eric-with/memory/` (indexed by `MEMORY.md`) hold
-the rulings and traps in more detail than fits here.
+## Historical snapshot — the zlib `.wo` bundle and the ABI/bundle blocker chain (2026-09-09)
 
-## 0. Where the repo stands (stable — build on it, don't re-fight it)
+The following preserves the September 9 investigation. Its open blockers and
+next-step instructions are historical; the current integration update above
+supersedes them.
 
-- **Main is green on all five CI lanes** (macOS, linux-x86_64, linux-aarch64,
-  windows-x86_64, windows-aarch64) at `79d523f4`. Windows was the last
-  holdout (#1081, a native-Windows `invalid free` in the compiler building
-  the pcre2 bundle); it is closed, and `fix_windows.md` records the route.
-- **Seeds:** `seed.lock` pins Mac/Linux to **v0.15.2.0** and both Windows
-  platforms to **v0.15.2.1**. Every platform bootstraps from a published seed
-  it can use. `with build :seed` reads the lock; `tools/bump_seed_pins.w`
-  rewrites every workflow pin from it.
-- **Never-again guards, all landed:** `seed.lock` + the `:seed-compat` lane
-  (the pinned seed builds stage1 of a tree copy — run it with the FRESH
-  compiler, see §6), D40 seed numbering (`docs/decisions.md`: `Y` is a
-  bootstrap-compatibility group, a breakage bumps `Y` and resets `Z`), and
-  publish-first releases (`with build :publish-release-asset`,
-  `build/release_publish.w`: each platform adds its asset the moment it is
-  verified; nobody waits for the slowest runner).
-- **Open PRs:** only #1078 (Eric's own draft audit evidence; not a review
-  target). Everything mergeable was merged or closed-as-landed on 09-07.
+This is a complete state dump for an agent picking up the `.wo` bundles /
+stdlib-sourcing campaign. It is long on purpose: read it all before touching
+anything. The headline is a **real, unsolved macOS bug** (section 1) that
+gates two PRs, plus a **three-deep dependency chain** of ABI/migrator fixes
+(section 2). Everything is on branches/worktrees; `main` is untouched.
 
-## 1. The campaign and its sequence
+Author/commit rules (do not violate): commits are `Eric Hartford
+<eric@quixi.ai>`, never any other identity, never `lazarus.enterprises`; no
+attribution/co-author trailers. Never `git stash`. No Python/bash/perl/sed/awk
+for scripts or transforms — use With one-liners (`with -p`/`-n`/`-e`). Never
+`-O0`. Only Eric blesses spec wording. The Bash tool's shell is **zsh** (an
+unquoted `$OPTS` holding several flags is ONE argument and gets silently
+dropped — spell flags out).
 
-The goal, per `docs/wo_bundles.md`, `docs/with-abi.md`, `docs/abi_roadmap.md`,
-`docs/fn_abi_descriptor_design.md`, and `docs/stdlib_sourcing_plan.md`:
-compile each migrated C corpus **once** into a `.wo` bundle behind a
-versioned With ABI (Level 0), so that bringing in the container/algorithm
-corpora costs nothing per build. The sequence in `wo_bundles.md` §Sequence:
+---
 
-| step | state |
-|---|---|
-| 1. ABI v1 written + ABI-hash check in the battery | **done** |
-| 2. pcre2 → `pcre2.wo`, `with_regex_*` shim retired | mechanism + bundle landed (C1–C3); **shim retirement = C4, built but NOT merged — see §2** |
-| 3. zlib → `zlib.wo` | **not started** — §3 |
-| 4. new corpora arrive as `.wo` from day one | gated on 2 and 3 — §4 |
+## 0. Branches, worktrees, PRs, issues (verified 2026-09-09 ~18:30Z)
 
-**The order is not negotiable:** C4 lands, then zlib, then Phase 0 of the
-corpora plan, then c-algorithms. zlib and Phase 0 touch the same
-embed/link wiring C4 touches, so starting them before C4 lands only adds to
-C4's rebase. Phase 0's *docs* (§4) are the one thing that can run in
-parallel.
+| Branch  | Worktree                          | Tip       | Meaning |
+|---------|-----------------------------------|-----------|---------|
+| main    | `~/with`                          | a2df2115  | untouched baseline |
+| wo-c4   | `~/.local/with-staging/c4r`       | 7910cf98  | **PR #1101** (C4: retire regex shim). Eric-finished; +my CI diagnostics |
+| zlib-wo | `~/.local/with-staging/zlibwo`    | 61f1e301  | **PR #1103** (zlib `.wo` bundle), stacked on wo-c4 |
+| va-list | `~/.local/with-staging/valist`    | 71b7467c  | **#1104** va_list ABI fix, off wo-c4. WIP, does not build yet |
 
-## 2. C4 — retire the regex shim. THE BLOCKER. Land this first.
+- **PR #1101** (wo-c4): `linux aarch64/x86_64` + `windows aarch64/x86_64` GREEN;
+  **`macOS arm64` FAILURE** (section 1). This is the ONLY thing blocking C4.
+- **PR #1103** (zlib-wo): `linux aarch64` + both `windows` GREEN (the Windows
+  `fcntl` fix worked); **`macOS arm64` FAILURE** (same bug, section 1);
+  **`linux x86_64` FAILURE** (= #1104 va_list crash, section 2).
+- **#1102** OPEN — migrator leaks host SDK macros into shared defs.
+- **#1104** OPEN — va_list modeled as a pointer on every target.
 
-### What it is
-`std.regex` calls pcre2 directly through the bundle interface; the
-`with_regex_*` runtime shim and every hook that carried it are deleted
-(D30); the compiler's regex-literal validation and codegen go through the
-facade. Tracked by #955 (also covers the emit-C lane after the bundle).
+Landing order intended: fix macOS bug → #1102 → #1104 → C4 (#1101) → #1103.
+The macOS bug (section 1) must be solved first; it blocks BOTH #1101 and #1103.
 
-### Where the code is
-Two worktrees under `~/.local/with-staging/`:
+---
 
-- **`c4r` — the landing tree.** Branch `wo-c4` rebased onto main
-  `79d523f4`: **head `973a738a`, 32 commits**, ABI hash re-recorded for the
-  merged tree, `with check src/main.w` passes with the seed. This is what
-  eventually merges to main.
-- **`c4p` — the measuring tree.** Head `980a12e0` (same fixes, on the older
-  base), working tree clean. Lane measurements were taken here because the
-  box must be quiet for a valid number.
+## 1. THE BLOCKER: macOS embedded-bundle bug (unsolved, not reproducible locally)
 
-Both carry the full C4 series, in this order: the facade (C4.1), regex-literal
-validation via `std.regex` (C4.2), codegen through the facade, the shim
-deletion (C4.4), the ambient-tier/prelude changes, the bundle-corpus
-in-unit compile for emit-C, the MIR global-proxy mark, then the three
-performance commits: **lazy interface collection** (`fe5d31dd`-class),
-**indexed symbol/signature/extern-var lookups** (`a463244a`), and the
-**on-demand interface merge** (`e331b848` + the root-tail rotation
-`2fe8ecb9`). Plus `1c775d05`: three "source wins" rules (Sema
-`collect_fn_decl`, `collect_extern_fn`, codegen `declare_function_at_inner`)
-so an interface declaration never displaces a same-named source
-declaration whatever the order.
+### What fails
 
-### The gate (Eric's ruling, 2026-09-07: "we are gonna need to fix the perf")
-**Hard. C4 does not land above it.**
-- hello-world `with check` ≤ **0.05 s** (pre-C4 baseline 0.03 s)
-- behavior-tests lane ≤ **158 s** (pre-C4 baseline 144 s; that is +10%)
-- measured on an **idle box**, first cold run excluded, release compiler.
+Both `wo-c4` and `zlib-wo` fail the `macOS arm64` CI lane on the **same two
+tests**, deterministically (three reruns, identical):
 
-### Where the numbers stand
-| mechanism | hello check | behavior lane | verdict |
-|---|---|---|---|
-| C4 without perf work | 0.23 s | 414 s | the bug Eric ruled on |
-| + lazy interface collection | 0.07 s | 177 s (green) | hello over, lane over |
-| + lookup indexes | 0.07 s | 177 s (no change — expected; it is the fix for large units) | — |
-| + on-demand merge, first run | **0.05 s ✓** (`decls` 4771→1366; interface parses 59 of 3,405 lines) | 306.8 s **RED**, 14/980 failed | invalid |
-| + root-tail rotation, rerun | 0.05 s ✓ | 282.2 s, **GREEN** (980/980) — but **invalid**: the box carried a full core of foreign load (Steam ~99% of a core, WindowServer, VS Code, a VM; load 3.0–3.5) | not a gate measurement |
+1. **`selfcheck`** corpus test = `out/stage/bin/with-stage2 check src/main.w`.
+   Errors:
+   ```
+   let stderr = with_fs_read_file(err_path)   // src/main.w:1307
+   error: wrong argument type in call to 'reduce_discard_kept_test_binary'
+     = label argument 'stderr' has type *mut c_void
+     = note: parameter 'text' expects &str
+   error: shadowing is not allowed for 'stderr'   --> src/main.w:1:1
+   ```
+   The local `stderr` binding is typed `*mut c_void` — the type of the libc /
+   bundle-interface global `stderr` (Darwin's `__stderrp`). The local should be
+   `str` (return of `with_fs_read_file`).
 
-**Neither 177 s nor 282 s is admissible** — both were taken on a loaded box.
-Per-test timings on `behav_derive_clone.w`, same box state, three binaries:
-pre-C4 seed check/build/test 0.03/0.09/0.39–0.54 s; eager C4 0.45/0.54/0.81 s;
-on-demand C4 **0.05/0.12/0.40 s** — parity with the seed on `test`, half of
-eager C4. On that arithmetic the lane on a quiet box lands near **150–160 s**,
-i.e. at the gate. So the "regression" was load, not the merge.
+2. **`behav_cli_test_command_args.w`** (a p7 CLI test). It writes a trivial
+   `tests/one.w` (`fn main: print("one")`) into a scratch dir and runs the
+   compiler there. It fails with:
+   ```
+   error: import module not found: 'std.re.defs' (build-generated modules live
+     under out/gen; run `with build` once in a fresh checkout)
+   error: import module not found: 'std.re.pcre2_compile' ...
+   ... (every std.re.* module)
+   ```
 
-The 14 failures in the first run were a real ordering bug: the merge
-appended interface chunks *after* the root's declarations, but
-`Sema.is_local_decl` takes the **last N** declarations of the merged pool as
-the root's, so the root's own types read as imported (`derive` generation,
-sealed-trait locality and `copy` all failed). `2fe8ecb9` rotates the chunks
-in before the root tail; the rerun above proves it (980/980).
+### Root cause (as far as established)
 
-**The remaining per-compile residue is measured** (phase profile of `check`
-on `behav_derive_clone.w`, on-demand release vs seed, ms): parse 9.7 vs 3.5,
-resolve 9.9 vs 3.8, imports 4.2 vs 0.3, interface 4.2 (new), comptime 9.9
-vs 4.4, sema 4.9 vs 3.9, MIR 3.5 vs 2.8 — **48 vs 21 ms**. About 16 of the
-extra 27 ms is the interface sections' **937 `use` lines**: parsed as `use`
-declarations twice (Resolve, then the import worklist — `decls` 1368 vs
-447, the 920 extra are those use decls), each resolved to a module path
-individually (`resolve_module_path_frontend` × 937 for ~35 distinct
-modules), then carried through the comptime transform's pool clone before
-being stripped. The chunk fixpoint itself is 4.2 ms (two passes); the
-rotation is sub-millisecond. **That fix is done and committed** (`c4p`
-`980a12e0`, ported to `c4r` as `4d775b12`): Resolve turns a section's `use`
-lines into import edges directly from text (`process_interface_module`),
-and the worklist enqueues a section's imports from the same text with a
-per-compile name→path memo (35 distinct modules) — no use declaration of a
-section enters the pool. Same check: **48 → 40 ms** (seed 21), `decls=463`,
-imports 0.5 ms. The same commit fixes a latent pairing bug it exposed: a
-section's path was pushed to the pending list before its imports recursed
-and its text after, so `pcre2_compile_8` was attributed to
-`pcre2_compile_cgroup.w`, its link name hashed the wrong module and the
-bundle went unlinked (caught by the regex tests). With it: check 0.04 s ×3
-(seed 0.03), hello-world **0.04–0.05 s ×4** — the hello gate is met; the 14
-derive/sealed/copy tests, the three regex behavior tests, the regex/abort
-repros, the compiler self-check and both fixtures all pass. The branch's
-`docs/wo_bundles.md` (`973a738a`) documents all five mechanisms with their
-figures.
+Both symptoms are downstream of the **embedded pcre2 bundle interface not being
+used** on the macOS CI build. When the bundle interface is active, `use
+std.regex` resolves to the embedded `.wi`, `std.re.*` resolve to it, and the
+libc/interface `stderr` global is import-gated (a local `stderr` wins). When it
+is NOT active, the frontend falls back to looking for `std.re` **sources** under
+`out/gen` (symptom 2's message), and the flat namespace lets the interface/libc
+`stderr` shadow a program local (symptom 1).
 
-### What you must do next (in order)
-1. **Measure the gate as a RATIO, LOCALLY — this is the only thing left before landing.** Every mechanism is done; per-test arithmetic (`test` 0.40 s vs the seed's 0.39–0.54) puts the lane at or under the seed's own 144 s. Eric's rulings (2026-09-09): activity on the laptop blocks nothing — do **not** wait for an idle box — and the measurement is **local, not CI**. The gate is *relative* (≤ +10% over the pre-C4 baseline), so measure it on this box under identical conditions where load cancels: run the pre-C4 seed's behavior lane and C4's behavior lane **interleaved, A/B/A/B, at least two full pairs**, same box, release compiler. Report each run's wall time and the ratio C4/seed; **ratio ≤ 1.10 is the gate.** A wall-clock number taken alone on the shared laptop (177 s, 282 s) is load noise and proves nothing either way.
-3. Iterate until the lane is **green and ≤ 158 s on the `c4p` base.** If the quiet-box number lands above the gate, profile a representative behavior test (not hello) with `WITH_PROFILE=1` and name the next mechanism with its ms, as above. Every mechanism you add: report its measured delta.
-4. **Port to `c4r`**, re-measure the lane once on the rebased tree (main's changes can shift it), then the full battery **with the move and drop audits** (C4 touches MIR): `with build`, then with the fresh `out/release/bin/with`: `:fixpoint`, `:move-audit`, `:drop-audit`, `:test`, `:seed-compat`, `analyze src/main.w audit:all`, `:test-green`, `:last-green`. Report all numbers. Only then push, reseed (`:update-seed`, `:install-user`), close #955.
-5. Update `docs/wo_bundles.md` §"Shim retired (batch C4)" with the final measured table (the branch's copy has the 0.23 s / 414 s pre-fix numbers and the placeholder).
+### Critical facts — read these before forming a theory
 
-### The prior agent
-Session id `aa40516def8194a3f` did all of the above and knows the code
-intimately; it can be resumed with a message if it is still reachable. It
-went idle twice without reporting a lane number — if you resume it, demand
-the number first. Its regression-found-then-fixed history is in this
-session's memory note `wo-c4-plan.md`.
+- **Not a flake.** Deterministic across reruns. The failing tests are real
+  compile errors, surfaced by the `Failure diagnostics` CI step (added on wo-c4
+  in 7910cf98 / zlib-wo 61f1e301 — `if: failure()` dumps captures + probes the
+  stage2 binary; it is the reason we can see this at all).
+- **Not reproducible locally.** On `~/.local/with-staging/c4r`,
+  `out/stage/bin/with-stage2 check src/main.w` returns **rc 0**, and
+  `out/release/bin/with test test/behavior/behav_cli_test_command_args.w`
+  passes. The C4 release binary embeds the bundle (`strings out/release/bin/with
+  | grep -c std/re/pcre2_compile` = 6) and its abi-sha is
+  `ea839643fc8666b5e605023e5e41f05026918a62405ea69d7fdf91f6f179718b`.
+  **The failure is layout/build-dependent** — the #729 / test-runner-only class
+  (see the `test-runner-only-failures` playbook: hard-link the runner's binary,
+  break on the collision). It manifests on the CI runner's freshly-built
+  stage2/release, not on a locally-built one.
+- **The zlib-wo Sema fix does NOT fix it.** I hypothesized that my zlib-wo
+  commit `ca40e7f5` ("a source definition keeps the flat signature index
+  whatever the collection order; interface globals bind per declaring module")
+  would green macOS. **REFUTED**: zlib-wo (61f1e301) CONTAINS ca40e7f5 and still
+  fails macOS on the identical two tests. Do not re-assert this.
 
-## 3. zlib → `zlib.wo` (DONE on branch `zlib-wo`; PR after #1101)
+### Candidate causes NOT yet checked (start here)
 
-**State (2026-09-09).** Branch `zlib-wo` = `wo-c4` (C4, PR #1101) + the
-zlib batch, in worktree `~/.local/with-staging/zlibwo`. Battery #3
-fully green there (build 195 s, fixpoint 289 s, test 1006 s,
-seed-compat, test-green, last-green; both drift lanes byte-identical,
-both harnesses run). Not reseeded: reseed from main once #1101 and this
-PR have merged. The second bundle was not "mechanical": it exposed five
-consumer-side defects and one build-cache defect, all fixed in the batch
-(commits `af9fd36c` migrator, `59012470` variadic interface,
-`c8835444` corpus, `ca40e7f5` Sema, `f6b82ba0` codegen, `0da6940b`
-build-layer, `ab30b320` store key) — see `docs/wo_bundles.md` and the
-notes below. **Measured** (interleaved A/B, `WITH_PROFILE=1`, release
-compilers of `wo-c4` vs `zlib-wo`, 3 rounds): a program importing
-`std.zlib` (`test/behavior/behav_zlib_std.w`) spends ~800 ms in the
-compiler's phases with the corpus in-unit and ~160 ms with the bundle
-(imports 48→1.3 ms, comptime 75→11 ms, mir.lower 30→4 ms, llvm
-gen/optimize/emit 570→115 ms; link unchanged at 26 ms). `with check
-build.w` is unchanged (57 ms comptime either way) and the compiler's
-own build is unchanged: the compiler binary never reaches zlib, so
-"stop recompiling zlib on every build" is a per-consumer win, not a
-compiler-build win.
+1. **Embedded-bundle abi-sha mismatch on the macOS build.** `Link.w`
+   (`link_stage_select_embedded_bundles`) refuses a bundle whose manifest
+   abi-sha != the compiler's baked abi-sha, and the frontend then has no
+   interface → falls back to out/gen. If the macOS CI build stamps a different
+   abi-sha into the compiler than into the bundle (build ordering, a stale
+   embed, the `.unstamped` vs stamped binary), the bundle is silently refused.
+   Check: on the runner, `with version --abi-sha` vs the embedded bundle
+   manifest's abi-sha; look for a "was built for ABI X but this compiler is Y"
+   eprint (it may be swallowed).
+2. **Empty/stale embed data.** `out/gen/compiler/EmbeddedBundlesData.w` (the
+   embed index) or the embedded `.wi` blob could be empty/wrong on the macOS
+   build. The p7 "run with build once" message is exactly the fresh-checkout
+   fallback — the frontend found neither embedded nor out/gen sources.
+3. **cwd / WITH_OUT_DIR resolution.** The p7 test runs the compiler with cwd =
+   scratch dir. macOS CI sets `WITH_OUT_DIR=<workspace>/out` (ci.yml). If bundle
+   / out/gen resolution uses cwd instead of WITH_OUT_DIR, a scratch-cwd compile
+   fails to find them. But the EMBEDDED bundle should not need out/gen at all —
+   so the real question is why the embedded path isn't taken.
+4. **The stderr collision itself** (symptom 1) may be a second, independent
+   flat-namespace hole not covered by wo-c4's `785730e1` / `b7758cad` /
+   zlib-wo's `ca40e7f5` — a local named exactly like a libc global the
+   (embedded or fallback) bundle interface re-exports. But if the bundle were
+   used correctly, `stderr` would be import-gated; so symptom 1 is likely also
+   downstream of "bundle not used."
 
-What the batch had to fix beyond the pcre2 template (each is a general
-rule now, not a zlib special case):
-- Sema flat namespace (D29-B pending): an interface declaration collected
-  after a same-named source definition kept `fn_decl_nodes` but
-  overwrote `sig_lookup` (std.zlib's `compress` vs the corpus's C
-  `compress`); interface globals were keyed by name alone (pcre2's
-  `UINT_MAX` hid zlib's). Both per-module now.
-- Codegen: unions were never predeclared, so the alphabetical `.wi`
-  (struct before the unions it holds) failed layout; a bundle build now
-  carries the non-corpus With functions its corpus reaches (std.libc's
-  gz I/O wrappers) as internal copies, because a whole-program consumer
-  never defines module-link-named symbols.
-- The bundle interface spells variadic functions (`gzprintf(..., ...)`).
-- The store slot is keyed by the compiler sources too (`compiler-src-sha`):
-  battery #2 linked a stale object under an unchanged ABI.
-- ToolFs accepted only project-relative paths, hiding the real error on
-  the helper-programs failure path; `std.zl` is an internal module for
+### How to reproduce (the hard part)
+
+You need the CI runner's binary or a from-scratch macOS build that reproduces
+the layout. Options: (a) trigger the macOS lane and pull the uploaded artifacts
+(zlib-wo's ci.yml `Failure diagnostics` dumps captures; consider adding an
+`actions/upload-artifact` of `out/stage/bin/with-stage2` + `out/gen` +
+`out/wo/*` on failure, as the Windows workflow already does); (b) a clean
+`git clone` + `with build :seed` + full `with build` on this Mac and run
+`out/stage/bin/with-stage2 check src/main.w` and the p7 test — try to hit the
+layout. The `WITH_ALLOC_NO_REUSE` / debug-allocator / `--dump-place-map` route
+applies once reproduced. This is a real deep-compiler bug; use the deep tools,
+not grep.
+
+**THE PLAN — a local CI VM via Apple Virtualization.** The failure is
+layout/build-dependent and does not reproduce on the dev Mac (option b keeps
+passing), so the strategy is to build a virtual machine that replicates the
+GitHub `macos-latest` runner environment as closely as possible and reproduce
+the failure inside it, where we can then attach the debugger. Use Apple's
+Virtualization framework (`https://developer.apple.com/documentation/virtualization`)
+to stand up a macOS arm64 guest that mirrors the runner: a clean checkout, the
+same seed (`with build :seed`, pinned in `seed.lock`), the same `.deps` LLVM
+SDK, the same env (`WITH_OUT_DIR`, `WITH`, `LLVM_PREFIX` per `.github/workflows/ci.yml`),
+and the same steps (`src/main build` → `build :fixpoint` → `src/main build :test`).
+The goal is a fresh, isolated filesystem/build layout matching the runner so the
+`#729`-class non-determinism actually triggers; once it fails inside the VM, the
+usual deep tools (debug allocator, `WITH_ALLOC_NO_REUSE`, breakpoints on the
+`stderr`/bundle collision, `--dump-place-map`, `--trace-ownership`) reach the
+live compiler branch. Per the self-host rule, any VM orchestration/driver we
+write is With, not shell/Python (the only exception is the framework calls
+themselves, reached via `extern fn`). This is Anka/Tart-style runner
+virtualization but built on the first-party Virtualization API so it stays a
+self-contained, reproducible local environment.
+
+CI run IDs for the dumps (`gh run view <id> --log`): #1101 macOS = 34368362224;
+#1103 macOS = 34372877059; #1103 linux x86_64 = 34372876934.
+
+---
+
+## 2. The dependency chain behind #1103's `linux x86_64` lane
+
+`#1103 (zlib bundle) → #1104 (va_list ABI) → #1102 (migrator macro leak)`.
+
+### #1104 — va_list is modeled as a pointer on every target (IMPLEMENTED, verified)
+
+**Bug**: `va_list` was modeled as the migration HOST's shape. On macOS it is
+`char *`, so a variadic C definition migrated there (zlib's `gzprintf`/
+`gzvprintf`, pcre2test's `cfprintf`) becomes `var __local_va: *mut i8`;
+`llvm.va_start` writes into an 8-byte slot. On SysV x86_64 the `__va_list_tag`
+is 24 bytes and `vsnprintf` wants a POINTER to it → stack corruption, **exit
+139** (this is #1103's `linux x86_64` `zlib-wo-drift` crash). Only variadic
+DEFINITIONS that read varargs are affected; calls and externs already work.
+pcre2 (the bundle) has none; only pcre2test (the harness) and zlib's gz layer.
+
+**Fix (on branch `va-list`, worktree `~/.local/with-staging/valist`, commits
+aec8b11a + 71b7467c):** C's va_list is a compiler-known per-target type
+`c_va_list`:
+- `TypeKind.TY_VA_LIST` (=21) in `src/Sema.w`; `ty_c_va_list` field, created
+  with `add_type(TY_VA_LIST,0,0,0)`, `register_prim("c_va_list", ...)`;
+  `is_copy` returns 1. Sema imports `TargetSpec`.
+- `src/TypeLayout.w`: `type_layout_c_va_list_size()` = 8 (Darwin/Windows) / 24
+  (Linux x86_64) / 32 (Linux aarch64); size_of/align_of handle TY_VA_LIST
+  (align 8). **TypeLayout.w is in `docs/with-abi.sha256` — re-record it.**
+- `src/Codegen.w` `sema_type_to_llvm`: TY_VA_LIST → `ptr` when size 8, else
+  `[i8 x size]`. Codegen imports `TypeLayout`.
+- **Share-place on Linux**: `Sema.sig_param_is_c_va_list_by_place(sig,pi)` (true
+  when the param is c_va_list AND `target_spec_os() == "Linux"`) →
+  `set_sig_param_value_ref_abi`, wired in `src/SemaDecl.w` for BOTH
+  `collect_fn_decl` and `collect_extern_fn`. `Codegen.declare_extern_fn`
+  declares a value_ref_abi param as `ptr`.
+- **Migrator**: `src/compiler/ClangBridge.w` `translate_type_recursive_mode`
+  checks the PRE-canonical spelling (`clang_getTypeSpelling` + `c_strstr
+  "va_list"`) and returns `c_va_list` BEFORE canonicalization decays a macOS
+  `char *` va_list. Also `CImport.w ci_map_builtin_typedef` maps
+  va_list/__builtin_va_list/__gnuc_va_list → c_va_list, the aggregate-va_list
+  path returns `ty_named("c_va_list")`, and `ci_translated_builtin_type_name`
+  knows it. `lib/std/libc.w`'s `vsnprintf`/`vfprintf`/`vprintf` take `c_va_list`.
+  `with_va_start`/`with_va_end` stay `*mut i8` (the migrator passes `&raw mut va`).
+
+**VERIFIED from IR** (`with ir X.w --target=linux_x86_64` vs native): the
+migrated pattern `var va: c_va_list; with_va_start(&raw mut va as *mut i8);
+vsnprintf(..., va)` emits, on linux_x86_64, `alloca [24 x i8]`, `va_start` on it,
+`vsnprintf(..., ptr %2)` (the tag ADDRESS); on darwin, `alloca ptr`, `va_start`
+on it, `vsnprintf(..., ptr %loaded)` (the char* BY VALUE). A macOS re-migration
+of `gzwrite.c` now emits `var __local_va: c_va_list` and `gzvprintf(...,
+__param_va: c_va_list)`.
+
+**Remaining for #1104 to land:**
+1. **Fix #1102 first** (below) — it blocks the pcre2 corpus re-promotion.
+2. Re-promote both corpora so `gzwrite.w` and `pcre2test.w` carry `c_va_list`.
+   The zlib half is done on `va-list` (71b7467c: only gzwrite.w's 2 va lines
+   changed; the +105-line SDK-macro defs.w drift was discarded = #1102). pcre2
+   still needs it (pcre2test.w's `cfprintf` still `__local_args: *mut i8`).
+3. **The branch does NOT build yet** — std.libc's v-formatters take c_va_list,
+   so pcre2test.w won't compile until re-promoted.
+4. Re-record `docs/with-abi.sha256` (TypeLayout.w changed → abi-hash-check trips).
+5. Full battery + move/drop audits (this is an ABI change — isolated batch).
+
+`c_va_list` is a builtin (registered prim), NOT emitted into `defs.w`, so
+`defs.w` does not change for #1104 — only the two files that USE va change.
+
+### #1102 — migrator leaks host SDK macros into shared defs (fix located)
+
+**Bug**: since the 2026-09-03 promote, the migrator captures object-like macros
+from SYSTEM headers and emits them as `pub let` into the shared `defs.w` —
+`MAC_OS_X_VERSION_10_0`, `FD_SETSIZE`, and on pcre2 config macros
+(`HAVE_UNISTD_H`, `USE_CLANG_TYPES`, `USE_CLANG_STDDEF`, `USER_ADDR_NULL`,
+`USE_CLANG_STDARG`) that collide → `error: shadowing is not allowed for
+'HAVE_UNISTD_H'`. This makes corpus output host-dependent AND blocks re-migrating
+pcre2 (the collisions are hard errors). Candidates for the regression: the
+c_import macro commits `1f826ac4` / `82f21d7c`.
+
+**Fix (located, one guard — NOT yet applied):** the bridge already computes
+system-ness. In `src/CiMigrate.w` `ci_capture_macro_values` (~line 776) and
+`src/CImport.w` `ci_collect_object_macro_values` (~line 2698), skip a macro when
+`with_cimport_macro_is_system(session, i) != 0`. That predicate
+(`src/compiler/ClangBridge.w:2613`, populated at 2310 from
+`macro_location_is_system_from_cursor` → `cimport_location_path_is_system`) is
+real and populated. **Still verify the pub-let EMIT path reads the capture
+table** (so skipping at capture actually suppresses emission), then re-promote
+both corpora and confirm the diff is empty except intended changes. #1102 is a
+migrator-hygiene fix; keep it its own commit/batch (do not fold into the ABI
+batch beyond what's forced).
+
+### Corpus re-promotion gotchas (both #1102 and #1104 need it)
+
+- The zlib corpus is package `std.zlib` under `lib/std/zlib/` on wo-c4 (NOT the
+  `std.zl` rename — that is zlib-wo only). It is prelude-ON (committed
+  `lib/std/zlib/defs.w` has NO `type c_void = opaque`). Migrate settings:
+  `--shared-defs std.zlib.defs --no-c-export --prefer-brace --width-slice 8`,
+  NO `--no-prelude`. A faithful full-directory re-migrate matched committed
+  byte-for-byte except gzwrite's va lines and defs.w's SDK-macro drift (#1102).
+- The pcre2 corpus is package `std.re` under `lib/std/re/`, prelude-OFF
+  (committed `lib/std/re/defs.w` HAS `type c_void = opaque` via the name-based
+  `ci_migrate_shared_defs_targets_regex_zone`). Its migrate is a directory
+  migrate with excludes (pcre2demo/pcre2grep/pcre2posix_test/pcre2_jit_test/
+  pcre2_dftables/pcre2_fuzzsupport) and special source handling
+  (`pcre2_chkdint.c` fails a naive CLI directory scan) — use the
+  `:pcre2-migrate` ACTION, not a hand CLI migrate.
+- **Reference trees** the actions expect: `out/zlib_reference/zlib-1.3.2/`
+  (with `.with-reference-ready`) and `out/pcre2_reference/pcre2-10.47/`
+  (NOT `out/pcre2_reference/src`). Copy from `~/with/out/*_reference/` or another
+  worktree; the reference download is network-gated.
+- **`:*-promote` chain via the native runner hits #921**: `error:
+  Workspace.set_migrate_options requires compiler driver comptime evaluation`.
+  Run `:*-migrate` directly (`WITH=<stage1> <stage1> build :zlib-migrate`), which
+  re-runs under comptime, then copy the .w files the way `run_*_promote_action`
+  does. Do the re-migrate with a stage1 that HAS the migrator changes.
+
+---
+
+## 3. The zlib `.wo` bundle (PR #1103) — what it is and what landed
+
+The campaign: compile each migrated C corpus once into a versioned-ABI `.wo`
+bundle (object + `.wi` interface + manifest, keyed by corpus/target/ABI), embed
+it, link on demand, so a consumer of `std.zlib` doesn't recompile zlib every
+build. pcre2 was the first bundle (C1–C4). zlib is the second.
+
+zlib-wo (61f1e301, over wo-c4) is a fully-green worktree battery (build/fixpoint/
+test/seed-compat/test-green/last-green) — the macOS + linux-x86_64 failures are
+CI-only (sections 1, 2). What the second bundle exposed and fixed (all in the
+batch; each is now a general rule, see `docs/wo_bundles.md`):
+- Corpus package `std.zlib` collided with the facade module `lib/std/zlib.w`
+  (the frontend's parent-module import fallback pulled the facade into the
+  `--no-prelude` bundle build). Renamed corpus → `std.zl` under `lib/std/zl/`;
+  `build/wo.w` now refuses a corpus whose package name is also a module file.
+  (This rename is ON zlib-wo only, NOT wo-c4/va-list.)
+- The migrator's prelude-free vocabulary (c_void, `__ci_unreachable`) is keyed
+  on the migrate workspace's `prelude_mode: None` (`with migrate --no-prelude`),
+  no longer on the corpus name `std.re` (`ci_migrate_output_is_prelude_free`).
+- The bundle interface spells variadic functions (`gzprintf(..., ...)`) instead
+  of refusing them (§18.5c: a `.wi` is ordinary declaration syntax).
+- Two Sema flat-namespace holes (`ca40e7f5`): a source fn signature was
+  overwritten by a same-named interface signature (facade `compress` vs corpus C
+  `compress`); interface globals were keyed by name only (pcre2's `UINT_MAX` hid
+  zlib's) → per-declaring-module binding (`interface_global_alt_*`).
+- Two codegen gaps (`f6b82ba0`): unions weren't predeclared (the alphabetical
+  `.wi` puts `ct_data_s` before its unions); a bundle build now carries the
+  non-corpus With functions its corpus reaches (std.libc's gz I/O wrappers) as
+  INTERNAL copies (`decl_path_is_bundle_carried`), because a whole-program
+  consumer never defines module-link-named symbols.
+- The store slot is keyed by the compiler SOURCES too (`compiler-src-sha`,
+  `ab30b320`): battery #2 linked a stale object under an unchanged ABI.
+- Windows: `fcntl` is a per-target runtime seam (`961bbda6`) — zlib's gz layer,
+  migrated on macOS with O_NONBLOCK/O_CLOEXEC resolved, calls fcntl, which
+  std.libc had as a bare extern and UCRT lacks. POSIX forwards via a variadic
+  libc extern; Windows returns -1. A failed undefined-symbol probe now warns
+  instead of silently linking every bundle (`6cb098c8`).
+- ToolFs accepts an absolute path under the project root (`0da6940b`, a
+  failure-path bug in build-helper-programs); `std.zl` is an internal module for
   the spec inventory.
-- #1102 filed: the migrator now leaks the macOS SDK's `MAC_OS_X_VERSION_*`
-  macros into every shared defs (host-dependent corpus output); zlib's
-  re-promoted defs carries them, pcre2 was not re-promoted.
-- Windows (#1103's first CI run): the bundle object carries every corpus
-  module, and zlib's gz layer — migrated on macOS with `O_NONBLOCK` /
-  `O_CLOEXEC` resolved — calls `fcntl`, which `std.libc` declared as a
-  bare extern and UCRT does not have. `fcntl` is now a runtime seam like
-  `open`/`read`/`close` (`with_libc_fcntl` → `rt_fcntl`; POSIX forwards
-  through a variadic extern, Windows reports unsupported). Windows linked
-  zlib's object at all because Link.w's undefined-symbol probe fails
-  there and a failed probe silently linked every bundle; it now warns.
-- **#1104 (blocks #1103's linux x86_64 lane): `va_list` is modeled as an
-  8-byte pointer on every target.** The drift harness runs zlib's
-  `gzprintf` → `vsnprintf(va)`; on SysV x86_64 `va_start` writes a
-  24-byte tag into the 8-byte slot and `vsnprintf` expects a pointer to
-  it — exit 139. Verified from the IR (`with ir --target=linux_x86_64`
-  emits the same `alloca ptr` as Darwin). Only variadic *definitions*
-  are affected (pcre2 has none). Fix = a per-target `VaList` type, one
-  `PassMode` rule in `compute_fn_abi`, the migrator emitting `VaList`,
-  zlib re-migrated, and a behavior test on every lane — an ABI batch,
-  alone, with the audits. Landing order: #1101 → #1104 → #1103.
-- macOS CI fails `behav_cli_test_command_args` and the `selfcheck` corpus
-  test on both this branch and #1101, deterministically, while both pass
-  locally; both use `out/stage/bin/with-stage2`, which the CI Fixpoint
-  step rewrites just before the battery. `wo-c4` (7910cf98, merged here)
-  adds a `Failure diagnostics` workflow step that dumps the surviving
-  captures and probes that binary; the next failing run names the cause.
 
-How it was wired (the template for the next corpus):
-- the corpus moved from `lib/std/zlib/` (package `std.zlib`) to
-  `lib/std/zl/` (package `std.zl`): the corpus package and the facade
-  `std.zlib` (`lib/std/zlib.w`) may not share a dotted path, because the
-  frontend's parent-module import fallback pulled the facade into the
-  `--no-prelude` bundle build (`docs/wo_bundles.md`; `build/wo.w` now
-  refuses such a corpus by name);
-- a `wo_bundle_plan(ctx, "zlib", "std/zl", "lib/std/zl/bundle.w")` in
-  `build.w` beside `pcre2_wo`, wired through `wo_bundle_targets`,
-  `target_with_link_bundle` on every stage, and `target_with_wo_blobs`;
-  `lib/std/zl/` is excluded from the embedded stdlib in BOTH lists
-  (`build.w target_with_embedded_stdlib_inputs` and the generator in
-  `build/runtime.w`; missing the second one is 232 "unknown type c_void"
-  errors at `<embedded-std>/std/zl/…`);
-- a generated bundle root over the 18 modules in `lib/std/zl/` (16 corpus
-  + `example.w`/`minigzip.w` harness), written by
-  `build/zlib.w zlib_bundle_root_text` the way `build/pcre2.w` writes
-  `lib/std/re/bundle.w`, and checked by `zlib-bundle-root-check`;
-- the migrator's prelude-free vocabulary (`type c_void = opaque`, the
-  `__ci_unreachable` shim) is keyed on the migrate workspace's
-  `prelude_mode: None` / `with migrate --no-prelude`
-  (`ci_migrate_output_is_prelude_free`), no longer on the corpus name
-  `std.re`; `build/zlib.w` and `build/pcre2.w` set it on every migrate
-  workspace. The zlib corpus is re-migrated with that compiler
-  (`WITH=<stage1> <stage1> build :zlib-promote`);
-- `std.zlib` and the consumers that recompile in-unit today (`std.build`,
-  `build/zlib_gzip.w`, `build/zlib_gunzip.w`) link the bundle instead
-  (measured above).
+**Measured** (interleaved A/B, `WITH_PROFILE=1`, release compilers wo-c4 vs
+zlib-wo, 3 rounds): a program importing `std.zlib` spends ~800 ms in compiler
+phases with the corpus in-unit vs ~160 ms with the bundle (imports 48→1.3 ms,
+comptime 75→11 ms, mir.lower 30→4 ms, llvm gen/opt/emit 570→115 ms; link
+unchanged). The compiler's own build is unchanged (it never reaches zlib).
 
-Landing order: #1101 (C4) merges first; then open the zlib PR onto
-main (the branch already contains C4, so its diff against main is only
-the zlib commits once C4 is in), merge, sync local main, reseed
-(`:update-seed` + `:install-user`), close #1102 when the migrator fix
-lands. Fast consumer test without a release build:
-`out/bootstrap/bin/with-stage1 build X.w --link-bundle out/wo/zlib
---link-bundle out/wo/pcre2`.
+`docs/wo_bundles.md` on zlib-wo has the full mechanism (naming rule, variadics,
+carried copies, the `compiler-src-sha` key). Design docs: `docs/wo_bundles.md`,
+`docs/abi_roadmap.md` (Level 0), `docs/with-abi.md`, `docs/decisions.md` D38/D39,
+`docs/stdlib_sourcing_plan.md`.
 
-## 4. The corpora plan (`docs/stdlib_sourcing_plan.md`)
+---
 
-Three corpora + one surgical port, each migrated **whole** through pcre2's
-pipeline and arriving as a `.wo`, with native facades choosing engines by
-benchmark (D37): **c-algorithms** (fragglet: RB/AVL, heap, sorted array,
-trie, hash table, list), **TommyDS** (hardened hashing/indexing), **STC**
-(modern breadth: vec/deque/pqueue/hmap/smap/cstr/cbits...), and **M*LIB**
-`m-bptree.h` only. Written natively, not migrated: graph algorithms,
-union-find, SlotMap's free list, and Vec/str.
+## 4. Battery / reseed discipline (do not skip)
 
-- **Phase 0 — measure first** (can start in parallel, docs-only until the
-  lane): `docs/stdlib_inventory.md` (every structure/algorithm needed, its
-  complexity contract, status — **not started**), the complexity-fixture
-  lane (**not started**), and SlotMap's native free list (#936, open;
-  Miguel is building SlotMap — keep it single-owner, no built-in locking;
-  see the D22/D27 notes). Gate: lane green with known cliffs recorded.
-- **Phase 1** c-algorithms whole (non-macro C; the `void*` + callback
-  idiom). **Phase 2** TommyDS. **Phase 3** STC (the macro-migrator
-  campaign). **Phase 4** M*LIB bptree, surgical.
+- Battery (batch tier): `with build` → `:fixpoint` → `:test` (includes
+  `:seed-compat`) → `:test-green` → `:last-green`; add `:move-audit`/`:drop-audit`
+  for ownership/codegen/ABI changes (#1104 needs them). Reseed once after
+  (`:update-seed` + `:install-user`). Commit BEFORE the battery, never during it
+  (even docs) or `install-user`'s gate trips.
+- An ABI change (#1104) must be ALONE in its batch. It changes
+  `docs/with-abi.sha256` inputs (TypeLayout.w) → re-record and expect
+  `abi-hash-check` to trip until you do.
+- The perf gate is a RELATIVE ratio measured LOCALLY by interleaved A/B on
+  Eric's laptop (~10x CI), never on CI, never by waiting for an idle box.
+- Run long work detached with a keep_awake hold (Eric's box is a traveling
+  laptop; runs die ~10 min after turn activity stops). Verify via logs.
+- The macOS in-place-overwrite SIGKILL class (2026-09-03 install incident):
+  `:install-user` renames via a temp sibling, not an in-place copy.
 
-**Open questions still Eric's** (plan §"Open questions"): #2 whether every
-corpus builds in every battery (a `corpora` lane); #3 whether Phase 0's
-inventory rules on names now (`Heap` vs `PriorityQueue`, the `BitSet` API)
-or leaves that to each facade PR. #1 was ruled as D37.
+---
 
-## 5. Related, done, don't redo
-- Publish-first release (`build/release_publish.w`, per-job publish in
-  `nightly-release.yml`), proven on CI (create-first and add-later).
-- D40 accepted and applied (v0.15.1.10 renumbered to v0.15.2.0; the
-  transient v0.15.1.9/.11/.12/.13 tags deleted).
-- Rob's #997/#1016/#1029/#1035 landed by cherry-pick (a c_import regression
-  #997 exposed — glibc's `NAN`/`INFINITY`/`HUGE_VALF` emitted as
-  self-referential globals — was caught by the battery and fixed, `1f826ac4`).
-- `with_str_from_cstr` copies (the #1081 root cause), Windows runtime fixes.
+## 5. Recommended order for the next agent
 
-## 6. Traps that cost days this week — read before your first battery
-- **Never commit during a battery.** `last-green`'s version stamp tracks
-  HEAD; a commit mid-battery leaves a stale test-pass marker and a red
-  `last-green`. Commit first, then battery, then reseed.
-- **Drive post-build steps with the FRESH compiler** (`./out/release/bin/with`),
-  as CI does. Driver-side rules (cache freshness, the RSS tripwire) live in
-  the compiler; the installed seed lacks them until reseed.
-- **`:seed-compat` is a fresh-compiler check, not a seed-driven `:test`
-  dep.** The pinned seed's 1 GiB RSS tripwire is flaky on its ~1 GiB nested
-  build; that is why it left `:test`. Run it as its own fresh-driver step.
-- **Build-layer API is seed-gated.** `build.w`/`build/*.w`/`lib/std/build.w`
-  are comptime-evaluated by the *pinned seed*; a new `std.build` API or
-  `Target` field used there needs a published seed that has it. Driver-side
-  rules keyed by target name take effect in-batch; a real API addition is a
-  seed-release cycle (land unused → publish seed → bump lock → use).
-- **A seed experiment must set `WITH=<seed>`.** The driver binary is not the
-  seed; unset `WITH` silently uses the installed compiler.
-- **Never revert language surface to appease an old seed** (build-layer
-  `s[i]` included). Cut a newer seed (D40 tells you the number).
-- **No Python/bash/perl/sed/awk for text work; With one-liners and With
-  tools.** Edit tool for edits. Never `git stash`.
-- **Verify by running.** A grep, dump or trace print is a hypothesis; the
-  root cause is the exact line, proven in lldb or the debug allocator.
-- **Isolation:** an ownership/drop/codegen/ABI change is alone in its batch
-  with `:move-audit` and `:drop-audit`. C4 qualifies.
+1. **Reproduce and fix the macOS embedded-bundle bug (section 1)** — it blocks
+   BOTH #1101 and #1103, is not fixed by anything on the branches, and is the
+   real gate. Start with the abi-sha-mismatch / empty-embed candidates; get a
+   reproduction (CI artifact upload of the runner's stage2 + out/gen + out/wo,
+   or a clean from-scratch build on this Mac). Use the deep-compiler tools once
+   reproduced. Land the fix so C4's macOS lane goes green; then #1101 can merge.
+2. **#1102** (one-guard migrator fix) — its own small batch.
+3. **#1104** (va_list) rebased on #1102 — re-promote both corpora, re-record
+   abi-hash, full battery + audits. Verify #1103's `linux x86_64`
+   `zlib-wo-drift` no longer exits 139.
+4. **#1103** rebased on the merged main — should then be green on all five.
 
-## 7. Worktrees and files
-- `~/.local/with-staging/c4r` (wo-c4 rebased, landing), `c4p` (measuring),
-  `c4` (older detached), `relpub` (rob-lanes, landed — can be removed),
-  `uncast` (wo-hash, landed — can be removed).
-- `build/pcre2.w`, `build/wo.w`, `lib/std/re/bundle.w` — the pcre2 pipeline
-  to mirror for zlib. `build/release_publish.w`, `build/seed.w`,
-  `tools/bump_seed_pins.w` — the release/seed machinery.
-- Issues: #955 (C4/emit-C), #936 (SlotMap free list, Phase 0), #1076/#1077
-  (filed by the C4 agent: silent in-unit corpus fallback; store install dir
-  `$HOME` literal).
+All the detail above (commits, file:line, IR evidence, reproduction notes) is
+mirrored in the session memory notes `wo-bundles-state`, `va-list-per-target-1104`,
+`bundled-corpus-two-exclusions`, `test-runner-only-failures`, `zsh-no-word-split`.

--- a/docs/perl-compatible-re.md
+++ b/docs/perl-compatible-re.md
@@ -1,0 +1,803 @@
+# Perl-Compatible Regular Expression Conformance Specification
+
+Status: proposed
+
+## 1. Goal
+
+With regular expressions SHALL provide the closest practical compatibility with Perl 5 regular expressions that the bundled PCRE2 engine permits.
+
+The governing rule is:
+
+> **Perl defines the target semantics. PCRE2 provides the matching engine. With must bridge every difference that can reasonably be bridged above PCRE2.**
+
+A behavior is not allowed to differ merely because the initial With regex implementation happened to expose PCRE2 differently.
+
+A difference is acceptable only when all of the following are true:
+
+1. Perl and PCRE2 genuinely differ for the behavior.
+2. The difference cannot be faithfully repaired by With's lexer, parser, compile-time pattern preprocessing, wrapper API, capture/state machinery, or match/substitution driver.
+3. Repair would require replacing or materially modifying the PCRE2 matching engine, or implementing a broader Perl runtime feature that With intentionally does not possess.
+4. The divergence is recorded in the versioned PCRE2 compatibility manifest and covered by a test demonstrating the difference.
+
+There are therefore no undocumented regex incompatibilities.
+
+If a Perl-compatible behavior can be implemented on top of PCRE2, With SHALL implement it.
+
+## 2. Versioned compatibility target
+
+The compatibility suite SHALL pin two versions:
+
+* the bundled PCRE2 version;
+* the Perl version used as the differential oracle.
+
+At the time of this proposal, With carries PCRE2 10.47.
+
+The initial Perl oracle SHOULD be Perl 5.44.
+
+An upgrade of either PCRE2 or the Perl oracle SHALL rerun the entire differential regex suite.
+
+The repository SHALL contain a generated or maintained compatibility manifest recording every accepted divergence:
+
+`docs/regex_pcre2_differences.md`
+
+Each entry SHALL identify:
+
+* Perl version;
+* PCRE2 version;
+* minimal pattern;
+* minimal subject;
+* Perl result;
+* PCRE2 result;
+* With result;
+* PCRE2 compatibility issue involved;
+* whether With bridges the difference;
+* if not bridged, why faithful emulation cannot reasonably be implemented above PCRE2.
+
+“PCRE2 is Perl-compatible” is not sufficient justification for an untested behavior.
+
+## 3. Compatibility layers
+
+Regex compatibility consists of four separate layers.
+
+### 3.1 Pattern-language compatibility
+
+The pattern between the delimiters SHALL accept every Perl pattern construct that PCRE2 accepts and SHALL preserve Perl semantics wherever PCRE2 does.
+
+This includes, among other things:
+
+* character classes;
+* quantifiers;
+* alternation;
+* capturing and non-capturing groups;
+* named captures;
+* numbered and named backreferences;
+* lookahead;
+* lookbehind;
+* variable-length lookbehind to the extent supported by the bundled PCRE2;
+* atomic groups;
+* possessive quantifiers;
+* branch-reset groups;
+* conditional patterns;
+* recursion;
+* subroutine calls;
+* backtracking-control verbs;
+* `\K`;
+* `\R`;
+* `\X`;
+* Unicode properties supported by PCRE2;
+* extended mode;
+* PCRE2's Perl-compatible special groups.
+
+With SHALL NOT maintain an arbitrary hand-written whitelist of pattern constructs.
+
+The pattern is passed through to PCRE2 unless With deliberately preprocesses it to reproduce Perl semantics that raw PCRE2 does not reproduce.
+
+### 3.2 Regex-literal and operator compatibility
+
+Perl's regex usability does not come only from its engine. It also comes from the syntax surrounding the pattern.
+
+With SHALL treat this operator surface as part of regex compatibility rather than dismissing it as “Perl syntax.”
+
+### 3.3 Match-state and capture compatibility
+
+Captures, global-match position, failed-match behavior, zero-width matches, and named-capture behavior are part of the observable regex semantics.
+
+They SHALL be tested independently of raw PCRE2 pattern matching.
+
+### 3.4 Text-operation compatibility
+
+Substitution, regex splitting, and transliteration are part of the practical Perl regex/text-processing surface.
+
+They SHALL be included in the parity campaign even where PCRE2 itself does not implement the operation.
+
+---
+
+# 4. Existing With behavior that remains valid
+
+The following existing With features are retained:
+
+```with
+let re = /foo+/i
+
+if text =~ /(\w+)=(\w+)/:
+    print($1)
+    print($2)
+
+if text !~ /^\s*#/:
+    process(text)
+
+/foo/g.find_all(text)
+
+/(foo)(bar)/.replace(text, "$2$1")
+```
+
+Regex literals remain first-class `Regex` values.
+
+`=~` and `!~` remain operators.
+
+Regex literals remain compiler-validated.
+
+The high-level `Regex` API remains available even when shorter Perl-style surface syntax is added.
+
+PCRE2 extensions MAY remain accessible. Supporting a PCRE2 extension that Perl lacks is not an incompatibility provided it does not change the semantics of valid Perl-compatible patterns.
+
+---
+
+# 5. Current gaps in With
+
+The current implementation has the following With-level compatibility gaps.
+
+| Area                                 | Current With                                         | Required target                                                                             |
+| ------------------------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Pattern engine                       | PCRE2                                                | Keep PCRE2                                                                                  |
+| Basic literal                        | `/pattern/flags`                                     | Keep                                                                                        |
+| Pattern syntax                       | PCRE2 syntax                                         | Full bundled-PCRE2 Perl-compatible surface                                                  |
+| Match operator                       | `=~`, `!~`                                           | Keep                                                                                        |
+| Alternate match delimiters           | missing                                              | support Perl-equivalent `m//`, `m{}`, `m!!`, etc. where grammar permits                     |
+| First-class quoted regex             | ordinary `/.../` already yields `Regex`              | functional parity already exists; `qr//` MAY be added as compatibility spelling             |
+| Pattern interpolation                | missing/incomplete                                   | implement Perl-equivalent regex interpolation                                               |
+| `\Q...\E` interpolation behavior     | raw PCRE2 behavior                                   | bridge Perl behavior in With frontend where possible                                        |
+| Literal flags                        | `i m s x g u U`                                      | expose all feasible Perl modifiers                                                          |
+| `/xx`                                | missing                                              | implement                                                                                   |
+| `/n`                                 | missing                                              | implement no-auto-capture                                                                   |
+| `/a`, `/aa`                          | missing                                              | map to closest PCRE2 ASCII restrictions                                                     |
+| `/d`                                 | missing                                              | emulate if possible; otherwise registered PCRE2 limitation                                  |
+| `/l`                                 | missing                                              | support if PCRE2 locale facilities can reproduce semantics; otherwise registered limitation |
+| `/p`                                 | missing                                              | implement pre/match/post capture state                                                      |
+| `/g`                                 | exists                                               | correct Perl global-state semantics                                                         |
+| `/c`                                 | missing                                              | implement                                                                                   |
+| `/o`                                 | missing                                              | implement for interpolated/dynamic patterns                                                 |
+| Captures                             | `$0`, `$1`, `$name` in narrow controlled scopes      | Perl-equivalent last-successful-match behavior                                              |
+| Captures from dynamic `Regex` values | no magic capture bindings                            | support                                                                                     |
+| Captures through compound conditions | deliberately unavailable                             | support where control flow establishes a successful match                                   |
+| Unmatched optional capture           | currently flattened toward empty text in magic paths | preserve unset versus empty distinction                                                     |
+| Special match variables              | mostly missing                                       | provide Perl-equivalent information                                                         |
+| Global position                      | stored on `Regex` object                             | match Perl target-match-position semantics as closely as With's value model permits         |
+| Empty global matches                 | manually advance one byte                            | use Perl/PCRE2 next-match rules                                                             |
+| Substitution syntax                  | method calls                                         | add concise `s///`-class surface                                                            |
+| Non-destructive substitution         | method API                                           | support `/r` semantics                                                                      |
+| Expression replacement               | callback API                                         | support concise `/e` equivalent                                                             |
+| Transliteration                      | missing                                              | add `tr///` / `y///`-equivalent operation                                                   |
+| Regex split                          | basic `Regex.split`                                  | match Perl split semantics                                                                  |
+| Empty-pattern reuse                  | missing                                              | implement where syntax permits                                                              |
+| Match offsets                        | available through `Match`                            | expose Perl-equivalent last-match offset information                                        |
+| Named duplicate captures             | wrapper currently resolves one numeric group         | reproduce Perl behavior to PCRE2's limit                                                    |
+
+---
+
+# 6. Pattern interpolation and quoting
+
+Perl regexes are quote-like operators, not raw PCRE2 pattern strings.
+
+With SHALL support interpolation in regex forms intended to correspond to Perl's interpolating forms.
+
+Conceptually:
+
+```with
+let word = "cat"
+text =~ /the $word/
+```
+
+SHALL construct the same logical pattern that the corresponding Perl expression constructs.
+
+Literal interpolation SHALL preserve regex semantics: interpolated regex values remain regex fragments where Perl treats them as such, while quoted text uses the equivalent of Perl's quoting behavior.
+
+`\Q...\E` requires special handling.
+
+PCRE2 itself treats `$` and `@` literally inside `\Q...\E` because PCRE2 has no language variables. Perl performs interpolation before the regex engine sees the result.
+
+Therefore this difference SHALL be bridged by the With frontend rather than accepted as an engine limitation whenever With interpolation is involved.
+
+Similarly, Perl pattern-level case-conversion escapes and named-character escapes that are processed before or outside the matching engine SHOULD be implemented by With preprocessing when an equivalent PCRE2 pattern can be produced.
+
+The rule is:
+
+> A feature does not become “unsupported by PCRE2” merely because Perl performs it before invoking its regex engine.
+
+If With can transform it into an equivalent PCRE2 pattern, it SHALL do so.
+
+---
+
+# 7. Delimiters and quote-like forms
+
+With's existing `/pattern/` literal remains the preferred ordinary syntax.
+
+For one-liner and Perl compatibility, With SHOULD additionally support alternate delimiters for cases where `/` occurs frequently inside the pattern.
+
+Required compatibility forms include the semantic equivalents of:
+
+```perl
+m/foo/
+m{foo/bar}
+m!foo/bar!
+qr/foo/
+s/foo/bar/
+s{foo/bar}{baz}
+tr/a-z/A-Z/
+y/a-z/A-Z/
+```
+
+Paired delimiters SHALL nest where Perl's corresponding quote-like syntax nests.
+
+Supporting `m{...}` is particularly important for URLs, paths, and HTML patterns because requiring slash escaping introduces unnecessary one-liner verbosity.
+
+`qr//` does not need a separate runtime type: With regex literals are already first-class `Regex` values. It is compatibility syntax over the same type.
+
+---
+
+# 8. Modifiers
+
+## 8.1 Pattern modifiers
+
+With SHALL expose Perl-equivalent behavior for every modifier that can be expressed using the bundled PCRE2 plus frontend logic.
+
+At minimum:
+
+```text
+i   case insensitive
+m   multiline anchors
+s   dot matches newline
+x   extended mode
+xx  stronger extended character-class mode
+n   non-capturing by default
+u   Unicode semantics
+a   ASCII restrictions
+aa  stronger ASCII restrictions
+p   retain pre-match/match/post-match information
+```
+
+`d` and `l` require explicit compatibility investigation against PCRE2.
+
+PCRE2 documents that it cannot exactly reproduce Perl's context-dependent `/d` character-set behavior. If no faithful wrapper implementation is possible, `/d` SHALL be entered in the compatibility manifest as an engine-bound divergence.
+
+`/a` and `/aa` SHALL use the closest PCRE2 ASCII-restriction options available and SHALL be differential-tested against Perl.
+
+`/l` SHALL use PCRE2 locale facilities if they provide equivalent behavior. Any remaining difference SHALL be explicitly documented and tested.
+
+With's existing uppercase `/U` may remain as a PCRE2 extension, but SHALL be documented as a With/PCRE2 extension rather than a Perl modifier.
+
+## 8.2 Match-operation modifiers
+
+The match operation SHALL support equivalents of Perl's:
+
+```text
+g   global / successive matching
+c   retain global position after failed match
+o   compile interpolated pattern once
+```
+
+These are operation semantics, not PCRE2 compile flags.
+
+## 8.3 Substitution modifiers
+
+Substitution SHALL additionally support:
+
+```text
+g   replace globally
+r   return modified value without mutating source
+e   evaluate a statically compiled With expression for replacement
+```
+
+A Perl-style `/ee` depends on runtime evaluation of generated source code. Unless With gains a general runtime source-evaluation facility, `/ee` SHALL be recorded separately as a broader dynamic-language capability gap rather than falsely attributed to PCRE2.
+
+---
+
+# 9. Capture semantics
+
+The current direct-condition-only capture rule is not the target.
+
+With SHALL maintain last-successful-match information with semantics as close to Perl as its static type system permits.
+
+A successful match SHALL update match state.
+
+A failed match SHALL behave like Perl with respect to existing match state.
+
+Captures SHALL work for:
+
+```with
+text =~ /(...)/
+text =~ regex_value
+
+if text =~ /(...)/:
+    ...
+
+while text =~ /(...)/g:
+    ...
+
+let ok = text =~ /(...)/
+
+let ok = ready and text =~ /(...)/
+```
+
+The compiler SHALL NOT make captures unavailable merely because the regex expression was stored in a variable or appeared inside a compound boolean expression.
+
+Control-flow analysis may restrict a capture use when success has not been established, but that is a safety/dataflow question, not a regex-language restriction.
+
+## 9.1 Capture participation
+
+Perl distinguishes:
+
+* a capture that participated and captured `""`;
+* a capture that did not participate.
+
+With SHALL preserve that distinction internally and expose a way to test it.
+
+Flattening both states to `""` is not Perl-compatible.
+
+The implementation may use an ephemeral compiler-known capture value, `Option[str]`, or another representation, but observable behavior MUST retain the distinction.
+
+## 9.2 Numbered and named captures
+
+The normal Perl-compatible forms SHALL be available:
+
+```text
+$1
+$2
+...
+$name
+```
+
+The full match SHALL be available.
+
+Named captures with duplicate names SHALL follow Perl behavior to the extent PCRE2 can represent the pattern.
+
+Where PCRE2 cannot represent Perl's duplicate-number/name topology, that exact case belongs in the engine compatibility manifest.
+
+## 9.3 Additional last-match information
+
+With SHALL expose equivalent information for Perl's useful regex match state, including:
+
+* whole match;
+* pre-match text;
+* post-match text;
+* highest participating capture;
+* capture start offsets;
+* capture end offsets;
+* named-capture lookup;
+* all captures sharing a name;
+* current global-match position.
+
+Exact punctuation-variable spelling is desirable for one-liner parity where it fits With's grammar, but semantic availability is normative.
+
+---
+
+# 10. Global matching
+
+`/g` is a semantic operation, not merely “find all.”
+
+Perl global matching maintains a current position associated with the matched target and successive matches continue from that position.
+
+With's current Regex-object-local cursor is not the normative model.
+
+The required behavior is Perl's observable behavior:
+
+```text
+success with /g       advances match position
+subsequent /g         begins from current position
+failure               resets position unless /c is active
+/c                    preserves position on failure
+changing target       uses the target's appropriate match state
+```
+
+The exact internal mechanism MAY differ because With strings and places differ from Perl scalars.
+
+However, using two regex values on the same target MUST NOT produce observably incorrect behavior merely because With stored position in the regex object rather than the target match state.
+
+A `pos(...)`-equivalent operation SHALL be available if required to reproduce Perl programs.
+
+---
+
+# 11. Zero-length global matches
+
+Zero-length matching is a mandatory compatibility case.
+
+With SHALL NOT implement global iteration by simply advancing one byte whenever a match has zero length.
+
+That algorithm is incorrect for both Perl compatibility and UTF-8 safety.
+
+The bundled PCRE2's recommended next-match behavior SHALL be used, including the retry rules required after an empty match.
+
+PCRE2 10.47 provides `pcre2_next_match`; the wrapper SHOULD use it or implement its exact algorithm.
+
+This rule applies to:
+
+* `=~ /.../g`;
+* `find_all`;
+* `captures_all`;
+* callback global replacement;
+* regex splitting;
+* any future regex iterator.
+
+Every one of these APIs SHALL share one tested next-match helper rather than independently reimplement empty-match advancement.
+
+---
+
+# 12. Substitution
+
+With SHALL provide a concise substitution surface equivalent in power to Perl `s///`.
+
+The current method APIs remain available:
+
+```with
+re.replace(text, replacement)
+re.replace_all(text, replacement)
+re.replace_fn(text, callback)
+re.replace_all_fn(text, callback)
+```
+
+but they are not sufficient for Perl one-liner parity.
+
+A concise syntax SHALL support:
+
+```text
+pattern
+replacement
+global replacement
+capture interpolation
+mutation of a target place
+non-destructive replacement
+computed replacement
+alternate delimiters
+```
+
+The Perl behavioral model is the target.
+
+A destructive substitution returns the substitution count/condition information required to reproduce Perl control flow.
+
+A non-destructive `/r` form returns the new string and leaves the source untouched.
+
+Replacement interpolation SHALL support numbered and named captures.
+
+Computed replacement SHALL make capture values available directly to the replacement expression.
+
+Conceptually:
+
+```with
+text =~ s/foo/bar/g
+let y = text =~ s/foo/bar/r
+text =~ s/(\d+)/$1 + 1/eg
+```
+
+Exact parser details may be adapted to avoid ambiguity with existing With syntax, but the resulting one-liner SHALL not require expansion into `replace_all_fn` boilerplate.
+
+---
+
+# 13. Transliteration
+
+Perl `tr///` / `y///` is not a regular-expression engine operation, but it is part of Perl's compact text-processing surface and is required for one-liner parity.
+
+With SHALL provide equivalent transliteration functionality, including equivalents of Perl's applicable transliteration modifiers:
+
+```text
+c   complement search set
+d   delete characters with no replacement
+s   squash repeated translated output
+r   return transformed value without mutating source
+```
+
+The implementation SHALL handle character ranges and Unicode according to the compatibility profile.
+
+ROT13 and case inversion SHALL not require regex callbacks or manually constructed character maps when they can be expressed as transliteration.
+
+---
+
+# 14. Regex split
+
+`Regex.split` SHALL be audited against Perl `split`.
+
+Current “split wherever the regex matches” behavior is insufficient as a conformance definition.
+
+Compatibility tests SHALL cover:
+
+* positive and zero limits;
+* negative limits if exposed;
+* leading empty field behavior;
+* trailing empty field removal;
+* zero-width separators;
+* separators containing capture groups;
+* captured separators appearing in output where Perl does so;
+* empty patterns;
+* Unicode patterns;
+* empty input;
+* separators at the start and end of input.
+
+Where Perl's special `split " "` whitespace behavior is not intrinsically regex behavior, With SHALL nevertheless provide an equally concise `fields()`/split facility for one-liner parity.
+
+---
+
+# 15. Dynamic regular expressions
+
+A runtime-created `Regex` SHALL not lose regex capabilities merely because it is not a literal.
+
+At minimum, dynamic regex values SHALL support:
+
+* matching;
+* captures;
+* named captures;
+* global matching;
+* substitution;
+* splitting;
+* match-position behavior.
+
+Magic capture syntax may require compiler/dataflow support, but dynamic regex values MUST expose equivalent capture information.
+
+Perl-style interpolated regexes SHALL compile at the same logical point Perl would compile them, subject to `/o` semantics.
+
+---
+
+# 16. PCRE2 compatibility differences
+
+PCRE2's compatibility document SHALL be treated as an input to With's implementation plan, not as a blanket waiver.
+
+Each known difference receives one of three dispositions:
+
+```text
+BRIDGED
+    With compensates above PCRE2 and matches Perl.
+
+ENGINE_LIMITATION
+    Exact Perl behavior cannot reasonably be reproduced above PCRE2.
+
+PCRE2_EXTENSION
+    PCRE2 supports additional behavior; With may expose it without
+    changing valid Perl behavior.
+```
+
+The current known classes include:
+
+| PCRE2 difference                                                | With disposition                                                             |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `.` behavior under non-LF newline conventions                   | configure Perl-compatible newline behavior by default; bridge                |
+| smaller/different Unicode-property universe                     | engine/version limitation; upgrade PCRE2/UCD when possible                   |
+| quantifiers Perl treats as literals/warnings where PCRE2 errors | frontend compatibility parsing where feasible                                |
+| captures inside negative assertions                             | engine limitation unless wrapper can reconstruct Perl result                 |
+| Perl `\F \l \L \u \U` preprocessing                             | frontend bridge                                                              |
+| Perl `\N{character name}` where PCRE2 lacks it                  | frontend Unicode-name bridge                                                 |
+| `\Q...\E` interpolation differences                             | frontend bridge                                                              |
+| `(?{ code })`                                                   | engine/language limitation unless exact callout mapping is proven            |
+| `(??{ code })`                                                  | engine/language limitation unless exact dynamic-subpattern mapping is proven |
+| control verbs inside called subpatterns                         | engine limitation                                                            |
+| repeated-capture final-state differences                        | engine limitation unless reconstructible                                     |
+| some duplicate name/number arrangements                         | engine limitation unless frontend rewriting can preserve semantics           |
+| warning versus compile-error differences                        | frontend bridge where practical                                              |
+| `\K` lookaround behavior                                        | configure PCRE2's Perl-compatible default                                    |
+| PCRE2-only pattern options/extensions                           | permitted extension                                                          |
+| pattern/match resource limits                                   | engine limitation; configure generous documented defaults                    |
+| Perl `/d` character-set semantics                               | likely engine limitation; verify                                             |
+| Perl `/a`/`/aa`                                                 | bridge using closest PCRE2 ASCII controls and differential tests             |
+| recursive-pattern cases where PCRE2 accepts more than Perl      | PCRE2 extension; valid Perl behavior must remain unchanged                   |
+| malformed `\x` warning/recovery differences                     | frontend bridge where feasible                                               |
+
+No row becomes permanently accepted merely because it is listed here.
+
+If a later PCRE2 release closes a difference, the corresponding With exception SHALL be removed.
+
+---
+
+# 17. PCRE2 extensions
+
+With MAY expose useful PCRE2 features not present in Perl.
+
+Examples include PCRE2-specific verbs, partial matching APIs, match limits, and other engine facilities.
+
+Extensions SHALL obey three rules:
+
+1. they must not change the default semantics of a valid Perl-compatible pattern;
+2. they must be clearly documented as PCRE2/With extensions;
+3. they do not count toward Perl parity coverage.
+
+With's existing `/U` ungreedy modifier is such an extension.
+
+The default compatibility profile remains Perl-oriented.
+
+---
+
+# 18. Unicode and character semantics
+
+The bundled PCRE2 SHALL be built with Unicode support.
+
+With SHALL expose the closest Perl-compatible UTF/UCP behavior available from that PCRE2 release.
+
+The compatibility suite SHALL include:
+
+* Unicode general categories;
+* scripts;
+* script extensions where available;
+* `\X`;
+* Unicode word boundaries;
+* case-insensitive Unicode matching;
+* non-ASCII case folding;
+* combining marks;
+* supplementary-plane code points;
+* malformed UTF behavior where With permits malformed byte strings.
+
+The PCRE2 Unicode version SHALL be reported by the toolchain and recorded in conformance output.
+
+When Perl and PCRE2 use different Unicode data versions, a mismatch attributable solely to the Unicode database is an engine-version divergence, not a With frontend bug.
+
+---
+
+# 19. Diagnostics
+
+For valid Perl-compatible syntax supported by PCRE2, With MUST NOT reject the pattern because of an independent With parser restriction.
+
+For invalid patterns, diagnostics SHOULD identify:
+
+* pattern;
+* offset;
+* PCRE2 error;
+* With preprocessing phase when applicable.
+
+When Perl accepts a construct that raw PCRE2 rejects but With has a compatibility rewrite, the user SHALL see the Perl-compatible behavior rather than the raw PCRE2 error.
+
+When the construct is an accepted engine limitation, the error SHOULD explicitly say that the construct is valid Perl but unsupported by the bundled PCRE2 compatibility profile.
+
+---
+
+# 20. Differential conformance suite
+
+Regex compatibility SHALL be tested against a real Perl executable.
+
+The suite has four lanes:
+
+### A. PCRE2 engine lane
+
+Run the bundled migrated PCRE2 against the upstream PCRE2 corpus.
+
+This verifies that migration has not changed PCRE2.
+
+### B. Shared Perl/PCRE2 pattern lane
+
+For patterns supported by both engines:
+
+```text
+pattern + modifiers + subject
+    → Perl result
+    → With result
+```
+
+Compare:
+
+* success/failure;
+* whole match;
+* every numbered capture;
+* participation/unset state;
+* named captures;
+* start/end offsets;
+* global-match sequence;
+* match position;
+* substitution result;
+* substitution count;
+* split result.
+
+### C. Known-divergence lane
+
+Every accepted PCRE2 limitation gets a pinned test proving:
+
+```text
+Perl result != PCRE2 result
+With result == chosen PCRE2-bound result
+```
+
+There SHALL be no uncategorized failures in this lane.
+
+### D. With-surface lane
+
+Test behavior PCRE2 does not provide itself:
+
+* interpolation;
+* alternate delimiters;
+* `m//`;
+* `qr//` if provided;
+* `s///`;
+* `/r`;
+* `/e`;
+* `tr///`;
+* capture-variable lifetime;
+* compound-condition captures;
+* dynamic-regex captures;
+* `/g`;
+* `/c`;
+* `/o`;
+* `pos`;
+* special match variables;
+* Perl-compatible split semantics.
+
+---
+
+# 21. Corpus strategy
+
+Do not invent a small compatibility suite by hand.
+
+Use, at minimum:
+
+* upstream PCRE2 tests;
+* PCRE2's Perl-comparison tests where available;
+* targeted cases from `pcre2compat`;
+* Perl's documented regex examples;
+* every regex appearing in the With one-liner corpus;
+* regression fixtures for every discovered mismatch.
+
+A differential test generator SHOULD make it easy to add:
+
+```text
+pattern
+flags
+subject
+expected divergence class
+```
+
+and execute the case through both Perl and With.
+
+---
+
+# 22. Acceptance criteria
+
+The regex campaign is complete when:
+
+1. Every pattern accepted by both the target Perl and bundled PCRE2 produces the same observable match behavior unless present in the explicit compatibility manifest.
+2. Every supported Perl regex modifier has equivalent With behavior.
+3. With adds no arbitrary capture-scope restriction.
+4. Dynamic and literal regexes expose the same matching power.
+5. `/g` and `/c` match Perl's state-machine behavior.
+6. Zero-length global matching is correct and UTF-safe.
+7. Substitution has concise Perl-equivalent power.
+8. Transliteration has concise Perl-equivalent power.
+9. Regex splitting passes a Perl differential suite.
+10. Every remaining divergence maps to a concrete PCRE2 limitation or a separately named broader With-language limitation.
+11. No difference is justified merely by saying “With is statically typed” or “the wrapper currently works this way.”
+12. `docs/regex_pcre2_differences.md` contains every accepted exception.
+13. The one-liner corpus can use the concise regex surface without working around wrapper verbosity.
+
+---
+
+# 23. Required immediate changes
+
+The first implementation campaign should address these in order:
+
+1. Replace the claim “everything Perl supports” with the precise conformance rule in this specification.
+2. Introduce the versioned Perl/PCRE2 differential harness.
+3. Centralize global-next-match logic and use PCRE2's correct empty-match algorithm.
+4. Fix `/g` state semantics and add `/c`.
+5. Remove the direct-literal-only capture restriction.
+6. Preserve unset versus empty captures.
+7. Add missing feasible pattern modifiers (`xx`, `n`, `p`, `a`/`aa`, etc.).
+8. Add pattern interpolation and Perl-compatible `\Q...\E` preprocessing.
+9. Add alternate-delimiter `m//`-style syntax.
+10. Add concise `s///` semantics, including `g`, `r`, and statically compiled `e`.
+11. Audit and correct `Regex.split`.
+12. Add `tr///`/`y///`-equivalent transliteration.
+13. Generate the initial PCRE2-difference manifest from the compatibility documentation plus differential tests.
+14. Re-run the complete With one-liner corpus and classify any remaining regex verbosity as a conformance defect rather than a generic one-liner inconvenience.
+
+---
+
+# 24. Governing principle
+
+The regex layer has one rule:
+
+> **If Perl does it and PCRE2 gives us enough information or machinery to reproduce it, With does it too.**
+
+PCRE2's genuine engine limitations are accepted, explicit, versioned exceptions.
+
+Everything else is ours to fix.

--- a/docs/plans/comptime-int-width.md
+++ b/docs/plans/comptime-int-width.md
@@ -1,0 +1,605 @@
+# comptime Integer Width — Implementation Plan (#943)
+
+## Authority and scope
+
+Execution plan for making comptime integer evaluation agree with runtime
+evaluation. Issue of record: #943.
+
+This plan fixes a **correctness** bug in `i64`/`u64` comptime arithmetic. It is
+not part of the i128/u128 campaign (#914), though it overlaps it: #914's D4
+describes the same evaluator and mis-characterizes it. See "Relationship to
+\#914" below.
+
+Verified by reading `main` at `22e534c6`. Runtime measurements were taken with
+the released `v0.15.1.7` binary (`04ca1a74`); `src/Overflow.w` and
+`src/ComptimeValue.w` are byte-identical between the two revisions, and the
+five `src/ComptimeEval.w` hunks that differ are all #679 decl-index caching,
+touching neither `:6742` nor `:7862`.
+
+---
+
+## The governing rule
+
+The semantic model this plan implements, stated once so every stage can be
+checked against it:
+
+> For any expression comptime evaluates, it must produce the value the runtime
+> would produce and detect exactly the same overflow conditions. Where comptime
+> cannot faithfully reproduce runtime behavior, it must **refuse to evaluate** —
+> never approximate.
+
+**Same, or refuse. Never different.**
+
+This is not a style preference. A `comptime fn` is callable at runtime:
+
+```with
+comptime fn f(x: i64) -> i64: x + 1
+const C: i64 = comptime f(3000000001)
+fn main:
+    let r = f(3000000001)
+    print(f"comptime = {C}")      // -1294967294
+    print(f"runtime  = {r}")      //  3000000002
+```
+
+One function, one argument, two answers. Agreement is a soundness requirement,
+not a nicety.
+
+Three corollaries, used as invariants below:
+
+1. **Sema is authoritative.** Every comptime integer value carries the sema type
+   of the expression that produced it. There is no default and no fallback. A
+   failed type lookup is an internal compiler error, not an `i32`.
+2. **Representation is canonical.** The payload always holds the value's
+   canonical form in its own type. `(type_id = i32, data0 = 3000000001)` must be
+   unrepresentable.
+3. **Arithmetic is the runtime arithmetic**, under the active overflow mode,
+   with checks applied to values *before* any width normalization.
+
+Truncation is a semantic operation the programmer asks for (`as`, `*%`, `+%`).
+It is never a repair applied to make an invalid internal state look valid. That
+distinction is the whole bug.
+
+---
+
+## Current state
+
+> **Historical.** This section and "Root cause" below record the defect as
+> found at `22e534c6`, before any fix. They are kept because the diagnosis is
+> what the stages were built against; for what is now true, see **Status** at
+> the end.
+
+| Behavior | State | Evidence |
+|---|---|---|
+| Plain const folding, within 64 bits | correct | `const A: i64 = 3000000001 + 0` returns `3000000001` |
+| Plain const folding, beyond 64 bits | **corrupt** | `const ADD: i128 = 18446744073709551616 + 1` folds to `1` — see "The 64-bit ceiling" below |
+| Runtime arithmetic | **correct** | measured |
+| `comptime` evaluator, values within `i32` | correct | measured |
+| `comptime` evaluator, values beyond `i32` | **corrupt** | four symptom classes below |
+| Overflow mode honored at comptime | yes | `sema.overflow_mode` is read; `h * 33 + 100` overflowing `u64` errors |
+| Refusal on unsupported operations | yes | `s.bytes()` reports "not comptime-evaluable yet" |
+
+The evaluator does integer arithmetic at **32 bits** regardless of declared type,
+suffix, annotation, or return type. `2147483647i64 + 1i64` raises
+`integer overflow in comptime`, which is itself proof of the width.
+
+### Four symptom classes
+
+```with
+3000000001i64 + 0i64        // -1294967295   signed, silent
+0i64 - 3000000000i64        //  1294967296   signed, silent
+4294967296u64 + 0u64        //  0            unsigned, silent — 2^32 becomes 0
+4294967301u64 * 1u64        //  5            unsigned, silent
+1i64 << 40                  //  0            shift, silent
+3000000001u64 + 0u64        //  error: integer literal does not fit expected type
+```
+
+The last is the one accidental guard: when the truncated value lands negative,
+the unsigned fit check catches it at materialization — with a message that
+blames a literal when no literal is at fault. Whether `u64` fails loudly or
+silently depends on which side of zero the corrupted value falls on.
+
+Note the shift case reaches the corruption through `eval_shift_value` rather
+than `int_signed_add`, confirming the width is wrong at the source rather than
+inside one arithmetic helper.
+
+### The 64-bit ceiling
+
+Separately from the 32-bit defect above, the evaluator cannot represent any
+value wider than 64 bits at all. The literal machinery is 128-bit exact; the
+evaluator discards the high word on entry.
+
+```with
+const LIT: i128 = 18446744073709551617          // 2^64 + 1, literal only
+const ADD: i128 = 18446744073709551616 + 1      // 2^64 + 1, via folding
+```
+```
+LIT >> 33 = 2147483648      // correct
+ADD >> 33 = 0               // ADD folded to 1
+```
+
+`ComptimeEval.w:7861` is the boundary:
+
+```with
+comptime_value_int(self.node_type_or(node, self.sema.ty_i64 as i32), exact.lo)
+```
+
+`exact.lo` only — `exact.hi` appears nowhere in the file. `2^64` arrives as its
+low word, `0`, so `ADD` is `0 + 1`. `9223372036854775807 + 1` in an `i128`
+context raises `integer overflow in comptime`, confirming the ceiling from the
+other side.
+
+That line is not sloppiness; it is forced. `data0: i64` has nowhere to put
+`exact.hi`. This is the concrete form of invariant 2 being unsatisfiable at
+128 bits, and the reason widening is structural rather than optional (see
+"Relationship to #914"). Still open: the 64-bit ceiling is unchanged by this
+campaign — the payload is still one `i64`.
+
+### Workaround for user code (superseded)
+
+`eval_cast` resolves the cast's target type expression itself rather than
+trusting sema, so **explicit `as i64` / `as u64` casts set the width reliably
+even pre-sema**. Verified against a runtime control:
+
+```with
+comptime fn casted -> u64:
+    var acc: u64 = 5381
+    var i = 0
+    while i < 8:
+        acc = (acc as u64) * (33 as u64) + (100 as u64)
+        i = i + 1
+    acc
+```
+```
+comptime = 7572279801686821
+runtime  = 7572279801686821      // identical
+```
+
+Without the casts the same loop raises `integer overflow in comptime` at the
+32-bit boundary. Note the asymmetry worth communicating to users: **`as u64`
+works, the `u64` literal suffix does not** — the evaluator never reads suffixes.
+
+**No longer needed.** S2 landed the suffix and annotation handling, so
+`5381u64` and `var acc: u64 = 5381` now carry their declared width without
+help. Kept as a record of the asymmetry that existed — casts worked because
+`eval_cast` resolved its own target type, which is what suggested reading the
+suffix in the same way.
+
+---
+
+## Root cause
+
+Three links. The first two are confirmed by reading; the mechanism behind link 1
+was inferred when this plan was first written and is now confirmed; see
+"Why the lookup misses".
+
+### L1 — the literal constructor guesses a type
+
+`src/ComptimeEval.w:7861-7862`:
+
+```with
+return comptime_control_value(comptime_value_int(self.node_type_or(node, self.sema.ty_i64 as i32), exact.lo))
+return comptime_control_value(comptime_value_int(self.node_type_or(node, self.sema.ty_i32 as i32), fast.value))
+```
+
+Two adjacent construction sites with two different defaults. A literal that fits
+`i64` takes the second and falls back to **`ty_i32`** when `node_type_or` finds
+no entry in `typed_expr_types`.
+
+The fallback cannot distinguish *"sema assigned i32"* — legitimate, and the
+documented default for small unsuffixed literals — from *"I failed to find what
+sema assigned"* — a compiler bug. Those require opposite responses. That the two
+lines disagree on their default is the tell that neither is principled.
+
+### L2 — the fallback propagates into arithmetic
+
+`src/ComptimeEval.w:6742`:
+
+```with
+let result_ty = self.node_type_or(node, if lhs.type_id != 0: lhs.type_id else: rhs.type_id)
+```
+
+`lhs.type_id` is now `i32`, so `comptime_int_width(result_ty)` returns 32 for
+every subsequent operation.
+
+### L3 — operands are truncated before the overflow check
+
+`src/Overflow.w:152-215`. All six helpers share the ordering:
+
+```with
+fn int_signed_add(lhs: i64, rhs: i64, width_raw: i32, mode: i32) -> IntArithmeticResult:
+    let width = int_width_clamp(width_raw)
+    let lv = int_truncate_to_width(lhs, width, false)   // 3000000001 -> -1294967295
+    let rv = int_truncate_to_width(rhs, width, false)
+    ...
+    let over_hi = rv > 0 and lv > max - rv               // rv == 0 -> false
+    if not over_hi and not over_lo:
+        return int_arith_ok(wrapped)                     // corrupted value, no diagnostic
+```
+
+The check asks whether the *operation* overflows, but the *operands* were
+already silently truncated. Adding `0`, subtracting `1`, or multiplying by `1`
+cannot overflow, so the corruption is never flagged. `int_signed_sub` `:171-172`,
+`int_signed_mul` `:203-204`, `int_unsigned_add` `:109-110`, `int_unsigned_sub`
+`:125-126`, `int_unsigned_mul` `:138-139` are identical in this respect.
+
+`OP_DIV` and `OP_MOD` escape because their arms in `ComptimeEval.w` compute on
+raw operands and consult the width only for `int_div_overflows`. That is luck,
+not design — `3000000000i64 / 1000000000i64` is correct today.
+
+**L3 is what makes the bug silent.** L1 alone would produce loud errors on any
+out-of-range literal. This ordering is only tempting because invariant 2 is not
+guaranteed, so the helper defensively normalizes inputs it cannot trust.
+
+### Why the lookup misses — confirmed
+
+**Comptime folding runs before sema.** `Frontend.w:1683-1688`:
+
+```with
+pre_sema.prepare_for_comptime_transform()
+...
+pool = pre_sema.comptime_transform_module(pool, self.pool)
+```
+
+`prepare_for_comptime_transform` (`Sema.w:6517`) does six things —
+`compute_method_origins`, `collect_declarations`, `build_ci_scoping`,
+`validate_copy_derives`, `validate_compiler_hooks`,
+`validate_generic_type_decls` — and **no `check_expr`**. So `typed_expr_types`
+is empty for function bodies while folding runs. Every fold entry point
+(`comptime_try_eval_expr` / `comptime_force_eval_expr`) is called from
+`ComptimeTransform.w` inside this pass; the only caller outside it is an
+`embed_file` path in `SemaCheck.w`.
+
+`typed_expr_types` is a partial `HashMap[i32, i32]` (`Sema.w:960`). It is not
+cleared by `prepare_comptime_eval_copy` (`Sema.w:1500`) — a stale-copy
+explanation is ruled out. The table is simply not populated yet.
+
+**Three things that should supply the width, and do not:**
+
+- **Literal suffixes are never consulted.** `literal_suffix` appears **zero**
+  times in `src/ComptimeEval.w`. `5381u64` evaluates as `i32`. Sema knows the
+  rule (`SemaCheck.w:6062`) but has not run. This is why an explicitly suffixed
+  `3000000001i64` still corrupts.
+- **Parameter types are not applied.** `eval_fn_symbol_call_values` binds
+  arguments raw; a declared `a: i64` never reaches the value.
+- **`let`/`var` annotations are ignored.** `eval_let_binding` reads `data1` and
+  binds without consulting the annotation.
+
+The only type seeding that exists is `ComptimeTransform.w:1105` (local `let`)
+and `:2992` (top-level `let`/`const`), which stamp a `const X: T = comptime …`
+annotation onto the outermost `NK_COMPTIME` node and its immediate child. That
+is why shallow cases pass while anything deeper does not, and why plain const
+folding is correct within 64 bits while the explicit `comptime (...)` form is
+not.
+
+**Cloned nodes can never be in the table.** `ct_clone_tree_with_subst`
+(`ComptimeTransform.w:590`) mints fresh node ids per unrolled `comptime for`
+iteration. Those ids are absent from `typed_expr_types` by construction, so any
+fix relying on the table alone must also cover them.
+
+**An existing band-aid confirms the class.** `apply_implicit_default_return`
+(`ComptimeEval.w:~1847`) masks the *returned* value to the declared return
+width, citing #767: "fold-order evaluation can compute an int body value in the
+operand's default representation … before the tail expr has its checked type
+record." That repairs the final value only — intermediates were already computed
+at the wrong width, and a panic-mode overflow has already aborted.
+
+> Source: `with-ui128/docs/comptime-int-width-bug.md`, diagnosed independently
+> at `5465144`. Every claim above re-verified against `22e534c6`. That doc's
+> predicted reproducer using `hash_str` does **not** fire — it dies earlier on
+> `str method 'bytes' is not comptime-evaluable yet` — so use an accumulator
+> loop over a range instead.
+
+---
+
+## Stages
+
+Ordering rationale: **S1 before S2.** S1 is local, low-risk, and converts silent
+corruption into loud errors — the worst symptom disappears first, and the
+guarantee it establishes stays valuable after S2 lands. S3 strictly after S2:
+turning a failed lookup into an ICE while lookups still miss would break every
+comptime evaluation in the compiler.
+
+### S0 — Pin current behavior (½ day)
+
+Land the differential oracle first. It is cheap and would have caught every
+symptom in this issue.
+
+**The oracle:** for any expression `E` of integer type `T` evaluable in all
+three paths, these must agree — **and agree with the value written out by
+hand**:
+
+```
+comptime E   ==   plain-const-fold E   ==   runtime E   ==   expected literal
+```
+
+The fourth term is not redundant, and the three paths are not equally
+trustworthy:
+
+- **Plain const folding is not independent** — it runs through the same
+  evaluator (see "Why the lookup misses"). It differs from the explicit
+  `comptime` form only in typing state, and inherits the same 64-bit ceiling:
+  `const ADD: i128 = 18446744073709551616 + 1` folds to `1`. Agreement between
+  the two const forms therefore proves very little on its own.
+- **Runtime is the independent term.** It is correct at 128 bits
+  (`let a: i128 = 2^64; a + 1` is exact), so it — not plain folding — is what
+  anchors the test.
+- **The expected literal** guards against all three drifting together and makes
+  a failure readable without re-deriving the arithmetic.
+
+Concretely: above 64 bits, plain folding already disagrees with runtime. That
+disagreement is a real finding, not test noise, and it belongs to #914's D4.
+
+Above 64 bits, `expected literal` cannot be checked by printing — D1 (#914)
+truncates every format path to 64 bits. Use the `>> n` layer discriminators from
+\#914's S0 (`(2^100 literal) >> 90 == 1024`) so the assertion lands on a value
+that renders correctly. This also keeps the two campaigns' 128-bit tests
+mutually intelligible.
+
+- `test/behavior/behav_comptime_int_width.w` — the agreement matrix across
+  `i8/i16/i32/i64` and `u8/u16/u32/u64`, with operands straddling each width
+  boundary, exercising `+ 0`, `- 0`, `* 1`, `<< 0`, `/ 1`.
+- `test/behavior/behav_comptime_overflow_modes.w` — the same under
+  `--overflow=panic|wrap|saturate`; comptime and runtime must make the same
+  decision, differing only in whether it surfaces as a compile error or a trap.
+- `test/compile_errors/comptime_int_width.w` — pins the current diagnostics so
+  later stages show a visible diff, including the misleading
+  "integer literal does not fit expected type" for the unsigned case.
+
+Mark expected-fail where the harness supports it.
+
+### S1 — L3: check before normalize (1 day)
+
+`src/Overflow.w`, all six arithmetic helpers.
+
+Replace *truncate-then-check* with *check-then-normalize*. An operand that does
+not fit `width` is not silently normalized; it is reported through the existing
+`IntArithmeticResult` channel so callers surface it as a diagnostic.
+
+- Add a fits-width predicate over the operand pair, evaluated before any
+  truncation.
+- On a non-fitting operand, return `int_arith_invalid()` (distinct from
+  `int_arith_overflow`, which means the *operation* overflowed) so callers can
+  emit an internal-error-grade diagnostic rather than a user-facing overflow.
+- Leave the arithmetic itself byte-identical for operands that do fit. **No
+  behavior change for any call site that already passes canonical operands.**
+
+That last point is the fixpoint-safety property and must be verified, not
+assumed: `Overflow.w` is reached by Sema, the comptime evaluator, and both
+codegens.
+
+**Acceptance:** every silent case in S0 becomes a diagnostic; no correct
+program changes behavior; full battery green.
+
+> After S1 the bug is loud but not fixed — `3000000001i64 + 0i64` errors instead
+> of returning a wrong number. That is a shippable intermediate state under the
+> governing rule, and an improvement on silent corruption. It is not the end
+> state.
+
+### S2 — L1/L2: seed the width the evaluator is missing (1–2 days)
+
+The mechanism is settled (see "Why the lookup misses — confirmed"), so this
+stage builds rather than investigates. Three increments, cheapest first; **S2a
+and S2b are compatible and can land together**, and each is independently
+shippable.
+
+**S2a — honor literal suffixes.** `ComptimeEval.w:7862`: consult
+`self.ast.literal_suffix(node)` → `self.sema.literal_suffix_type(...)` before
+falling back. Small, self-evidently correct, and it makes the documented user
+workaround behave as users expect. Does not help un-suffixed code.
+
+**S2b — apply declared types at binding sites.** Three edits:
+
+- `eval_fn_symbol_call_values` — coerce each argument to the declared parameter
+  type before `bind_value`, reusing the masking in `comptime_bit_result` that
+  `apply_implicit_default_return` already applies to returns.
+- `eval_let_binding` — resolve the annotation and retype the bound value.
+- Tail expressions — use the enclosing fn's return type as demand *before*
+  evaluating the body, not only as a post-hoc mask.
+
+Covers most real code. Watch that coercion **masks** rather than silently widens
+a value that legitimately overflowed a narrow declared type — that would trade
+this bug for a quieter one.
+
+**S2c — structural.** Populate `typed_expr_types` for comptime-reachable bodies
+during `prepare_for_comptime_transform` (`Sema.w:6517`) so folding sees checked
+types, and carry types across `ct_clone_tree_with_subst` for unrolled bodies.
+Fixes the whole class including generic comptime fns and `comptime for`.
+Supersedes S2a/S2b. Largest blast radius; needs care about ordering against
+declaration collection, and about sema/comptime re-entrancy.
+
+Land S2a+S2b first for the value, then decide whether S2c is worth its cost in
+this campaign or belongs to its own issue. **S2c is the only increment that
+closes the cloned-node case**, so without it `comptime for` bodies stay broken.
+
+**Acceptance:** the S0 oracle green for all eight integer types; the
+`comptime`/runtime divergence in the governing-rule example gone; for S2c, the
+unrolled-loop case green too.
+
+### S3 — Make the miss an internal error (½ day)
+
+Once S2 makes the fallback unreachable, a failed lookup becomes a loud internal
+compiler error rather than a silent `i32`. This is invariant 1, enforced.
+
+Do this **after** S2, not before — inverting the order turns every currently
+working comptime evaluation into an ICE. Note S2a/S2b alone do not make the
+lookup reliable for cloned nodes; gate this stage on S2c, or scope the ICE to
+node classes S2c covers.
+
+### S4 — Canonical representation (1 day)
+
+Enforce invariant 2 at the constructor. `comptime_value_int` (`ComptimeValue.w:86`)
+asserts the payload is canonical in `type_id`:
+
+```
+payload == extend(truncate(payload, w, signed), w, signed)
+```
+
+With S1 and S2 in place this assertion should never fire; it is the regression
+guard that keeps the class closed.
+
+Note `comptime_value_int` already writes `data1: 0` — the second word is
+allocated and unused, so the eventual 128-bit widening is a change to the
+constructor contract, not to the struct layout.
+
+### S5 — Fixpoint and full battery (½ day)
+
+`with build :fixpoint` — stage2 byte-identical to stage3. `Overflow.w` is shared
+across Sema and both codegens, so run fixpoint after S1 **alone**, before
+starting S2. Full battery per CONTRIBUTING's "Compiler Changes vs Library
+Changes".
+
+---
+
+## Relationship to #914
+
+#914's D4 describes this evaluator as "i64-only", silently narrowing for 128-bit
+values, and recommends refusing 128-bit operands with a diagnostic rather than
+widening `ComptimeValue`.
+
+Two corrections:
+
+1. The measured boundary is **32 bits**, not 64, and the corruption reaches
+   `i64`/`u64` code with no 128-bit involvement.
+2. A refusal keyed on the evaluator's own width would be keyed on `32` here, not
+   `128`, so it would not fire and these expressions would still be corrupted.
+
+The recommendation itself remains sound as a stopgap for #914's scope. But under
+invariant 2, a canonical 128-bit value cannot live in an `i64` payload, so
+widening is eventually **forced**, not optional. Worth a line in D4 so the
+refusal is not recorded as the intended end state.
+
+This plan should land first; #914's D4 then reduces to the widening alone.
+
+---
+
+## Risks
+
+| Risk | Why it bites | Mitigation |
+|---|---|---|
+| **`Overflow.w` is shared by Sema and both codegens** | S1 touches helpers reached by four subsystems; the i128 plan flags the same hazard for its own `Overflow.w` work. | Additive predicate only; byte-identical behavior for canonical operands; fixpoint after S1 alone before S2 starts. |
+| **S1 surfaces latent errors in existing comptime code** | Any std/lib comptime currently relying on the silent truncation begins erroring. | Full battery on S1 in isolation. Treat each new failure as a real bug found, not as S1 regressing — but budget time to triage them. |
+| **Sema/comptime re-entrancy in S2c** | Populating `typed_expr_types` during `prepare_for_comptime_transform` runs checking where none ran before, and comptime folding can re-enter sema. | Recursion guard; check the enclosing declaration once rather than per-node; S2a/S2b carry none of this risk, which is why they land first. |
+| **S3 before S2** | Turning the fallback into an ICE while lookups still miss breaks every comptime evaluation. | Strict stage ordering; S3 gated on the S0 oracle being green and on S2c for cloned nodes. |
+| **Diagnostic quality regression** | The unsigned path's "integer literal does not fit expected type" already points at the wrong thing. | Fix the message in S2 while the code is open; it is pinned by S0 so the change is visible in the diff. |
+
+## Non-goals
+
+No arbitrary-precision comptime integer. Exactness belongs at the literal layer,
+where `set_int_literal_exact` / `int_literal_expr_bits` already provide it
+correctly including 128-bit and the `2^(bits-1)` MIN case. Pushing exactness into
+`ComptimeValue` would make comptime arithmetic succeed where the same expression
+overflows at runtime — the divergence this plan exists to remove, promoted to a
+design.
+
+No tagged union over integer widths. That would put width in two places
+(`type_id` and the active variant) and make the ill-typed state representable
+again in a new shape.
+
+No 128-bit widening here; that stays with #914.
+
+## Estimate
+
+4–7 working days for S0–S5, plus a fixpoint cycle after S1 and after S2. S2
+dominates the variance: S2a+S2b are ~1 day and well understood; S2c is the
+open-ended one and may warrant its own issue.
+
+## Build environment
+
+Resolved. Follow `docs/with-bootstrap-runbook.md` → **Path A**, with one
+deviation: `with build :deps` failed here with
+
+```
+error: deps: could not find a release containing asset
+       'with-llvm-sdk-22.1.6-darwin-aarch64.tar.gz'
+```
+
+even though the asset is published on `v0.15.1.7` and every nightly. The
+documented escape hatch is `WITH_LLVM_SDK_VERSION=<tag> with build :deps`;
+fetching the asset by hand and extracting into `.deps/` also works, since the
+tarball's top-level directory is already `llvm-22.1.6-darwin-arm64` as
+`BuildGraphTools.w:58` expects. Note the asset name says `aarch64` while the
+directory says `arm64`. Root cause of the `:deps` failure is not established —
+the release-lookup parser works on the live API response when simulated, so do
+not assume it is the culprit.
+
+With the SDK in `.deps/` and `LLVM_PREFIX` / `WITH_LIBCLANG` / `SDKROOT` set,
+the full Path A chain passes on `22e534c6`:
+
+```
+with build            → all targets green, v0.15.1.7-g22e534c6c
+with build :fixpoint  → FIXPOINT (stage2 byte-identical to stage3)
+with build :test      → all green, 35 targets, 618s, 0 failures
+otool -L out/release/bin/with | grep -iE 'clang|LLVM'  → no dynamic dependency
+```
+
+All three symptom classes reproduce on that build, so this plan is validated
+against a compiler built from the commit it targets.
+
+## Status
+
+Branch `issue943`. All commits gate-verified: `:fixpoint` FIXPOINT and the full
+`:test` suite green, every target re-run rather than cached.
+
+- **S0 — done** (`b236f1b6`). Three behavior files carrying the four-term
+  oracle, plus two compile_errors fixtures pinning the then-current
+  diagnostics. The fixtures were deleted and their cases promoted once the
+  errors stopped firing, exactly as their own comments instructed.
+
+- **S2 — done**, in four commits. It took more sites than the stage predicted,
+  because the same defect was independently re-implemented by every consumer of
+  a typed integer payload:
+
+  | commit | sites |
+  |---|---|
+  | `f668e4f1` | literal type from suffix + sema's value-based default; local `let`/`var` annotation applied at binding |
+  | `ff07cf5e` | value write-back to the AST (`ct_build_value_tree`); unsigned `OP_DIV`/`OP_MOD`; unsigned ordering `< > <= >=` |
+  | `4c6f87e5` | negated literals in comptime, via `int_literal_expr_bits` on the unary node |
+  | `ff201949` | #914 D2 — sema `check_unary` + the negation-aware fit check + both MIR lowering paths |
+
+  Nine sites in total. Every one had narrowed or re-interpreted a payload before
+  measuring it.
+
+- **S3 (miss → internal error) — not done, and now lower value.** S2 fixed the
+  width resolution rather than making the lookup reliable, so the fallback is
+  still reachable in principle. S4 below is the stronger guard and lands first.
+
+- **S4 — done in part.** `checked_int_value` in `ComptimeEval.w` asserts the
+  payload is canonical in its own `type_id` and aborts with a `BUG:` diagnostic
+  otherwise, matching the `ast_pool_phase_bug` idiom.
+
+  **Partial by choice:** 25 of 102 `comptime_value_int` call sites are routed
+  through it — the 21 that build computed arithmetic results plus the literal
+  and annotation constructions. Those are where every defect in this campaign
+  originated. The remaining 77 construct trivially canonical values
+  (`comptime_value_int(ty_i32, 0)` and similar), and mechanical edits at that
+  scale in a self-hosting compiler cost more risk than the coverage is worth.
+  Anyone extending this should convert the rest rather than assume it is total.
+
+- **S1 — deliberately not done.** See "S1 reassessed" below.
+
+- **S5 — standing.** Every commit above ran `:fixpoint` and the full suite.
+
+### S1 reassessed
+
+S1's value was converting silent corruption into loud errors *while the width
+bug was live*, which is why it was ordered first. That rationale is gone: S2
+fixed the widths, so S1 now changes no observable behavior — its own acceptance
+criterion says as much ("no behavior change for any call site that already
+passes canonical operands"). Against that it touches six helpers on a path
+reached by Sema, the comptime evaluator, and both codegens: the largest blast
+radius left, for no measurable gain.
+
+The decisive evidence is a bug made during this campaign. The `4c6f87e5` fix
+stored `0x80000001` into an `i64` payload typed `i32` without sign-extending,
+and `-2147483647i32 / 3` silently returned `+715827883`. It was caught by a
+differential test that happened to include negative-operand division.
+
+**S1 would not have caught it** — the corruption surfaced through `OP_DIV`,
+which computes `lv / rv` directly and never enters the helpers S1 modifies.
+**S4 catches it at construction**, before the value reaches any operator, along
+with the original `(i32, 3000000001)` defect.
+
+S4 is strictly upstream: every case S1 could see must pass through the
+constructor first, plus cases S1 structurally cannot see. Recommendation: leave
+S1 undone, and fold it into #914's word-pair work on `Overflow.w`, where the
+file is open anyway and the change is close to free.

--- a/docs/plans/libgit2.md
+++ b/docs/plans/libgit2.md
@@ -1,0 +1,336 @@
+# libgit2 Migration Proposal
+
+Migrate libgit2 to With using `with migrate`, making git a native capability of the compiler, build system, and standard library.
+
+**Status: BLOCKED on zlib migration.** Git objects are zlib-compressed. Every read operation -- opening a commit, reading a blob, listing a tree -- requires zlib decompression. libgit2 cannot function without zlib. The zlib migration (~15K lines of clean C, public domain) must land first as `std.compress.zlib` before this proposal can begin.
+
+---
+
+## 1. What libgit2 Is
+
+libgit2 is a portable, pure C implementation of git core methods. It is a library, not a CLI wrapper around git. It provides programmatic access to git repositories without requiring git to be installed.
+
+- ~200K lines of C
+- MIT licensed
+- No external dependencies beyond system libraries
+- Used in production by GitHub Desktop, Visual Studio, GitKraken, Sublime Merge, and others
+- Clean, well-documented API
+- Cross-platform: Linux, macOS, Windows, BSD
+
+---
+
+## 2. Why
+
+The compiler and build system currently shell out to git for version detection and committed-state checks. The package manager will need git for fetching dependencies. The migration tool could fetch source directly from repositories. Today these are external tool dependencies. After this migration, they are native With code.
+
+The broader principle: the With compiler stands on system calls alone. Every capability it needs, it owns. libgit2 migrated to With means git operations are as native as regex (PCRE2) or JSON (std.json).
+
+This is also a proof point. PCRE2 (73K lines of C) demonstrated the migration tool on complex, macro-heavy systems code. libgit2 (200K lines) demonstrates it at a larger scale on clean, well-structured library code. Two major C libraries running as native With, both migrated mechanically.
+
+---
+
+## 3. What It Enables
+
+### 3.1 Package management (`with get`)
+
+Native git clone, fetch, and checkout. The package manager fetches With packages directly from git repositories without requiring git, curl, or tar on the system.
+
+```bash
+# Fetch a With package from a git repository
+with get github.com/user/package@v1.2.0
+
+# Fetch a specific commit
+with get github.com/user/package@abc1234
+
+# Fetch a C package and migrate it
+with get c.github.com/user/clib
+```
+
+The package manager resolves the version tag or commit, clones the minimum necessary objects (shallow clone or single-commit fetch), and places the source in the project's dependency directory. Lock files reference exact commit hashes, verifiable by the compiler without external tools.
+
+### 3.2 Build system
+
+Version detection reads `.git/HEAD` and refs natively. Committed-state enforcement compares the index against the working tree natively. No subprocess calls to git.
+
+```with
+use std.git
+
+let repo = git.open(".")
+let head = repo.head_commit()
+let version = f"v0.13.1-g{head.short_id()}"
+
+if repo.is_dirty():
+    print("error: working tree has uncommitted changes")
+```
+
+### 3.3 Migration tool
+
+`with migrate` can fetch C source directly from a git URL:
+
+```bash
+# Migrate a C library directly from its repository
+with migrate git://github.com/edubart/minicoro -o rt/minicoro.w
+
+# Migrate a specific tag
+with migrate git://github.com/PCRE2Project/pcre2@pcre2-10.44 -o lib/std/re/
+```
+
+No manual download step. The migration tool resolves the ref, fetches the source tree, and migrates it in one command.
+
+### 3.4 Standard library (`std.git`)
+
+A public API for With programs that work with git repositories:
+
+```with
+use std.git
+
+let repo = git.open("/path/to/repo")
+
+// Read refs
+let head = repo.head()
+let branches = repo.branches()
+let tags = repo.tags()
+
+// Read objects
+let commit = repo.lookup_commit(head.target())
+let tree = commit.tree()
+let blob = tree.entry_by_path("src/main.w").to_blob()
+let content = blob.content()
+
+// Status
+let status = repo.status()
+for entry in status:
+    print(f"{entry.path}: {entry.status}")
+
+// Clone
+git.clone("https://github.com/user/repo", "/local/path")
+
+// Diff
+let diff = repo.diff_index_to_workdir()
+for delta in diff.deltas():
+    print(f"{delta.old_file.path} -> {delta.new_file.path}")
+```
+
+### 3.5 Developer tooling
+
+The LSP server and future IDE integrations can read git state natively:
+
+- Show current branch in diagnostics
+- Annotate symbols with "last modified in commit X"
+- Provide git-aware file watching (ignore untracked files)
+- Integrate blame information into hover tooltips
+
+### 3.6 CI and deployment
+
+Programs built with With can inspect their own build provenance:
+
+```with
+use std.git
+
+fn build_info() -> str:
+    let repo = git.open(".")
+    let commit = repo.head_commit()
+    f"built from {commit.short_id()} on {commit.time()} by {commit.author().name}"
+```
+
+---
+
+## 4. Migration Plan
+
+### 4.1 Obtain and prepare
+
+```bash
+git clone https://github.com/libgit2/libgit2 .reference/libgit2
+cd .reference/libgit2
+git checkout v1.8.4  # pin to a specific release
+```
+
+### 4.2 Scope the migration
+
+libgit2's source is organized into:
+
+```
+src/libgit2/       -- core library (~150K lines)
+src/util/          -- platform utilities (~30K lines)
+deps/              -- bundled dependencies (http-parser, zlib, etc.)
+```
+
+The core library includes subsystems we don't need immediately (merge, rebase, blame, cherry-pick, stash). The migration can be incremental:
+
+**Phase A -- Read-only operations (immediate need):**
+- Repository opening and discovery
+- Reference reading (HEAD, branches, tags)
+- Object database reading (commits, trees, blobs)
+- Index reading and status computation
+- Config file parsing
+
+**Phase B -- Network operations (for package management):**
+- HTTP/HTTPS transport (the compiler already has a TLS stack from BearSSL)
+- Git protocol support
+- Clone and fetch
+- Shallow clone support
+
+**Phase C -- Write operations (future):**
+- Index modification
+- Commit creation
+- Reference updates
+- Push
+
+### 4.3 Handle bundled dependencies
+
+libgit2 bundles several small C libraries:
+
+- **zlib** -- Compression. Git objects are zlib-compressed. Every read operation requires decompression. This is a hard prerequisite, not an optional dependency. **zlib must be migrated to With as `std.compress.zlib` before libgit2 migration can begin.** zlib is ~15K lines of clean C under a permissive license (zlib license). It is also independently useful for the compiler and standard library (compressed assets, package archives, HTTP content-encoding).
+- **http-parser** -- HTTP/1.1 parser. The compiler may already have HTTP parsing from the package manager. Deduplicate or migrate separately.
+- **pcre/pcre2** -- Optional, for gitignore pattern matching. With already has PCRE2 migrated. No work needed.
+- **sha1/sha256** -- Hashing. The BearSSL port already provides SHA-256. SHA-1 is needed for git object IDs. BearSSL includes SHA-1 as well. No work needed.
+
+Dependency status:
+
+| Dependency | Status | Blocking? |
+|---|---|---|
+| zlib | **Not migrated -- BLOCKER** | Yes. Must land before libgit2. |
+| SHA-1 / SHA-256 | Available via BearSSL port | No |
+| PCRE2 | Already migrated | No |
+| http-parser | Needed for Phase B (network) only | No, Phase A proceeds without it |
+
+### 4.4 Migrate
+
+```bash
+with migrate .reference/libgit2/src/libgit2/ \
+    -o lib/std/git/ \
+    -I .reference/libgit2/include \
+    -I .reference/libgit2/src/libgit2 \
+    -I .reference/libgit2/src/util \
+    --no-c-export
+```
+
+This will produce a set of With modules under `lib/std/git/`. The migration tool handles struct translation, typedef resolution, function signature conversion, and goto elimination.
+
+Platform-specific code (Windows vs Unix filesystem operations, threading, etc.) will need conditional compilation or platform-abstraction rewrites after migration, following the same pattern as the runtime's platform layer.
+
+### 4.5 Build a With-native API layer
+
+The migrated code preserves libgit2's C API shape. Layer a With-idiomatic API on top:
+
+```
+lib/std/git/          -- migrated libgit2 internals (private)
+lib/std/git.w         -- public With API (Repository, Commit, Tree, etc.)
+```
+
+The public API uses With types (str, Vec, Option, Result), handles, and the ownership model. The internals remain close to libgit2's original structure for maintainability and future upstream sync.
+
+---
+
+## 5. Integration Points
+
+### 5.1 Wire into the build system
+
+After Phase A, replace the git subprocess calls in `build_compiler.w`:
+
+| Current | Replacement |
+|---|---|
+| `git rev-parse --short HEAD` | `repo.head_commit().short_id()` |
+| `git rev-list --count HEAD` | Omit, or `repo.head_commit().ancestor_count()` |
+| `git status --porcelain` | `repo.is_dirty()` |
+
+### 5.2 Wire into the package manager
+
+After Phase B, `with get` uses native git transport:
+
+```with
+use std.git
+
+fn fetch_package(url: str, version: str, dest: str) -> Result[str, Error]:
+    let opts = git.CloneOptions.new()
+        .depth(1)
+        .branch(version)
+    git.clone(url, dest, opts)
+```
+
+### 5.3 Wire into the migration tool
+
+After Phase B, `with migrate` accepts git URLs:
+
+```with
+use std.git
+
+fn fetch_source(url: str, ref: str, dest: str) -> Result[str, Error]:
+    let opts = git.CloneOptions.new().depth(1)
+    if ref.len() > 0:
+        opts = opts.branch(ref)
+    git.clone(url, dest, opts)
+```
+
+---
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| zlib migration must land first | zlib is ~15K lines of clean C, public domain, well-understood. It is a smaller and simpler migration than PCRE2. Independently useful for std.compress. |
+| 200K lines is a large migration | Phase A alone is ~50-80K lines (read-only core). Start there. |
+| Platform-specific code (Windows, Unix) | libgit2 already abstracts this. The migration preserves the abstraction layer; rewire it to With's runtime platform APIs. |
+| Upstream updates | Pin to a release tag. Re-migrate when needed. The migrated code is a snapshot, same as PCRE2. |
+| Network stack integration | The BearSSL TLS port already provides HTTPS. Wire libgit2's HTTP transport to use it instead of system OpenSSL/SecureTransport. |
+| Migration tool bugs | libgit2 is cleaner C than PCRE2 (no computed gotos, no macro codegen). Expect fewer migrator issues. |
+
+---
+
+## 7. Size Estimate
+
+| Component | Estimated LOC | Notes |
+|---|---|---|
+| **zlib migration (prerequisite)** | **~25-35K** | **Must land first as std.compress.zlib** |
+| Phase A migration output | ~100-150K | Read-only core + utilities |
+| Phase B migration output | ~30-50K | Network transport |
+| std.git public API | ~500-1000 | With-idiomatic wrapper |
+| Build system integration | ~100 | Replace git subprocess calls |
+| Package manager integration | ~200-400 | Clone/fetch for `with get` |
+| **Total** | **~160-240K migrated** | Plus ~1-2K hand-written |
+
+---
+
+## 8. Timeline
+
+This is not blocking current work. The immediate git needs (HEAD hash, committed-state check) are solved with ~70 lines of file reads and a hash manifest. libgit2 migration is a strategic investment that pays off when package management comes online.
+
+Prerequisite chain:
+
+```
+zlib migration (~15K lines C)
+  --> std.compress.zlib
+    --> libgit2 Phase A (read-only, ~50-80K lines)
+      --> build system integration (replace git subprocess calls)
+      --> libgit2 Phase B (network, ~30-50K lines)
+        --> with get git-based packages
+        --> with migrate from git URLs
+```
+
+Suggested sequencing:
+
+1. Ship the manual git file reads and hash manifest now (Phase 5-6 of no-deps plan).
+2. Migrate zlib to `std.compress.zlib`. This is independently useful (compressed assets, package archives, HTTP content-encoding) and unblocks libgit2.
+3. Migrate libgit2 Phase A (read-only) after zlib lands.
+4. Replace the manual file reads with std.git calls.
+5. Migrate Phase B (network) when `with get` is ready for git-based packages. Wire HTTP transport to the BearSSL TLS stack.
+6. Phase C (write operations) as needed.
+
+---
+
+## 9. Success Criteria
+
+The zlib prerequisite is met when:
+
+1. `std.compress.zlib` provides inflate/deflate operations.
+2. zlib is migrated With code, not a system library link.
+3. Compression/decompression round-trips match the reference zlib output.
+
+The libgit2 migration is complete when:
+
+1. `std.git` can open a repository, read HEAD, list refs, read commits/trees/blobs, and report status.
+2. The build system uses `std.git` instead of subprocess calls to git.
+3. `with get` can clone and fetch from git repositories without git installed.
+4. All git operations work on Darwin, Linux, and Windows.
+5. `make build && make fixpoint && make test` pass.
+6. git is not required on the system for any compiler or build system operation.

--- a/docs/plans/mutability-impl.md
+++ b/docs/plans/mutability-impl.md
@@ -1,0 +1,324 @@
+# Implementation Plan: docs/mutability.md
+
+## Context
+
+`docs/mutability.md` is a 786-line comprehensive specification for the With language's mutability and calling-convention model. The doc defines six axes: binding stability, value mutation, calling convention, receiver modes, effect summaries, and effect pinning.
+
+**Goal**: Implement all features described in the doc.
+
+**Already implemented (skip):**
+- `var` keyword / `let` for binding stability (Parser.w:801, 5107)
+- `mut self: Self` receiver mode with call-site enforcement (Ast.w:214, SemaCheck.w:8255)
+- Basic borrow checker with SHARED/EXCLUSIVE live borrows (Sema.w:341–350)
+- `&T` reference type (TY_REF = 14)
+
+**Not yet implemented (this plan):**
+- `copy`/`move` call-site argument annotations (`f(copy x)`, `f(move x)`)
+- Copy trait tracking for aggregates
+- `&Self` and `move self: Self` receiver modes (only `mut self` is complete)
+- Effect summary inference (read/write/consume/escape_value/escape_view)
+- Effect pinning via `@[effect(...)]` attribute
+- View-origin tracking for `escape_view`
+
+---
+
+## Phase 1: Call-Site Passing Modes (`copy x`, `move x`)
+
+**The most impactful missing feature.** Without these, the calling convention model can't be demonstrated.
+
+### 1a. Token and AST Nodes
+
+**src/Token.w**: Add `TK_KW_COPY` token near `TK_KW_MOVE` (line ~132). The keyword `copy` is not yet in the lexer.
+
+**src/Ast.w**: Add two new node kinds:
+- `NK_COPY_ARG` — wraps an expression to indicate copy-passing at call site
+- `NK_MOVE_ARG` — wraps an expression to indicate move-passing at call site (distinct from `move ||` closures)
+
+Both nodes: `d0 = inner_expr_node`, d1/d2 unused.
+
+### 1b. Parsing
+
+**src/Parser.w**: In `parse_call` (around line 3274), in the argument loop before calling `parse_expr()`, check:
+```
+if self.peek() == TK_KW_COPY:
+    self.advance()
+    let inner = self.parse_expr()
+    arg = self.node_with(NK_COPY_ARG, inner, 0, 0)
+else if self.peek() == TK_KW_MOVE:
+    // check next token isn't `||` (that's a closure)
+    if self.peek_ahead(1) != TK_PIPE and self.peek_ahead(1) != TK_PIPE_PIPE:
+        self.advance()
+        let inner = self.parse_expr()
+        arg = self.node_with(NK_MOVE_ARG, inner, 0, 0)
+    else:
+        arg = self.parse_expr()  // move closure
+else:
+    arg = self.parse_expr()
+```
+
+### 1c. Semantic Checking
+
+**src/SemaCheck.w**: In call argument checking:
+
+For `NK_MOVE_ARG`:
+- Type-check inner expr normally
+- Record the symbol as "moved" in the borrow checker (invalidate binding)
+- Error if the symbol is already moved or is a with-binding
+
+For `NK_COPY_ARG`:
+- Type-check inner expr normally
+- Check type implements `Copy` or `Clone`; error otherwise
+- If `Clone` only, generate a `.clone()` call in MIR lowering
+
+### 1d. MIR / Codegen
+
+**src/MIR.w** and **src/Codegen.w**:
+- `NK_MOVE_ARG`: lower as the inner expression (same as a value move — the key difference is binding invalidation in sema, codegen is same as passing the value)
+- `NK_COPY_ARG` on `Copy` types: lower as inner expression (copy happens automatically)
+- `NK_COPY_ARG` on `Clone`-only types: lower as `inner.clone()` method call
+
+### Tests
+- `test/behavior/behav_mut_md_copy_move.w`: test `f(copy x)` and `f(move x)` basic cases
+- `test/compile_errors/err_copy_non_copy.w`: error when `copy x` on non-Copy/non-Clone type
+- `test/compile_errors/err_move_invalidates.w`: error when using moved binding
+
+---
+
+## Phase 2: Copy Trait Tracking for Aggregates
+
+The doc says: primitives are `Copy` by default; aggregate types are non-Copy by default, opt-in via `impl Copy for T` or `: Copy`.
+
+### 2a. Determine Current State
+
+First, grep for `is_copy`, `trait_copy`, `impl Copy` in src/Sema.w and src/SemaCheck.w to see what's already tracked. (The trait system has blanket impl support; `Copy` may already exist.)
+
+### 2b. If Not Tracked: Add Copy Flag to Type Descriptors
+
+**src/Sema.w**: Add a `is_copy` flag to struct/enum type descriptors. Primitives (i32, u8, bool, f64, char, etc.) are marked copy at type-system initialization. Structs/enums default to non-copy unless `impl Copy for T` is present.
+
+### 2c. `type T: Copy { ... }` Syntax
+
+Parser.w may already parse the `: TraitName` after type declaration name. Verify it creates an impl for Copy and sets the is_copy flag.
+
+### 2d. Call-Site Copy-ness Rules
+
+**src/SemaCheck.w**: At call argument checking:
+- For default `f(x)` where arg type is Copy: no action needed (codegen copies)
+- For default `f(x)` where arg type is non-Copy: track as share-place alias (ephemeral borrow)
+- This distinction matters for effect checking in Phase 4
+
+### Tests
+- `test/behavior/behav_copy_aggregate.w`: Copy struct passed by value; mutation in callee doesn't affect caller
+- `test/behavior/behav_non_copy_shared.w`: Non-Copy struct share-place; mutation in callee visible in caller
+
+---
+
+## Phase 3: Complete Receiver Modes (`&Self`, `move self: Self`)
+
+Only `mut self: Self` is fully implemented. `&Self` and `move self: Self` need explicit flag tracking and enforcement.
+
+### 3a. Flags
+
+**src/Ast.w** (around line 214 near `FN_PARAM_FLAG_MUT_SELF`): Add:
+- `FN_PARAM_FLAG_REF_SELF` — receiver is `&Self` (read-only view)
+- `FN_PARAM_FLAG_MOVE_SELF` — receiver is `move self: Self` (consuming)
+
+### 3b. Parsing
+
+**src/Parser.w**: In method parameter parsing (around line 5997 where `FN_PARAM_FLAG_MUT_SELF` is set), also detect:
+- `self: &Self` → set `FN_PARAM_FLAG_REF_SELF`
+- `move self: Self` → set `FN_PARAM_FLAG_MOVE_SELF`
+
+The `&Self` case currently parses `&Self` as a type annotation. Change to also set the flag.
+
+### 3c. Semantic Enforcement
+
+**src/SemaCheck.w**:
+
+For `&Self` methods:
+- At method body: flag that self is a read-only reference. Any mutation of self (field assignment, calling a `mut self` method on self) is a compile error.
+- At call site: treated as a read borrow of the receiver (no mutation).
+
+For `move self` methods:
+- At call site: receiver binding is invalidated (same as `move x` for free functions).
+- The receiver cannot be used after the call.
+- Error: calling a `move self` method on a with-binding (with-bindings are not rebindable).
+
+**Plain `fn method(self: Self)` with no mode annotation**: Per the doc, this is a compile error. Enforce this: if a method's self parameter has no receiver mode flag, emit error "method receiver must be &Self, mut Self, or move Self".
+
+### Tests
+- `test/compile_errors/err_no_receiver_mode.w`: method without receiver mode annotation → error
+- `test/compile_errors/err_ref_self_mutation.w`: mutation of `&Self` receiver → error
+- `test/behavior/behav_move_self.w`: `move self` method invalidates receiver at call site
+
+---
+
+## Phase 4: Effect Summary Inference (Core Borrow-Checker Model)
+
+This is the largest phase. The doc's full borrow-checking model depends on per-parameter effect sets.
+
+**Effects**: `read`, `write`, `consume`, `escape_value`, `escape_view`
+
+### 4a. Data Structures
+
+**src/Sema.w**: Add per-function effect tracking during body analysis:
+```
+fn_param_effects: Vec[i32]      // bit set per param: EFF_READ|EFF_WRITE|EFF_CONSUME|EFF_ESCAPE_VALUE|EFF_ESCAPE_VIEW
+fn_param_origins: Vec[i32]      // for escape_view: which params are view origins (bitmask over param indices)
+```
+
+Define effect constants (as named module-level lets or a small enum):
+```
+EFF_READ         = 0x01
+EFF_WRITE        = 0x02   // implies read
+EFF_CONSUME      = 0x04
+EFF_ESCAPE_VALUE = 0x08
+EFF_ESCAPE_VIEW  = 0x10
+```
+
+### 4b. Effect Inference During Type-Checking
+
+**src/SemaCheck.w**: As each operation on a parameter is analyzed, update the effect set:
+
+| Operation | Effect contributed |
+|---|---|
+| Reading param value | `read` |
+| Field assignment `param.field = ...` | `write` |
+| Calling `mut self` method on param | `write` |
+| `return param` (owned) | `escape_value` |
+| Passing param to function with `consume/escape_value` effect | transitive effect |
+| `let y = param` (local move) | `consume` |
+| `return &param.field` | `escape_view` |
+| `x = param` (rebinding) | nothing on the effect of the original param place |
+
+**Key implementation challenge**: tracking which parameter a sub-expression "originates from" for escape_view. This requires a "value provenance" or "origin set" alongside types during expression checking.
+
+### 4c. Call-Site Effect Checking
+
+**src/SemaCheck.w**: At call sites, look up the callee's effect summary for each argument:
+
+```
+for each arg at call site:
+    effects = callee.param_effects[i]
+    is_copy_type = arg_type.is_copy
+    call_mode = COPY if NK_COPY_ARG else MOVE if NK_MOVE_ARG else DEFAULT
+
+    if effects & (EFF_CONSUME | EFF_ESCAPE_VALUE):
+        if not is_copy_type and call_mode == DEFAULT:
+            error: "non-Copy type used where callee may consume/escape; use `move x` or `copy x`"
+
+    if effects & EFF_ESCAPE_VIEW:
+        // view-origin tracking (Phase 5)
+
+    if effects & EFF_WRITE:
+        // register exclusive borrow during call duration
+        // conflict with existing SHARED borrows on this place
+```
+
+### 4d. Export in Compiled Interface
+
+Effects must be persisted alongside function type signatures so cross-module calls can be checked. Store effect vectors in the serialized type information.
+
+### Tests
+- `test/behavior/behav_eff_write.w`: callee with write effect; mutation visible at caller
+- `test/behavior/behav_eff_escape.w`: callee with escape_value; requires move/copy
+- `test/compile_errors/err_eff_escape_no_move.w`: non-Copy arg to escape_value function without move/copy
+
+**Critical path note**: Phase 4 requires that all existing tests still pass (`make fixpoint`). Effect inference must be added conservatively — when a function's effects can't be fully computed (e.g., recursive or mutually recursive), assume worst case (all effects present) or use a fixpoint iteration.
+
+---
+
+## Phase 5: View-Origin Tracking for `escape_view`
+
+This is lifetime inference without explicit annotations. When a function returns `&T`, track which parameter(s) the returned reference originates from.
+
+### 5a. Origin Set Representation
+
+During Phase 4 escape_view detection, when a reference is returned, record which parameters it may alias. This is a bitmask over parameter indices (up to 64 params covered with i64 origin mask).
+
+### 5b. Call-Site Lifetime Checking
+
+When `escape_view` effect is present, at the call site:
+- The returned view's lifetime is the intersection of all origin parameter lifetimes
+- If any origin parameter is invalidated (moved, goes out of scope) before the view is last used → error
+
+This requires tracking view liveness: when `let v = f(x)`, `v` is a view into `x`. The borrow checker must reject use of `v` after `x` is moved or out of scope.
+
+**Implementation**: Extend the existing borrow tracking to associate returned reference bindings with their origin symbols. When an origin is invalidated, all dependent views become invalid.
+
+### Tests
+- `test/compile_errors/err_escape_view_move_origin.w`: `f(move xs)` where f has `escape_view` → error
+- `test/compile_errors/err_view_dangling.w`: view outlives origin → error
+- `test/behavior/behav_escape_view_valid.w`: valid use of escaped view within origin lifetime
+
+---
+
+## Phase 6: Effect Pinning (`@[effect(...)]`)
+
+### 6a. Attribute Parsing
+
+**src/Parser.w** (around line 343–353 in `skip_attributes`/attribute parsing): Add `effect` to recognized attribute names. Parse `@[effect(param = effect_set)]` where effect_set is one of: `read`, `write`, `consume`, `escape_value`, `escape_view`, or `[effect, effect, ...]`.
+
+**src/Ast.w**: Store parsed effect pins in function node extra data (or in the existing pending_attrs mechanism).
+
+### 6b. Floor/Ceiling Enforcement
+
+**src/SemaCheck.w**: After effect inference for a function body:
+- **Floor check**: inferred effects must be ⊇ pinned effects. If inferred < pinned, error: "body doesn't satisfy pinned effect floor"
+- **Ceiling check**: inferred effects must be ⊆ pinned effects. If inferred > pinned, error: "body exceeds pinned effect ceiling"
+
+Also: the exported effect summary for a pinned function is the pinned set (not the inferred set), so downstream callers are checked against the pin.
+
+### Tests
+- `test/compile_errors/err_pin_floor.w`: body doesn't satisfy pinned floor
+- `test/compile_errors/err_pin_ceiling.w`: body exceeds pinned ceiling
+- `test/behavior/behav_effect_pin.w`: pinned function with future-reserved write
+
+---
+
+## Implementation Order and Dependencies
+
+```
+Phase 1 (copy/move syntax)    — no dependencies, start here
+    ↓
+Phase 2 (Copy tracking)       — needed for Phase 1 semantics
+    ↓
+Phase 3 (receiver modes)      — can be done alongside Phase 1/2
+    ↓
+Phase 4 (effect summaries)    — depends on Phase 1-3; largest work
+    ↓
+Phase 5 (view-origin)         — depends on Phase 4
+    ↓
+Phase 6 (effect pinning)      — depends on Phase 4
+```
+
+Each phase must individually pass:
+```
+make build && make fixpoint && make test
+```
+
+---
+
+## Critical Files
+
+| File | Phases | Key Changes |
+|---|---|---|
+| `src/Token.w` | 1 | Add TK_KW_COPY |
+| `src/Ast.w` | 1,3 | NK_COPY_ARG, NK_MOVE_ARG, FN_PARAM_FLAG_REF_SELF, FN_PARAM_FLAG_MOVE_SELF |
+| `src/Parser.w` | 1,3,6 | Call-site copy/move parsing; receiver mode flags; effect attribute |
+| `src/Sema.w` | 2,4 | Copy flag in type descriptors; effect set Vecs |
+| `src/SemaCheck.w` | 1,2,3,4,5,6 | Bulk of semantic enforcement |
+| `src/MIR.w` | 1 | Lower NK_COPY_ARG / NK_MOVE_ARG |
+| `src/Codegen.w` | 1 | Codegen for copy/move args (Clone call if needed) |
+
+---
+
+## Verification
+
+Full end-to-end verification after each phase:
+1. `make build` — compiler compiles
+2. `make fixpoint` — stage2 == stage3 (nondeterminism check)
+3. `make test` — no regressions
+4. New tests in `test/behavior/behav_mut_md_*.w` and `test/compile_errors/err_mut_md_*.w`
+
+The hardest fixpoint risk is Phase 4 (effect inference), because any nondeterminism in effect computation (e.g., HashMap iteration order) will break fixpoint. Use parallel Vec arrays for effect storage, not HashMap — same pattern used for `try_eval_const_int` in memory.

--- a/docs/plans/no-deps.md
+++ b/docs/plans/no-deps.md
@@ -1,0 +1,236 @@
+## Eliminating External Tool Dependencies
+
+### Principle
+
+The With compiler and build system must be self-sufficient. Every operation — compilation, assembly, archiving, path discovery, version detection — uses either LLVM APIs (already statically linked) or With runtime system calls. No `cc`, no `ar`, no `llvm-config`, no `xcrun`, no `git`.
+
+The only subprocess calls that remain are running the With compiler itself (stage chain, test runner) and running user-specified executables (Command targets). Those are architecturally necessary.
+
+---
+
+### Phase 1: Pure-With archive creation
+
+**What it replaces:** `ar rcs` subprocess (BuildGraphOps.w:186)
+
+**Priority:** First because it's zero-risk, zero-investigation, pure With, ~100 lines.
+
+Implement the AR format directly in With. No LLVM dependency, no platform dependency, works identically everywhere.
+
+The format is simple:
+- 8-byte magic (`!<arch>\n`)
+- For each member: 60-byte header (name, timestamp, uid, gid, mode, size, magic `\x60\n`), then the file contents padded to 2-byte alignment
+
+For long filenames (>16 chars), use the BSD `#1/` extended name format: the name is prepended to the file data and the header's name field reads `#1/<name_length>`.
+
+**Add to runtime (`rt/rt_core.w`):**
+
+```with
+@[c_export("with_create_archive")]
+pub fn create_archive(output: str, object_files: str) -> i32
+```
+
+Where `object_files` is null-separated paths (same convention as the existing argv blobs).
+
+Alternatively, implement entirely in With in the build system layer (BuildGraphOps.w) using `with_fs_read_file` / `with_fs_write_file`. No runtime C code needed — just byte-level format construction.
+
+**Replace in BuildGraphOps.w:186.** Remove the `ar` tool from BuildGraphTools.w.
+
+**Verification:** Create an archive, verify with `nm` that symbols are accessible, link the compiler against it, fixpoint passes.
+
+---
+
+### Phase 2: SDK path discovery + seed compiler probe
+
+**What it replaces:**
+- `/usr/bin/xcrun --show-sdk-path` (build_compiler.w:166)
+- `with --version` seed probe (build_compiler.w:190)
+
+**Priority:** Second because both are trivial filesystem probes, ~15 lines each.
+
+**SDK path — probe known paths using `with_fs_file_exists`:**
+
+```
+1. $SDKROOT environment variable (if set)
+2. /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+3. /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+```
+
+On Linux: no SDK path needed (system headers are in `/usr/include`).
+On Windows: probe `%WindowsSdkDir%` or known Visual Studio paths.
+
+**Replace in build_compiler.w:166.**
+
+**Seed compiler probe — walk PATH with filesystem checks:**
+
+```
+1. $WITH environment variable (if set) — already checked first
+2. out/bin/with — already checked
+3. Walk $PATH: split on ':', check each dir for 'with' using with_fs_file_exists
+4. src/main — already checked as fallback
+```
+
+This is what shell `which` does internally — a filesystem probe, not a subprocess. Replace the `with --version` subprocess call with a PATH walk.
+
+**Replace in build_compiler.w:190.**
+
+**Verification:** Compare discovered paths against `xcrun --show-sdk-path` and `which with` on a dev machine.
+
+---
+
+### Phase 3: Git-free version detection
+
+**What it replaces:** `git rev-parse --short HEAD` and `git rev-list --count HEAD` (build_compiler.w:260-274)
+
+**Priority:** Third because it's straightforward file reads, no external dependencies.
+
+**Read `.git` directly through the runtime:**
+
+```with
+fn read_git_head_hash(root: str) -> str:
+    let head = with_fs_read_file(root ++ "/.git/HEAD")
+    if head.starts_with("ref: "):
+        // HEAD is a symbolic ref like "ref: refs/heads/main\n"
+        let ref_path = head.slice(5, head.len()).trim()
+        let hash = with_fs_read_file(root ++ "/.git/" ++ ref_path)
+        if hash.len() >= 9:
+            return hash.slice(0, 9)  // short hash (9 chars, matching --short=9)
+        // Loose ref doesn't exist — check packed-refs
+        let packed = with_fs_read_file(root ++ "/.git/packed-refs")
+        // parse lines for the matching ref
+    else:
+        // Detached HEAD — the file contains the hash directly
+        return head.slice(0, 9)
+    "unknown"
+```
+
+**Commit count:** Omit it. The reflog approach is fragile (reflogs get pruned, shallow clones don't have them). Walking the commit graph is complex and unnecessary. The version string `v0.13.1-g<hash>` is sufficient without the count.
+
+If `.git` doesn't exist (tarball build), fall back to reading `src/version` which already contains the release version.
+
+**Replace in build_compiler.w:260-274.**
+
+**Verification:** Compare output against `git rev-parse --short=9 HEAD` on a dev machine.
+
+---
+
+### Phase 4: Git-free committed-state check
+
+**What it replaces:** `git status --porcelain` (build_compiler.w:479-483)
+
+**Priority:** Fourth because it needs design work but has no external dependencies.
+
+**Approach: Hash-based manifest (Option B)**
+
+This is the most robust option and has no git dependency at all. It answers "is this the code I intended to ship?" rather than "is git clean?" — arguably better semantics.
+
+**Mechanics:**
+
+At `with build :fixpoint` success (or a new `with build :bless` command), record content hashes of all source files into a manifest:
+
+```
+out/.build-state/blessed-manifest
+```
+
+Contents: sorted lines of `<path>:<content-hash>`, covering `src/*.w` (recursively), `rt/*.w`, `lib/std/*.w`, `build.w`, `build_compiler.w`.
+
+At `install-user` / `update-seed` time, recompute hashes of the same files and compare against the manifest. If any file differs or the manifest doesn't exist, fail with a diagnostic listing the changed files. `--force` bypasses as before.
+
+**Why not Option A (mtime-based):** mtime comparison is inherently racy and filesystem-dependent. Content hashing through the runtime is deterministic and portable.
+
+**Why not Option C (skip when no git):** The check should work everywhere, not just in git repos.
+
+**Replace in build_compiler.w:479-483.**
+
+---
+
+### Phase 5: LLVM path discovery
+
+**What it replaces:** `llvm-config --libfiles --link-static ...` (build_compiler.w:354)
+
+**Priority:** Fifth because it requires care around LLVM version portability.
+
+**Current behavior:** Runs `llvm-config --libfiles --link-static engine ...` with 58 hardcoded component names to get a list of LLVM library paths for linking.
+
+**Replacement:**
+
+1. Read `LLVM_PREFIX` environment variable (already used elsewhere), or probe known paths (`/usr/local/llvm`, `/opt/homebrew/opt/llvm`, `/usr`).
+2. List `$LLVM_PREFIX/lib/` using `with_fs_list_files`.
+3. Include ALL `libLLVM*.a` and `libclang*.a` files found. Do NOT hardcode component names — they change between LLVM versions. Over-linking is free; the linker discards unused objects.
+4. Check for unified `libLLVM.a` first — if it exists, use just that instead of component libraries.
+5. Write the result to `out/lib/llvm_link.rsp` as before.
+
+**Replace in build_compiler.w:354.**
+
+**Verification:** Diff the generated `llvm_link.rsp` against what `llvm-config` would produce — it should be a superset (same libraries plus possibly unused ones). The compiler must link and fixpoint.
+
+---
+
+### Phase 6: LLVM-based C compilation, assembly, and IR-to-object
+
+**What it replaces:** `cc -c` for C objects, `cc -c` for assembly, `clang -c` for LLVM IR (BuildGraphDispatch.w:116-120)
+
+**Priority:** Last because it requires the most investigation and has the highest risk.
+
+**Critical investigation needed before implementation:**
+
+The compiler dynamically links `libclang` (for `c_import` header parsing) but the full clang compilation pipeline (C source → object file) requires the static clang libraries (`libclangCodeGen.a`, `libclangFrontend.a`, etc.). These are different link dependencies. Before committing to an approach, determine:
+
+1. What clang APIs are available through the current `libclang` dynamic link? Check `rt/clang_bridge.w` for the current API surface.
+2. Does `libclang` expose any code emission / compilation function, or only parsing/indexing?
+3. Would switching from dynamic `libclang` to static clang libraries be feasible? What's the binary size impact?
+4. Can the clang frontend be driven through the LLVM C API that's already statically linked?
+
+**Scope reduction — check how many C files actually need compiling:**
+
+The build timeline says "Apr 5 — Zero C source files." If no `.c` files remain in the build graph, C compilation may not be needed at all. Check `with build --dry-run` for kind-12 (CompileCObject) targets. If there are none, this phase reduces to two problems:
+
+- **Assembly (kind 13):** Can LLVM's MC layer be driven through the existing LLVM C API? The compiler already initializes LLVM targets for codegen — the same target initialization serves assembly. Use `createMCAsmParser` → `MCStreamer` or `LLVMTargetMachineEmitToFile`.
+- **LLVM IR to object (kind 14):** The compiler already does this for With source (emit IR → compile to object via LLVM backend). Factor out the "IR text → object file" step into a standalone runtime function. This is likely the easiest of the three.
+
+**Add to the LLVM bridge (`rt/llvm_bridge.w`):**
+
+```with
+/// Assemble a .s file to an object file using LLVM's MC layer.
+fn wl_assemble_to_object(source: str, output: str, target_triple: str) -> i32
+
+/// Compile an LLVM IR .ll file to an object file.
+fn wl_compile_ir_to_object(source: str, output: str) -> i32
+
+/// (Only if C files exist) Compile C source to object.
+fn wl_compile_c_to_object(source: str, output: str, include_paths: str, flags: str) -> i32
+```
+
+**Replace in BuildGraphDispatch.w:116-120.** Route each target kind to the appropriate LLVM function instead of subprocess.
+
+**Verification:** Rebuild the compiler. Every runtime object (rt_core.o, llvm_bridge.o, clang_bridge.o, fiber_asm.o, etc.) must be produced by the LLVM bridge functions, not by subprocess. `nm` on the output objects should produce identical symbols. Fixpoint must pass.
+
+---
+
+### Ordering
+
+```
+Phase 1: Archive creation              (pure With, ~100 lines, zero risk)
+Phase 2: SDK probe + seed probe        (filesystem checks, trivial)
+Phase 3: Git version detection         (file reads, straightforward)
+Phase 4: Committed-state check         (hash manifest, needs design)
+Phase 5: LLVM path discovery           (directory listing, version-portability care)
+Phase 6: C/asm/IR compilation          (hardest — needs clang API investigation)
+```
+
+After each phase: `with build`, fixpoint, test. Commit after each phase.
+
+---
+
+### Verification
+
+After all phases:
+
+```bash
+# Confirm no external tool subprocesses remain
+rg 'exec_argv_capture|exec_binary' src/ --include '*.w' -l
+# Should show only: BuildGraphOps.w (user Command targets),
+#                   BuildGraphTests.w (test runner),
+#                   build_compiler.w (stage chain — runs With itself)
+```
+
+Every remaining subprocess call must be either running the With compiler itself or running a user-specified executable. Zero platform tool invocations.

--- a/docs/plans/regex.md
+++ b/docs/plans/regex.md
@@ -1,0 +1,198 @@
+# Regex Integration Plan
+
+## Summary
+
+Implement regex as a **normal stdlib/prelude type** backed by the existing migrated PCRE2 engine, with **compiler-known syntax** for `/.../flags`, `=~`, `!~`, and regex `match` arms.
+
+This milestone includes:
+- `std.regex` facade on top of `std.re`
+- regex literals
+- `=~` / `!~`
+- scoped `$0`, `$1`, `$name` bindings for direct positive regex conditions
+- regex arms in `match`
+
+This milestone does **not** include:
+- compiler-side literal validation
+- JIT
+- full upstream `pcre2test` corpus
+- flow-sensitive capture bindings through compound boolean expressions
+- magic capture bindings for non-literal `Regex` values
+
+## Implementation Changes
+
+### 1. Stdlib facade first
+
+Add `lib/std/regex.w` and pull it into `lib/std/prelude.w`.
+
+Public API for v1:
+- `type Regex`
+- `type Match { text: str, start: i32, end: i32 }`
+- `type Captures`
+- `type RegexError { code: i32, offset: i32, message: str }`
+- `fn Regex.compile(pattern: &str) -> Result[Regex, RegexError]`
+- `fn Regex.compile_flags(pattern: &str, flags: &str) -> Result[Regex, RegexError]`
+- `fn Regex.is_match(self: &Self, text: &str) -> bool`
+- `fn Regex.find(self: &Self, text: &str) -> Option[Match]`
+- `fn Regex.captures(self: &Self, text: &str) -> Option[Captures]`
+- `fn Regex.replace_all(self: &Self, text: &str, repl: &str) -> str`
+- `fn Regex.split(self: &Self, text: &str) -> Vec[str]`
+- `fn Captures.get(self: &Self, index: i32) -> Option[Match]`
+- `fn Captures.by_name(self: &Self, name: &str) -> Option[Match]`
+
+Compiler-only helper:
+- `fn Regex.__compile_literal(pattern: &str, flags: &str, file: &str, line: i32, col: i32) -> Regex`
+- This must fail loudly with a source-located panic if compilation fails. No silent fallback, no invalid zero-value regex.
+
+Representation defaults:
+- `Regex` owns the compiled `pcre2_code` and frees it in `drop`
+- `Regex` stores `global: bool` separately from compile options
+- `g` is not passed to `pcre2_compile_8`; it only affects higher-level iteration APIs
+- `Captures` stores the original subject plus span pairs; explicit APIs return `Option[Match]`
+- Compiler-generated `$N` / `$name` locals are plain `str`; unmatched optional groups bind to `""`
+
+Named capture extraction:
+- Parse and cache the PCRE2 name table once during `Regex.compile*`
+- `Captures.by_name()` uses the cached name-to-index metadata from the owning `Regex`
+
+### 2. Syntax and AST
+
+Update `src/Token.w`, `src/Lexer.w`, `src/Parser.w`, and `src/Ast.w`.
+
+Lexer:
+- Add `TK_REGEX_LIT`
+- Add dedicated tokens for `=~` and `!~`
+- Extend identifier lexing so `$1`, `$name`, `$foo_bar` lex as `TK_IDENT`
+- Keep the token span over the full regex literal; parser splits `pattern` and `flags` from source text
+- Use context-sensitive `/` disambiguation exactly from `docs/regex-spec.md`
+- Regex scanning must respect escaped `/`, escaped `\\`, and character classes `[...]`
+- Unknown literal flags are a compile error; duplicate flags are accepted and deduplicated
+
+AST choices:
+- Add `NK_REGEX_LIT`
+- Add `NK_PAT_REGEX` for regex `match` arms
+- Do **not** add `NK_MATCH_OP` / `NK_NEG_MATCH_OP`; parse `=~` and `!~` as `NK_BINARY` with new `BinaryOp` values. This matches the current Pratt parser and reduces downstream branching.
+
+Parser behavior:
+- `/.../flags` parses anywhere an expression parses
+- `=~` / `!~` use equality-precedence
+- `match` arms may use regex literals directly as patterns
+- No parser-time capture injection. Parser only needs to accept `$...` identifiers and regex nodes.
+
+### 3. Sema rules and capture scope
+
+Update `src/Sema.w` and `src/SemaCheck.w`.
+
+Type ownership:
+- `Regex`, `Match`, `Captures`, and `RegexError` are normal named types from `std.regex`
+- The compiler must not register `Regex` as a primitive/builtin type
+- Sema resolves `Regex` through the prelude import path, just like `Vec` / `Option`
+
+Operator rules:
+- `lhs =~ rhs` requires `lhs: str-compatible`, `rhs: Regex`
+- `lhs !~ rhs` requires the same and returns `bool`
+- Regex literals typecheck as `Regex`
+- Regex `match` arms require the `match` subject to be `str-compatible`
+
+Capture-binding defaults:
+- Scoped `$...` bindings are available only for:
+  - `if text =~ /literal/:`
+  - `while text =~ /literal/:`
+  - regex `match` arms
+- `!~` never creates captures
+- Compound boolean expressions do not get magic captures
+  - `if ready and text =~ /.../:` is valid boolean code, but `$1` is not available
+  - `if text =~ /a/ or text =~ /b/:` is valid boolean code, but `$1` is not available
+- `=~` with a non-literal `Regex` value returns `bool` but does not create `$...` locals in v1
+- Using `$...` outside an eligible body is a compile error
+- Using `$name` / `$N` that the literal does not declare is a compile error
+
+Implementation strategy:
+- Analyze regex literals in sema to extract:
+  - numbered group count
+  - named group map
+- Store that metadata in `AstPoolState`, keyed by the `NK_REGEX_LIT` node
+- When checking an eligible `if` / `while` body or regex `match` arm, push synthetic scoped bindings for the declared captures before checking the body, then pop them afterward
+- Record per-body capture metadata so lowering can materialize the synthetic locals before user code in that body
+
+LSP/tooling:
+- Update hardcoded prelude completions in `src/Lsp.w` so `Regex`, `Match`, `Captures`, and `RegexError` appear like other prelude types
+
+### 4. MIR lowering and codegen
+
+Update `src/MirLower.w`, `src/CodegenTraits.w`, and `src/CodegenDispatch.w`.
+
+Regex literals:
+- Lower each literal to a synthetic module runtime-init global using the existing `module_runtime_init` machinery
+- Do not invent a separate startup path
+- Emit one synthetic global per literal site, with dedup by exact pattern+flags within a module if easy; if dedup complicates bootstrap, use one-per-site for v1
+- Runtime init helper calls `Regex.__compile_literal(pattern, flags, file, line, col)`
+
+`=~` / `!~`:
+- Non-capturing boolean use lowers to `Regex.is_match(text)` or `Regex.captures(text).is_some()`
+- Direct-capture conditions lower to:
+  - evaluate literal/global regex
+  - call `Regex.captures(text)`
+  - branch on `is_some()`
+  - materialize synthetic `$...` locals at controlled-body entry from the `Captures` value
+- Named and numbered capture locals should use helper accessors that produce `str`, with unmatched optional captures becoming `""`
+
+Regex `match` arms:
+- Lower regex arms as ordered `captures()` probes against the string subject
+- On success, branch into the arm body and materialize that arm’s `$...` locals before lowering user code
+- Non-regex arms keep existing lowering behavior
+
+Critical constraint:
+- Do not try to implement regex literals through general comptime execution. The current comptime path cannot call the migrated PCRE2 runtime safely enough for this milestone.
+
+### 5. Follow-up phase after syntax lands
+
+After the above is green, do a second pass for:
+- compiler-side regex literal validation in sema
+- optional literal dedup improvements across a module
+- `captures_all`, `replace_all_fn`, `splitn`
+- JIT
+- broader `pcre2test` corpus coverage
+- any future expansion of capture scope beyond direct positive conditions
+
+Compiler-side literal validation should be a dedicated compiler validation path, not a vague “run it at comptime” shortcut.
+
+## Test Plan
+
+Add or update tests in `test/behavior`, `test/compile_errors`, and the PCRE2 harnesses.
+
+Behavior:
+- `Regex.compile()` / `compile_flags()` success and failure
+- `is_match`, `find`, `captures`, `by_name`, `replace_all`, `split`
+- `/.../flags` lexing and slash-vs-division disambiguation
+- direct `if text =~ /.../:` with `$0`, `$1`, `$name`
+- direct `while text =~ /.../:` with capture reuse per iteration
+- `!~` boolean semantics with no captures
+- regex `match` arms with capture bindings
+- repeated use of the same literal in one module reuses correct compiled state
+
+Compile errors:
+- unknown literal flag
+- `$1` outside regex-controlled scope
+- `$name` not declared by the regex literal
+- `$1` used after `!~`
+- `$1` used inside compound boolean cases
+- `$1` used when RHS is a non-literal `Regex` variable
+- regex `match` arm applied to non-string subject
+
+Engine regression gates:
+- `make build`
+- `make fixpoint`
+- `make test`
+- `make test-pcre2`
+
+## Assumptions and Defaults
+
+- `Regex` stays a stdlib/prelude type; the compiler owns only the syntax and lowering.
+- V1 capture magic is intentionally narrow: direct positive conditions and regex `match` arms only.
+- Non-literal `Regex` values are supported for boolean matching, but not for magic `$...` locals.
+- Invalid regex literals are a loud runtime failure in this milestone; compile-time literal validation is a separate follow-up.
+- Full upstream `pcre2test` corpus and JIT are not blockers for this milestone.
+- After implementation, update `docs/regex-spec.md` and `docs/regex-plan.md` to reflect:
+  - compiler-known syntax + stdlib-owned data model
+  - direct-condition-only capture scope
+  - staged literal validation

--- a/docs/plans/zlib.md
+++ b/docs/plans/zlib.md
@@ -1,0 +1,364 @@
+# zlib Migration Proposal
+
+Migrate zlib to With using `with migrate`, providing native compression and decompression as `std.compress.zlib`.
+
+---
+
+## 1. What zlib Is
+
+zlib is a general-purpose lossless data compression library. It implements the DEFLATE compression algorithm (RFC 1951) and the zlib (RFC 1950) and gzip (RFC 1952) data formats.
+
+- ~15K lines of C (core library, excluding tests and examples)
+- zlib license (permissive, no attribution required)
+- Zero external dependencies
+- Cross-platform: every operating system, every architecture
+- The most widely deployed compression library in existence
+- Created by Jean-loup Gailly and Mark Adler, maintained continuously since 1995
+
+---
+
+## 2. Why
+
+zlib is infrastructure. It sits underneath everything:
+
+- **git objects** are zlib-compressed. libgit2 cannot function without zlib. This migration unblocks the libgit2 proposal.
+- **Package archives** (tar.gz, .zip) use DEFLATE. The package manager needs decompression to extract downloaded packages.
+- **HTTP content-encoding** uses gzip/deflate. The compiler's HTTP client (BearSSL-backed) needs decompression for compressed responses from package registries.
+- **PNG images** use DEFLATE for pixel data compression.
+- **ZIP files** use DEFLATE. Reading and writing .zip archives requires zlib.
+
+Without native zlib, every one of these capabilities requires either a system library link or an external tool. With native zlib, they are all self-contained.
+
+This is also the smallest and lowest-risk C library migration after PCRE2. It validates the migration tool on a different class of code (algorithmic/numerical rather than pattern-matching/state-machine) and produces a universally useful standard library module.
+
+---
+
+## 3. What It Enables
+
+### 3.1 Unblocks libgit2
+
+The primary immediate motivation. The libgit2 migration proposal is blocked on this. Every git read operation decompresses objects through zlib. Once `std.compress.zlib` exists, libgit2 migration can begin.
+
+### 3.2 Package management
+
+`with get` downloads compressed archives. Native decompression means no dependency on system `tar`, `gzip`, or `unzip`:
+
+```with
+use std.compress.zlib
+use std.io
+
+fn extract_tar_gz(archive_path: str, dest: str) -> Result[void, Error]:
+    let compressed = file.read_bytes(archive_path)
+    let decompressed = zlib.decompress(compressed)?
+    tar.extract(decompressed, dest)
+```
+
+### 3.3 HTTP content-encoding
+
+Package registries and APIs typically serve gzip-compressed responses. The HTTP client can decompress transparently:
+
+```with
+use std.compress.zlib
+use std.net.http
+
+fn fetch_json(url: str) -> Result[str, Error]:
+    let response = http.get(url)?
+    if response.header("Content-Encoding") == "gzip":
+        return zlib.gunzip(response.body_bytes())?
+    response.body()
+```
+
+### 3.4 Standard library compression
+
+General-purpose compression available to any With program:
+
+```with
+use std.compress.zlib
+
+// Compress data
+let original = file.read_bytes("large_file.dat")
+let compressed = zlib.compress(original, zlib.Level.Default)
+file.write_bytes("large_file.dat.gz", zlib.gzip(compressed))
+
+// Decompress data
+let data = file.read_bytes("archive.gz")
+let restored = zlib.gunzip(data)
+```
+
+### 3.5 Future: PNG, ZIP
+
+With native zlib, writing a PNG encoder/decoder or ZIP reader/writer becomes straightforward -- the hard part (DEFLATE) is already done.
+
+---
+
+## 4. Migration Plan
+
+### 4.1 Obtain and prepare
+
+```bash
+mkdir -p .reference/zlib
+curl -L https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz \
+    | tar xz -C .reference/zlib --strip-components=1
+```
+
+Pin to v1.3.1 (latest stable as of 2024, actively maintained).
+
+### 4.2 Source inventory
+
+zlib's source is compact and well-organized:
+
+```
+adler32.c    -- Adler-32 checksum (~50 lines of core logic)
+compress.c   -- One-shot compression convenience function (~30 lines)
+crc32.c      -- CRC-32 checksum with precomputed tables (~60 lines core)
+deflate.c    -- DEFLATE compression engine (~1800 lines, the largest file)
+gzclose.c    -- gzip file close (~30 lines)
+gzlib.c      -- gzip file utility functions (~300 lines)
+gzread.c     -- gzip file reading (~500 lines)
+gzwrite.c    -- gzip file writing (~400 lines)
+infback.c    -- Inflate using a callback interface (~300 lines)
+inffast.c    -- Fast inflate for short codes (~300 lines)
+inflate.c    -- DEFLATE decompression engine (~1500 lines)
+inftrees.c   -- Huffman tree construction for inflate (~300 lines)
+trees.c      -- Huffman tree construction for deflate (~1100 lines)
+uncompr.c    -- One-shot decompression convenience function (~30 lines)
+zutil.c      -- Utility functions (~100 lines)
+```
+
+Header files:
+
+```
+zlib.h       -- Public API (~1800 lines, mostly comments/documentation)
+zconf.h      -- Configuration/platform detection
+deflate.h    -- Internal deflate state
+inffast.h    -- Internal inflate fast-path declarations
+inflate.h    -- Internal inflate state
+inftrees.h   -- Internal tree structures
+trees.h      -- Static tree data
+zutil.h      -- Internal utility macros
+crc32.h      -- CRC-32 precomputed table
+gzguts.h     -- Internal gzip state
+```
+
+Total: ~7K lines of implementation code plus ~8K lines of headers, comments, and tables.
+
+### 4.3 What to migrate
+
+**Include (core compression):**
+- `adler32.c` -- checksum, needed by zlib format
+- `crc32.c` -- checksum, needed by gzip format
+- `deflate.c` + `trees.c` -- compression engine
+- `inflate.c` + `inffast.c` + `inftrees.c` -- decompression engine
+- `compress.c` + `uncompr.c` -- convenience one-shot functions
+- `zutil.c` -- utility functions
+- All internal headers
+
+**Include if needed (gzip file I/O):**
+- `gzlib.c` + `gzread.c` + `gzwrite.c` + `gzclose.c` -- gzip file operations. These wrap the core engine with FILE* I/O. May be better reimplemented in With using the runtime's file I/O rather than migrated, since they depend on C stdio.
+
+**Exclude:**
+- `infback.c` -- callback-based inflate interface, rarely used
+- Test programs, examples, contrib/
+
+### 4.4 Migrate
+
+```bash
+with migrate .reference/zlib/ \
+    -o lib/std/compress/zlib/ \
+    -I .reference/zlib \
+    --no-c-export \
+    --exclude minizip \
+    --exclude test \
+    --exclude examples
+```
+
+### 4.5 Expected migration challenges
+
+zlib is cleaner C than PCRE2. No computed gotos, no macro-heavy codegen, no bit-manipulation spells. The main challenges:
+
+- **Large precomputed tables** in `crc32.h` and `trees.h`. These are static const arrays. The migrator handles these (proven with PCRE2's character tables).
+- **Macro-heavy configuration** in `zconf.h`. Platform detection macros (`_WIN32`, `__linux__`, `__APPLE__`). The migrator's `#ifdef` handling resolves these to the target platform at migration time. For cross-platform support, migrate once per platform or abstract behind With's runtime platform layer.
+- **Pointer arithmetic in hot loops** in `deflate.c` and `inflate.c`. The migrator handles pointer arithmetic (proven with PCRE2). Performance-sensitive -- verify the migrated code produces the same output and comparable throughput.
+- **longjmp for error recovery** in `gzlib.c`. If present, the migrator will flag these. Replace with With's error handling (Result types or early returns).
+- **FILE* I/O** in the gzip file functions. These depend on C stdio. Better to reimplement the gzip convenience layer in With using runtime file I/O than to migrate the stdio wrappers.
+
+### 4.6 Build a With-native API layer
+
+The migrated code preserves zlib's C API. Layer a With-idiomatic API on top:
+
+```
+lib/std/compress/zlib/     -- migrated zlib internals (private)
+lib/std/compress.w         -- public With API
+```
+
+The public API:
+
+```with
+// lib/std/compress.w
+pub module zlib
+
+pub enum Level: i32:
+    None = 0
+    BestSpeed = 1
+    BestCompression = 9
+    Default = 6
+
+/// Compress data using the zlib format (RFC 1950).
+pub fn compress(data: &[u8], level: Level) -> Vec[u8]
+
+/// Decompress zlib-formatted data.
+pub fn decompress(data: &[u8]) -> Result[Vec[u8], Error]
+
+/// Compress data using the gzip format (RFC 1952).
+pub fn gzip(data: &[u8]) -> Vec[u8]
+
+/// Decompress gzip-formatted data.
+pub fn gunzip(data: &[u8]) -> Result[Vec[u8], Error]
+
+/// Compress raw DEFLATE (no header/trailer).
+pub fn deflate_raw(data: &[u8], level: Level) -> Vec[u8]
+
+/// Decompress raw DEFLATE.
+pub fn inflate_raw(data: &[u8]) -> Result[Vec[u8], Error]
+
+/// Streaming compressor for large data.
+pub type Deflater { ... }
+pub fn Deflater.new(level: Level) -> Deflater
+pub fn Deflater.write(self: mut Deflater, data: &[u8]) -> Vec[u8]
+pub fn Deflater.finish(self: mut Deflater) -> Vec[u8]
+
+/// Streaming decompressor for large data.
+pub type Inflater { ... }
+pub fn Inflater.new() -> Inflater
+pub fn Inflater.write(self: mut Inflater, data: &[u8]) -> Result[Vec[u8], Error]
+pub fn Inflater.finish(self: mut Inflater) -> Result[Vec[u8], Error]
+```
+
+---
+
+## 5. Verification
+
+### 5.1 Correctness
+
+zlib includes test vectors and a comprehensive test program. The primary correctness test:
+
+1. Compress known data with the migrated implementation.
+2. Decompress with the system zlib (or reference implementation) and verify the output matches.
+3. Compress with the system zlib, decompress with the migrated implementation, verify the output matches.
+4. Round-trip: compress then decompress, verify output equals input.
+5. Test edge cases: empty input, single byte, maximum compression, incompressible data, corrupted input (must return error, not crash).
+
+```bash
+# Generate test data
+dd if=/dev/urandom bs=1M count=10 of=/tmp/test_random.bin
+dd if=/dev/zero bs=1M count=10 of=/tmp/test_zeros.bin
+cp src/main.w /tmp/test_source.w
+
+# Round-trip test
+with run test/behavior/behav_zlib_roundtrip.w
+```
+
+### 5.2 Compatibility
+
+Compressed output must be decompressible by any standard zlib/gzip implementation. Decompress must handle any valid zlib/gzip stream produced by any implementation. Test against:
+
+- System zlib (`/usr/lib/libz`)
+- gzip command-line tool
+- Python's `zlib` module
+- Node.js `zlib` module
+
+### 5.3 Performance
+
+Compression and decompression throughput should be within 2x of the C reference implementation. zlib's hot loops are pointer-intensive -- the migrator's pointer arithmetic translation is correct but may not match hand-optimized C performance. This is acceptable; correctness is the priority.
+
+Benchmark:
+
+```with
+fn bench_compress(data: &[u8], iterations: i32):
+    let start = clock_nanos()
+    for _ in 0..iterations:
+        let _ = zlib.compress(data, zlib.Level.Default)
+    let elapsed = clock_nanos() - start
+    let mb_per_sec = (data.len() * iterations) as f64 / (elapsed as f64 / 1e9) / 1e6
+    print(f"compress: {mb_per_sec:.1} MB/s")
+```
+
+---
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Precomputed CRC/Huffman tables are large | The migrator handles static const arrays (proven with PCRE2 character tables). |
+| Pointer arithmetic in hot loops | The migrator handles pointer arithmetic (proven with PCRE2). Verify correctness with round-trip tests. |
+| Platform-specific optimizations (SSE, NEON) | zlib's core is portable C. Hardware-accelerated CRC is optional and can be added later. Migrate the portable path first. |
+| stdio-dependent gzip file I/O | Reimplement gzip convenience layer in With using runtime file I/O instead of migrating C stdio wrappers. |
+| Performance regression | Acceptable if within 2x. Correctness first. Optimize hot paths after migration if needed. |
+
+---
+
+## 7. Size Estimate
+
+| Component | Estimated LOC | Notes |
+|---|---|---|
+| Core migration output (deflate + inflate) | ~8-12K | Compression and decompression engines |
+| Checksum migration (adler32 + crc32) | ~1-2K | Including precomputed tables |
+| Utility migration | ~500 | zutil and internal helpers |
+| std.compress public API | ~200-400 | With-idiomatic wrapper |
+| Gzip convenience layer (reimplemented) | ~200-300 | With file I/O instead of C stdio |
+| Tests | ~300-500 | Round-trip, compatibility, edge cases |
+| **Total** | **~10-15K migrated** | Plus ~700-1200 hand-written |
+
+---
+
+## 8. Timeline
+
+This is a short migration. zlib is smaller than PCRE2 by 5x, cleaner C, and a well-understood algorithm. Estimated effort: 2-3 sessions.
+
+```
+Session 1: Migrate core (deflate, inflate, checksums, utilities)
+           Verify round-trip correctness
+Session 2: Build std.compress.zlib public API
+           Gzip convenience layer
+           Compatibility testing against system zlib
+Session 3: Performance baseline
+           Integration with existing HTTP client
+           Edge case and error handling tests
+```
+
+After this lands, the libgit2 migration proposal is unblocked.
+
+---
+
+## 9. What This Unblocks
+
+```
+std.compress.zlib (this proposal)
+  |
+  +--> libgit2 migration (std.git)
+  |      +--> build system: native git version/status
+  |      +--> with get: git-based package fetching
+  |      +--> with migrate: fetch from git URLs
+  |
+  +--> package archive extraction (tar.gz, .zip)
+  |      +--> with get: extract downloaded packages
+  |
+  +--> HTTP content-encoding (gzip)
+  |      +--> with get: compressed registry responses
+  |
+  +--> future: PNG, ZIP, compressed assets
+```
+
+---
+
+## 10. Success Criteria
+
+1. `std.compress.zlib` provides compress, decompress, gzip, and gunzip.
+2. Round-trip correctness: compress then decompress produces identical output for all test inputs.
+3. Cross-implementation compatibility: output is decompressible by system zlib, gzip, Python zlib.
+4. Cross-implementation compatibility: can decompress streams produced by system zlib, gzip, Python zlib.
+5. Works on Darwin, Linux, and Windows.
+6. No system zlib link required. The implementation is pure migrated With code.
+7. Performance within 2x of reference C implementation.
+8. `with build && with build :fixpoint && with build :test` all pass.
+9. libgit2 proposal is unblocked.

--- a/docs/stdlib_sourcing_plan.md
+++ b/docs/stdlib_sourcing_plan.md
@@ -1,8 +1,8 @@
 # Stdlib sourcing: three migrated corpora, one facade
 
-Status: PLAN (2026-09-01). Ruled in direction by Eric; nothing here is
-implemented. Paths are proposals in the repo's existing conventions, not
-part of the ruling. Companion: `docs/harden_migrate.md` (the migrator plan
+Status: PLAN (2026-09-01), with engine selections ruled on 2026-09-12.
+The selections below describe the destination, not completed migrations.
+Module grouping is provisional. Companion: `docs/harden_migrate.md` (the migrator plan
 this campaign exercises), `docs/harden_plan.md` item 7.
 
 ## The ruling
@@ -42,8 +42,9 @@ Three corpora with complementary roles, plus one surgical port:
 
 Outside the corpora, written natively: graph algorithms and union-find
 (too small for migration provenance to beat a native version), SlotMap's
-free list (#936 — no mature C library ships generational slot maps), and the
-intrinsic-integrated Vec and str, which stay as they are.
+free list (#936 — no mature C library ships generational slot maps).
+`Vec` moves to STC's engine while preserving its language integration;
+STC's `cstr` is used selectively without changing With's `str` contract.
 
 **The sourcing rule** (Eric, 2026-09-02). Why we take code from these
 libraries at all: **hardenedness**. ffmpeg, zlib, minicoro, pcre2 have
@@ -65,15 +66,86 @@ To confirm at pin time, not from memory: TommyDS's exact license text (its
 `COPYING`), and that c-algorithms is `void*` + comparator callbacks
 throughout (expected; it determines facade shape).
 
+## Facade and engine selection — Eric's ruling (2026-09-12)
+
+For With’s default `HashMap[K, V]` / `HashSet[T]` engine, we will use
+STC’s `hmap` / `hset`.
+
+STC’s current hash map uses Robin Hood hashing, stores keys/values directly
+in the table, and keeps a compact side table of hash/bucket metadata. That
+shape maps naturally onto the facade With wants: an owning generic
+`HashMap[K, V]`, rather than a C-style intrusive index over separately
+allocated objects.
+
+The facade map is explicit. The corpora are implementation engines; their
+names do not automatically become permanent standard-library API names.
+This ruling supersedes the earlier open engine choices in this plan.
+Benchmarks validate the selected engines and compare alternatives; changing
+a primary engine requires a new ruling.
+
+| `lib/std` facade | Primary engine | Secondary / comparison engine | Notes |
+| --- | --- | --- | --- |
+| `Vec[T]` | **STC `vec`** | TommyDS `array` | General growable contiguous sequence |
+| `Deque[T]` | **STC `deque`** | — | Double-ended queue |
+| `Stack[T]` | **STC `stack`** | — | Can remain a thin facade over the chosen sequence engine |
+| `Queue[T]` | **STC `queue`** | c-algorithms queue | FIFO queue |
+| `PriorityQueue[T]` | **STC `pqueue`** | c-algorithms binary heap | Heap-backed priority queue |
+| `List[T]` | **STC `list`** | c-algorithms list / TommyDS list | General linked list |
+| `HashMap[K, V]` | **STC `hmap`** | TommyDS `hashdyn` / `hashlin`; c-algorithms hash table | Default owning hash map |
+| `HashSet[T]` | **STC `hset`** | TommyDS hashing machinery | Same hash-table family as `HashMap` |
+| `OrderedMap[K, V]` | **STC `smap`** | c-algorithms RB tree / AVL tree | Public ordered associative map |
+| `OrderedSet[T]` | **STC `sset`** | c-algorithms RB tree / AVL tree | Public ordered set |
+| `BTreeMap[K, V]` | **M*LIB `m-bptree`** | — | B+ tree-backed ordered/indexed map |
+| `BTreeSet[T]` | **M*LIB `m-bptree`** | — | B+ tree-backed ordered set |
+| `Trie[V]` | **c-algorithms trie** | TommyDS `trie` / `trie_inplace` | Prefix-keyed lookup |
+| `BitSet` | **STC `cbits`** | — | Dynamic bitset |
+| `Span[T]` | **STC span machinery** | — | Non-owning contiguous view |
+| `String` / internal string engine | **STC `cstr` where useful** | Existing With string implementation | Use STC selectively; With’s existing `str` semantics remain the public contract |
+| `SortedVec[T]` | **c-algorithms sorted array** | STC algorithms + `Vec` | Sorted contiguous collection |
+| `ChunkedVec[T]` / internal block storage | **TommyDS `arrayblk`** | — | Growth without one large contiguous realloc; possibly internal rather than public |
+| `Index[T]` / intrusive object index | **TommyDS `hashtable` / `hashdyn`** | — | Internal/specialized rather than everyday `std` API |
+| `IncrementalHashIndex[T]` | **TommyDS `hashlin`** | — | Specialized incremental-resize hash index; likely internal |
+| `BinaryHeap[T]` | **c-algorithms binary heap** | STC `pqueue` | Could expose separately from `PriorityQueue` if desired |
+| `RbTree[K, V]` | **c-algorithms RB tree** | — | Could stay internal behind `OrderedMap` |
+| `AvlTree[K, V]` | **c-algorithms AVL tree** | — | Alternate/internal ordered-tree engine |
+| `sort` | **STC algorithm layer** | — | With-generic facade over migrated implementation |
+| `stable_sort` | Evaluate / implement separately | — | Only map if upstream provides the required stability contract |
+| `binary_search` | **STC algorithms** | c-algorithms sorted-array logic | Shared generic algorithm |
+| `lower_bound` / `upper_bound` | **STC algorithms** | c-algorithms | Useful with `Vec`, `Span`, sorted collections |
+| `reverse` | **STC algorithms** | — | Generic sequence algorithm |
+| `shuffle` | **STC algorithms** | — | With RNG passed through facade |
+| `find` / search helpers | **STC algorithms** | — | Where available and semantically appropriate |
+| Heap algorithms | **STC `pqueue` / c-algorithms heap** | — | Support `PriorityQueue` and possibly generic heap utilities |
+
+The public surface is grouped roughly as follows:
+
+- `std.collections`: `Vec`, `Deque`, `Stack`, `Queue`, `PriorityQueue`,
+  `List`, `HashMap`, `HashSet`, `OrderedMap`, `OrderedSet`, `BTreeMap`,
+  `BTreeSet`, `Trie`, `BitSet`, and perhaps `SortedVec`.
+- `std.slice` / `std.span`: non-owning sequence/view machinery.
+- `std.algorithms`: `sort`, `binary_search`, bounds searches, `reverse`,
+  `shuffle`, and the other generic sequence algorithms.
+
+Several imported structures remain engines rather than public types.
+TommyDS `hashdyn`, `hashlin`, `arrayblk`, c-algorithms’ AVL/RB trees,
+and perhaps the raw M*LIB B+ tree can sit underneath the public facade
+without forcing their implementation names into the permanent API.
+Optional exposure in the table remains optional.
+
+**STC provides most everyday containers and algorithms; c-algorithms
+supplies the classical trees/heaps/trie and reference implementations;
+TommyDS supplies specialized high-performance indexing/storage engines;
+M*LIB supplies the B+ tree.**
+
 ## Why the un-facaded code is not waste
 
 Everything migrated compiles in the battery whether or not a facade uses
 it. That gives:
 
 - migration regression coverage on real generic C, forever;
-- alternative engines under identical With compilation, so facades choose
-  winners by benchmark, not by reputation (five migrated hash tables
-  underneath, exactly one exposed);
+- alternative engines under identical With compilation, so benchmarks
+  validate the selected primary engines and quantify tradeoffs (several
+  migrated hash tables underneath, exactly one default facade);
 - examples for future facade expansion;
 - a standing corpus for finding migrator bugs;
 - internal assumptions kept intact — no partial fork where `sort.h` came
@@ -123,9 +195,9 @@ bundle's upstream tests, plus the `wo-drift` lane from `docs/wo_bundles.md`.
   `remove` transfers, when elements drop, and how Drop-class elements are
   released when the container drops. The drop audit gains cells per facade
   (fully consumed, partially consumed then dropped, zero elements).
-- **One engine per abstraction**, chosen by benchmark across the corpora
-  under identical compilation; the choice is recorded next to the facade
-  with the numbers.
+- **One primary engine per abstraction**, selected in the facade map above.
+  Benchmark it against comparison engines under identical compilation and
+  record the numbers next to the facade.
 - **A complexity fixture per facade** (insert N descending then ascending,
   lookups, removals; a wall-clock bound an O(n²) cliff cannot meet), run in
   the battery. This is the guard that was missing.
@@ -199,7 +271,7 @@ every `T` the engine indexes.
   empty, full, after partial removal, after a consuming iteration
   abandoned midway (D33: the iterator owns the tail).
 - *Callbacks.* Engines take `int (*cmp)(const void*, const void*)` and
-  hash functions. A generic facade `BTreeMap[K: Ord, V]` supplies a
+  hash functions. A generic engine adapter `RbTree[K: Ord, V]` supplies a
   monomorphized With `fn` per `K` (With generics are monomorphized, so
   `fn(*const u8, *const u8) -> i32` wrapping `K < K` exists per
   instantiation), plus a context pointer where the engine offers one.
@@ -211,29 +283,32 @@ every `T` the engine indexes.
   traversal yielding `&T` views (the `VecIter` shape); `into_iter()`
   transfers elements out in order and its drop releases the rest.
 
-**Sketch: `BTreeMap[K, V]` over c-algorithms' red-black tree**
+**Sketch: an internal `RbTree[K, V]` adapter over c-algorithms**
+
+This illustrates ownership for a comparison engine. The selected public
+`OrderedMap` uses STC's `smap`; `BTreeMap` uses M*LIB's B+ tree.
 
 ```
 use std.c_algorithms.rb_tree        // raw: RBTree, rb_tree_new(cmp), rb_tree_insert(tree, key, value), rb_tree_lookup, rb_tree_remove, rb_tree_free …
 
-pub type BTreeMap[K, V] {
+type RbTree[K, V] {
     tree: *mut RBTree,              // engine handle (raw)
     nodes: EntryArena[K, V],        // facade-owned stable storage for (K, V)
 }
 
-impl[K: Ord, V] BTreeMap[K, V]:
-    pub fn new() -> BTreeMap[K, V]:
-        BTreeMap { tree: rb_tree_new(btree_compare[K]), nodes: EntryArena.new() }
+impl[K: Ord, V] RbTree[K, V]:
+    pub fn new():
+        RbTree { tree: rb_tree_new(rb_compare[K]), nodes: EntryArena.new() }
     pub fn get(key: &K) -> Option[&V]:            // observes: engine pointer typed as a view
         let node = rb_tree_lookup_node(self.tree, key as *const u8)
         if node == null: None else: Some(self.nodes.value_view(node))
     pub mut fn insert(key: K, value: V) -> Option[V]:  // returns the displaced value, if any
         …move (key, value) into the arena; rb_tree_insert with the slot's address…
     pub mut fn remove(key: &K) -> Option[V]:      // transfers out; slot freed; no second copy
-    pub fn iter() -> BTreeIter[K, V]              // ephemeral cursor: rb_tree_root_node → successor walk, yields (&K, &V)
+    pub fn iter() -> RbTreeIter[K, V]             // ephemeral cursor: rb_tree_root_node → successor walk, yields (&K, &V)
     move fn drop():                                // drop every (K, V) in the arena, then rb_tree_free
 
-fn btree_compare[K: Ord](a: *const u8, b: *const u8) -> i32:   // the monomorphized callback
+fn rb_compare[K: Ord](a: *const u8, b: *const u8) -> i32:   // the monomorphized callback
     …view both as &K and compare…
 ```
 
@@ -260,13 +335,14 @@ pub mut fn Vec[T].sort_by(cmp: fn(&T, &T) -> i32) -> Unit:
 §comptime, "dead branches are not instantiated") is the tool. The shape set
 is declared in one place next to the facade, benchmarked, and extended by
 adding an instantiation to the corpus's build inputs — never by editing
-migrated code. Where a byte engine is faster or simpler for all shapes,
-the facade uses it for all shapes; the point is that both answers keep
-the migrator raw.
+migrated code. This earlier sketch illustrates shape adaptation; it does
+not settle arbitrary-`T` support for the selected STC engine. That support
+must be demonstrated in Phase 3 without silently substituting another
+primary engine.
 
-**Sketch: `Deque[T]`, `Heap[T]`, `BitSet`**
+**Sketch: `Deque[T]`, `PriorityQueue[T]`, `BitSet`**
 
-Same anatomy: `Deque[T]` and `Heap[T]` own storage and wrap the engine's
+Same anatomy: `Deque[T]` and `PriorityQueue[T]` own storage and wrap the engine's
 ring buffer / binary heap through the raw modules with the callback per
 `T`; `BitSet` is the simplest case — STC's `cbits` is not generic, so the
 facade is an owning handle plus `mut fn set(i)`, `fn test(i) -> bool`,
@@ -274,45 +350,52 @@ iteration over set bits, and `move fn drop()`, the `Regex` shape exactly.
 
 **Facade surfaces (the contracts the fixtures pin)**
 
-| Facade | Engine candidates | Surface | Complexity contract |
+| Facade | Primary engine | Surface | Complexity contract |
 |---|---|---|---|
-| `HashMap[K, V]` / `HashSet[T]` | `rt_core` (today), c-algorithms hash-table, TommyDS `hashdyn`/`hashlin` | `get(&K) -> Option[&V]`, `insert(K, V) -> Option[V]`, `remove(&K) -> Option[V]`, `iter()` views | O(1) expected; delete O(cluster), no allocation |
-| `BTreeMap[K, V]` / `BTreeSet[T]` | c-algorithms RB/AVL, M*LIB B+ tree | as above plus `first`/`last`, `range(&K, &K)`, ordered `iter()` | O(log n) all ops |
-| `Heap[T]` | c-algorithms binary heap, STC `pqueue` | `push(T)`, `pop() -> Option[T]`, `peek() -> Option[&T]` | O(log n) push/pop, O(1) peek |
+| `HashMap[K, V]` / `HashSet[T]` | STC `hmap` / `hset` | `get` observes, `insert` owns inputs, `remove` transfers, `iter()` views | O(1) expected; delete O(cluster), no allocation |
+| `OrderedMap[K, V]` / `OrderedSet[T]` | STC `smap` / `sset` | ordered lookup, insertion, removal, range traversal | O(log n) lookup/insert/remove |
+| `BTreeMap[K, V]` / `BTreeSet[T]` | M*LIB `m-bptree` | ordered lookup, insertion, removal, range traversal | O(log n) lookup/insert/remove |
+| `PriorityQueue[T]` | STC `pqueue` | `push(T)`, `pop() -> Option[T]`, `peek() -> Option[&T]` | O(log n) push/pop, O(1) peek |
+| `BinaryHeap[T]` (optional public type) | c-algorithms binary heap | owning heap operations | O(log n) push/pop, O(1) peek |
 | `Deque[T]` | STC `deque` | `push_front/back(T)`, `pop_front/back() -> Option[T]`, `get(i) -> &T` | O(1) amortized ends, O(1) index |
 | `BitSet` | STC `cbits` | `set/clear/test`, `count`, `iter()` | O(1) bit ops, O(n/64) count |
-| `Vec[T].sort`, `sort_by`, `binary_search`, `lower_bound` | STC algorithms (shape set), byte engine | in-place, deterministic, stable variant for `sort_by` | O(n log n), O(log n) |
-| `Trie` | c-algorithms trie, TommyDS `trie` | `insert(&str, V)`, `get(&str)`, prefix iteration | O(key length) |
+| `Vec[T].sort`, `sort_by`, `binary_search`, `lower_bound` | STC algorithms | generic sorting and search; stability promised only for a verified `stable_sort` | O(n log n), O(log n) |
+| `Trie[V]` | c-algorithms trie | `insert(&str, V)`, `get(&str)`, prefix iteration | O(key length) |
+| `SortedVec[T]` | c-algorithms sorted array | sorted insertion, lookup, removal, views | O(log n) search, O(n) insert/remove |
 | `SlotMap[T]` (native) | `rt_core` + FIFO free list (#936) | unchanged | O(1) insert/remove/lookup |
 
 Each row gets its complexity fixture in the battery and its drop-audit
-cells; the engine column is decided by the benchmark table, not by this
-document.
+cells. These are facade planning sketches; existing language ownership and
+view contracts remain authoritative. Engine selection follows the ruling
+above, with benchmark evidence recorded during implementation.
 
 ## Phases and gates
 
 **Phase 0 — measure first (small, immediate).**
 The complexity-fixture lane and a stdlib inventory (`docs/stdlib_inventory.md`:
 every structure and algorithm we need, its complexity contract, current
-status). Winners cannot be chosen without the yardstick. SlotMap's native
+status). Engine validation needs this yardstick. SlotMap's native
 free list (#936) lands here too. Gate: lane green on today's containers
 with the known cliffs recorded as expected failures.
 
 **Phase 1 — c-algorithms, whole.**
 The first container corpus through the pipeline; non-macro C, so the
 migrator work is the facade-shaped `void*` + callback idiom, not templates.
-Facades: `BTreeMap`/`BTreeSet` (RB or AVL, retiring the sorted-Vec
-implementation, #937), `Heap`/`PriorityQueue`, sorted array, trie; the hash
-table as the first alternate engine to benchmark against `rt_core`'s.
+Facades: `Trie`, `SortedVec`, and an owning binary-heap adapter, optionally
+exposed as `BinaryHeap`. RB/AVL trees and the hash table remain internal or
+comparison engines. This phase does not replace the default hash maps,
+`OrderedMap`, `PriorityQueue`, or `BTreeMap` with c-algorithms engines.
 Gate: upstream `test/` passes under With; facades' complexity fixtures
-green; drop audit green; #937 closed.
+green; drop audit green; comparison measurements recorded. #937 is retired
+by the M*LIB-backed `BTreeMap`/`BTreeSet` work in Phase 4.
 
 **Phase 2 — TommyDS, whole.**
-Performance engines: `hashdyn`/`hashlin` benchmarked against the Phase 1
-hash table and `rt_core`'s (#939 becomes "which engine wins", not a patch),
-tries, blocked arrays. The facade design item is node ownership (above).
-Gate: `check.c` passes under With; benchmark table recorded; HashMap
-engine decision made with numbers.
+Specialized indexing/storage engines: `hashtable`, `hashdyn`, `hashlin`,
+tries, and `arrayblk`. Benchmark the hash engines against Phase 1's hash
+table and today's `rt_core` engine; STC remains the selected default owning
+map engine. The facade design item is node ownership (above).
+Gate: `check.c` passes under With; benchmark table recorded; specialized
+adapters have complexity and drop evidence. #939 remains a Phase 3 gate.
 
 **Phase 3 — STC, whole: the macro-migrator campaign.**
 STC is valuable because its template mechanism is nasty: containers are
@@ -333,18 +416,28 @@ POD, `str`, fat views — STC's own instantiation set, extended in the
 corpus's build inputs when a shape is missing), or
 (b) the facade routes arbitrary `T` to a `void*` + `elem_size` engine from
 c-algorithms/TommyDS and keeps the STC engine for the concrete shapes it
-covers. Both keep the migrator raw; both are decided by benchmark and
-recorded next to the facade.
-Facades: `Deque`, `BitSet` (`cbits` is not generic — raw fits it
-directly), `Vec.sort`/`sort_by`/`binary_search`/`lower_bound` (#940),
-sequence algorithms; `VecIntoIter`'s cursor (#938) either from STC's vec
-iteration or native, by benchmark. Gate: STC's own `tests/` pass under
-With with no corpus-specific migrator code; #940 and #938 closed.
+covers. Both keep the migrator raw, but the second approach predates the
+engine-selection ruling above and is a comparison approach, not approval
+to replace STC for arbitrary `T`. Phase 3 must demonstrate how the selected
+STC engines support the generic facade contracts and record that design
+with benchmark evidence.
+Facades: `Vec`, `Deque`, `Stack`, `Queue`, `PriorityQueue`, `List`,
+`HashMap`/`HashSet`, `OrderedMap`/`OrderedSet`, `BitSet`, spans, and
+generic sequence algorithms including sorting and searches (#940).
+Use `cstr` selectively while preserving With's `str` semantics.
+`VecIntoIter` must use a linear cursor (#938); default hash deletion must
+meet the no-allocation complexity contract (#939).
+Gate: STC's own `tests/` pass under With with no corpus-specific migrator
+code; facade complexity fixtures and drop audit green; #938, #939, and
+#940 closed. Evaluate `stable_sort` separately against its stability
+contract before exposing it.
 
 **Phase 4 — M*LIB `m-bptree.h`, surgical.**
-Only the B+ tree, benchmarked against the Phase 1 tree for the ordered-map
-engine; the facade keeps whichever wins. Gate: M*LIB's bptree tests pass;
-decision recorded.
+Only the B+ tree, providing `BTreeMap`/`BTreeSet` and retiring their
+sorted-Vec implementation (#937). Benchmark against Phase 1's RB/AVL
+comparison engines; `OrderedMap`/`OrderedSet` retain STC's `smap`/`sset`.
+Gate: M*LIB's bptree tests pass under With; facade complexity fixtures and
+drop audit green; comparison measurements recorded; #937 closed.
 
 Order is fixed by risk: 1 validates the whole-corpus pipeline on a
 container library, 2 adds the performance yardstick, 3 is the campaign, 4
@@ -355,19 +448,22 @@ is a bounded extra.
 Each phase is done only when: the corpus migrates from its pin with zero
 hand edits; its upstream tests pass under With; every migrator change made
 for it is general (no corpus name in `with migrate`); the facades it feeds
-have complexity fixtures and drop-audit cells; the engine choice is
-recorded with numbers; and the issues it retires are closed with evidence.
+have complexity fixtures and drop-audit cells; the selected engine is
+implemented with benchmark evidence; and the issues it retires are closed
+with evidence.
 A green build with a silently mishandled corpus is 0% done (§"Good enough
 for now").
 
 ## Open questions for Eric
 
-1. (Ruled: D37 — the migrator is raw; generic facades over templated
-   engines choose between a declared instantiation set and a byte-engine
-   in Phase 3, by benchmark.)
+1. D37 settles that the migrator is raw, and the facade map settles primary
+   engines. Phase 3 still needs to demonstrate arbitrary-`T` support over
+   STC's concrete instantiations; comparison engines do not silently
+   become defaults.
 2. Where the corpora live and whether all of them build in every battery
    (proposal: yes, in a `corpora` lane — the coverage is the point; cost is
    build time, measured in Phase 1).
-3. Whether Phase 0's inventory should also rule on names and surfaces now
-   (`Heap` vs `PriorityQueue`, `BitSet` API), or leave that to each facade
-   PR.
+3. The facade map above settles primary engines and the broad public
+   grouping. Optional public types (`BinaryHeap`, `SortedVec`, specialized
+   indexes/storage) and detailed new API signatures remain facade-PR
+   decisions.

--- a/docs/storage-types-and-caller-places-implementation.md
+++ b/docs/storage-types-and-caller-places-implementation.md
@@ -1,0 +1,818 @@
+# Storage Types and Caller-Place Parameters — Implementation Notes
+
+Companion to `storage-types-and-caller-places-spec.md`. This document
+says how to build the feature in the With compiler: which modules
+change, in what order, what each stage must prove before the next
+starts, and where the tests go. Module and function names below were
+checked against `src/` at the time of writing; line numbers are omitted
+because they rot.
+
+Governing discipline, unchanged from the D22 and fn-ABI campaigns: every
+stage lands behind a green test suite, every rule in the spec gets a
+pinned fixture, and no stage may regress an existing lane. Behavior-
+neutral refactors land first and separately from behavior changes.
+
+---
+
+## 0. Dependency order
+
+```
+S1  physical-type capabilities (BitwiseCopyable / AnyBitPattern)
+S2  storage type: parse, declare, layout check
+S3  storage projections as places + origin facts
+S4  storage codegen
+S5  storage reflection + diagnostics polish
+        │
+P1  ParamMode in signatures + call-site spelling
+P2  FnAbi alias contract + codegen attrs
+P3  borrow checker: exclusivity, byref class, no-move-out
+P4  reservation between designator evaluation and invocation
+P4b returned-view provenance across calls
+P5  suspend / first-class / closure restrictions
+P6  intra-callee byref may-alias
+```
+
+S1–S5 have no dependency on P. P3 depends on S3 (origin overlap facts).
+P1–P2 can proceed in parallel with S2–S4.
+
+**Feature gate.** `inout`/`byref` in source programs remain rejected
+(or accepted only under an internal `--enable-caller-places` gate used
+by the test lanes) until *every* P stage, P1 through P6 including P4b,
+has landed. "P6 landed" below is shorthand for that. Every intermediate state is unsafe
+for real programs: after P1 alone, `byref` inherits today's `noalias`;
+after P2 before P3, overlapping `inout` is accepted with an exclusive
+ABI contract; before P4, a projected place can go stale during argument
+evaluation; before P4b, a view returned from `fn balance(r: inout Rec) -> &i32`
+carries no caller origin and the borrow checker's cross-call facts are
+wrong; before P6, the callee's alias model is incomplete. The
+refactors land separately and green; the *language* feature lands once.
+Accordingly, S4 + P2 (a storage value passed `inout`, projection
+mutated, round-tripped through LLVM) is an internal lowering milestone,
+not a usable-language milestone.
+
+---
+
+## Part A — Storage types
+
+### S1. Capabilities
+
+**Where.** `SemaTypes.w` (type property queries), `SemaDecl.w` (derive
+at declaration), `CapabilityRegistry.w` if the existing registry is the
+right home for compiler-derived traits (check before adding a parallel
+mechanism).
+
+**What.**
+- Two new derived predicates on `TypeId`: `is_bitwise_copyable(ty)` and
+  `is_any_bit_pattern(ty)`. Both memoized per type like the existing
+  `Copy` query.
+- Base cases: fixed-size integers (both), `f32`/`f64` (`BitwiseCopyable`
+  only — NaN payloads are valid bits, but keep floats out of
+  `AnyBitPattern` for v1 to avoid a debate we don't need), `bool`
+  (`BitwiseCopyable` only; `2` is not a `bool`), `bytes[K]` (both),
+  raw pointers (`BitwiseCopyable` only).
+- Structural cases: `[T; K]` inherits both from `T`. A `@[repr(C)]` or
+  `@[repr(packed)]` struct is `BitwiseCopyable` iff every field is and it
+  has no `Drop`; `AnyBitPattern` iff every field is *and there is no
+  padding* (padding bytes are unspecified, so the struct's size has
+  bits not covered by any field — treat as not `AnyBitPattern` unless
+  packed with no gaps).
+- Storage types (S2) are both by construction.
+- `impl Drop` anywhere in the type → not `BitwiseCopyable`.
+- Ephemeral types (§5) → neither.
+- A `@[physical]` attribute (std/compiler-internal; rejected in user
+  code) requests exact layout: alignment 1, no padding, size = sum of
+  fields, and **every field must itself have alignment 1** (`u8`, `i8`,
+  `[u8; N]`, other `@[physical]` types). Otherwise ordinary field access
+  on a `@[physical]` value at an odd address would need its own
+  unaligned lowering; keeping fields at alignment 1 means `@[physical]`
+  needs no codegen support at all. It does **not** assert either
+  capability. The compiler still
+  derives `BitwiseCopyable` and `AnyBitPattern` structurally from the
+  fields, so `@[physical] type Bad { flag: bool }` is `BitwiseCopyable`
+  but not `AnyBitPattern` and is rejected as a projection type. This is
+  how `text[N, Enc]` and `packed_dec[P, S]` are declared without
+  compiler special cases, and without the attribute being able to lie.
+
+**Tests.** `test/compile_errors/` fixtures for each false case (a type
+with `Drop` claimed bitwise; a padded struct claimed any-bit-pattern);
+`test/comptime_diff/` fixtures asserting `T.is_bitwise_copyable()` via
+reflection once S5 exposes it.
+
+**Done when.** Both predicates are queryable, memoized, and pinned.
+
+### S2. Parse, declare, layout check
+
+**Where.** `Lexer.w` (no new token kinds; `storage`, `overlay`, `at` are
+contextual identifiers), `Parser.w`/`Parse.w` (new decl form), `Ast.w`
+(`TypeDeclKind.Storage = 7`; a new node kind for a projection carrying
+`(name, type_node, offset, overlay_group)`), `SemaDecl.w` (declaration
+and layout verification).
+
+**Parsing.** `storage` is recognized only as the first token of a
+declaration when followed by `type`. Inside a storage body, `at` is
+recognized only after a type expression. `overlay at N:` opens an
+indented block; projections inside default to offset `N` and may add
+`at K` for `N + K`. Record for each projection: byte offset, overlay
+group id (0 = none), source span. Do not compute size yet.
+
+**Declaration (SemaDecl).** v1 declarations are concrete: `N` is an
+integer literal and projection types are concrete (generic storage is
+deferred; see spec A.8). After the projection types resolve:
+1. Verify `N > 0`. Verify `align(A)` if present: `A` power of two,
+   `N % A == 0`.
+2. For each projection: resolve the type, require `is_bitwise_copyable
+   and is_any_bit_pattern` (S1), compute `size = sizeof(type)`, range
+   `[offset, offset + size)`, require range within `[0, N)`.
+3. Overlap check. Adjacent-pair comparison after sorting is *not*
+   sufficient (`A=[0,100)`, `B=[10,20)`, `C=[30,40)`: A–B and A–C
+   intersect but B–C do not, so an adjacent walk misses A–C). Use an
+   active-interval sweep:
+
+   ```
+   sort projections by start
+   for each P:
+       retire active projections whose end <= P.start
+       for each still-active Q: if Q.group != P.group or P.group == 0:
+           error(overlap, P, Q, intersection)
+       add P to active
+   ```
+
+   With copybook-scale counts, plain O(n²) pairwise comparison is also
+   acceptable and easier to audit; either is fine, adjacent-pair is not.
+4. Reject `impl Drop for` the storage type at the impl site
+   (`SemaDecl.w` impl handling), reject ephemeral flag on the decl.
+4a. Recursive views: add storage types to the declaration-cycle audit,
+   but with their own rule. A projection whose type is (or transitively
+   projects) the enclosing storage type is rejected with
+   `err_storage_recursive_view` — *not* by the existing infinite-size
+   aggregate cycle checker, which would either mis-diagnose it as
+   infinitely sized or, worse, accept it because projections add no
+   size. Mutual reference between two storage types is rejected the same
+   way. Fixture: `err_storage_recursive_view.w`, `err_storage_mutual_view.w`.
+5. Record the storage type's layout as `(N, align, projections)` in the
+   type table. Layout is *declared*; the existing struct-layout
+   computation in `Codegen.w` (`wl_struct_set_body` path) must not run
+   for `Storage`.
+
+**Fieldwise initializer.** In `SemaCheck.w`'s struct-literal path, a
+literal whose type is `Storage` is an error with the `zeroed()` /
+`from_bytes()` suggestion. Add `zeroed` and `from_bytes` as compiler
+intrinsics on storage types (or as generated methods; intrinsic is
+simpler for v1 since they are a `memset` and a `memcpy`). There is no
+literal construction form in v1; `from_bytes` already covers it.
+
+**Tests.** `test/compile_errors/err_storage_*.w` for every S2
+diagnostic. `test/behavior/behav_storage_decl_sizes.w` asserting
+`sizeof` and array stride via existing size-probe helpers.
+
+**Done when.** A storage type declares, all layout diagnostics fire, and
+`sizeof(T) == N` for an array element.
+
+### S3. Projections as places; origin facts
+
+**Where.** `SemaCheck.w` (place classification, view-origin machinery
+around `compute_expr_view_origin_mask` and `set_sig_param_view_origin`),
+`BorrowCfg.w` if the CFG walk needs a new place kind, `Mir.w`/`MirCore.w`
+(a place projection variant).
+
+**Place kind.** Add a place projection `StorageField(base_place, offset,
+size, overlay_group)`. *Every* subprojection below a storage root
+refines the flattened `(root_place, [lo, hi))`, not only nested
+`storage` fields: ordinary field access on an admissible physical type
+(`r.header.code`, `r.balance.raw[2]`), and array indexing (`r.items[0]`).
+A constant index narrows to the exact element range; a runtime index
+keeps the enclosing array's range (a later pass may use index facts to
+narrow `i != j`). The borrow checker never sees a chain, only the
+flattened range on the root. This is rule A.5.4 and it is what makes
+the overlap query cheap; it is also what makes `inout r.items[0], inout
+r.items[1]` provably disjoint, which the `OCCURS` modernization path
+depends on. Fixtures: `behav_storage_index_disjoint_inout_ok.w`,
+`err_storage_runtime_index_inout_overlap.w`.
+
+**Overlap query.** Two storage places on the same root overlap iff their
+ranges intersect. Two storage places on different *owned* roots never
+overlap. Two places whose roots are `byref` parameters in a common
+may-alias class (P6) are *potentially overlapping* regardless of
+syntactic root; the query must consult the class, and this is the same
+query used by every overlap check (call arguments, guards, mutating
+receivers, nested calls), not only view invalidation. A storage place
+and a whole-value access of its root overlap. Until P6 lands, the query
+treats every pair of `byref`-rooted places as potentially overlapping
+(maximally conservative), which is one more reason the feature stays
+gated. This query is used by:
+- existing `mut self` argument conflict checks (a projection of the
+  receiver's root passed as an argument), and
+- P3's `inout`/`byref` checks.
+
+**Reads and writes.** A projection *write* stores a value
+(`store_bytes(place, temp, size)`). A projection *read* in an owned
+context (`let x = r.f`, owned argument, return) is permitted only when
+the projection type is `Copy`; it then materializes as a byte copy into
+a temporary (MIR: `load_bytes(place, size)` → temp). For a non-`Copy`
+projection type, the owned demand is rejected with a diagnostic pointing
+at the type and suggesting a borrow, `inout`/`byref`, or an explicit
+snapshot. This is the `BitwiseCopyable` vs. `Copy` split enforced at the
+read: the former lets *codegen* move bytes (whole-value `=`, `byref`
+marshalling, `memcpy` lowering), the latter lets *source* duplicate a
+value. Wire this through the same owned-demand resolution used by D22
+(`resolve_contextual_join` and the owned-anchor path), not as a separate
+check, so it behaves identically to any other non-`Copy` place. Neither touches the
+union last-written tracking (`Sema.w`'s `union_last_written`); storage
+overlays are a different kind and that map must not be consulted for
+them. Add an assertion in `SemaCheck.w` that a `Storage` place never
+reaches the union tracking path.
+
+**Views.** `&record.field` is permitted when the alignment proof (rule
+A.5.6) passes. Implement the proof as: `guaranteed_align(root_place)`
+(1 for a storage local unless `align(A)` was declared, or the target's
+guarantee if the root is a known-aligned allocation) combined with the
+offset via `gcd(align, offset)` for offset ≠ 0, then compared against
+`alignof(T)`. Emit the under-aligned diagnostic otherwise. Views derived
+from a projection carry the root as their view origin using the existing
+origin mask machinery, so §21's rules apply unchanged.
+
+**`prefix(n)`.** Implement as a compiler-recognized method on `[P; K]`
+projections returning a read slice view over `[0, n*sizeof(P))` of the
+projection's range; bounds-check `n <= K` at runtime. Origin: the root.
+It is a typed view, so it is subject to the same alignment proof as
+`&P`; on an under-aligned `[u32; 4] at 1` it is rejected. The same
+applies to `with r.field as mut b:` place aliases. Add fixtures
+`err_storage_prefix_unaligned.w` and `err_storage_with_alias_unaligned.w`
+alongside `err_storage_unaligned_ref.w`.
+
+**Tests.** `test/behavior/behav_storage_overlay_read.w` (write via one
+overlay member, read via the other, assert bytes);
+`err_storage_owned_read_non_copy.w` (`let c = parent.child` for a
+non-`Copy` nested storage type); `behav_storage_owned_read_copy_ok.w`
+(same shape with `impl Copy for Child`); `behav_storage_non_copy_place_ok.w`
+(borrow / `inout` / assign to a non-`Copy` projection all fine); `behav_storage_nested_origin.w`
+(mutate `r.address.zip`, confirm a live `&r.address` view is rejected —
+a `compile_errors` fixture); `err_storage_unaligned_ref.w`.
+
+**Done when.** Overlapping projections are readable and writable in safe
+code; the borrow checker rejects a live view across an overlapping write;
+the alignment proof fires correctly for `at 4` in an align-1 type.
+
+### S4. Codegen
+
+**Where.** `Codegen.w` (type lowering; `declare_function` is untouched),
+`CodegenDispatch.w` (MIR op lowering).
+
+**Note on `bytes[N]`.** Wherever the spec says `bytes[N]` it means
+`[u8; N]`. No new type is introduced by this campaign; if a prelude alias
+is wanted, it is a one-line std change.
+
+**Type lowering.** A storage type lowers to `[N x i8]`. Never to an LLVM
+struct with typed fields. `align(A)` is recorded in the central
+type-layout record (`SemaTypes.w`, wherever `alignof` is answered), not
+inferred from the LLVM byte-array type: every site that asks `alignof`,
+lays a storage value inside another aggregate, allocates one, or
+classifies its ABI (`fn_abi_platform_aggregate_indirect`) reads that
+record. The LLVM `alloca`/global gets the matching `align` attribute
+from the same source. This means the
+existing `wl_struct_set_body` path is bypassed for `Storage`.
+
+**Projection access.** `load_bytes(place, size)`: GEP `i8` to
+`root + offset`, then load the projection's *actual* codegen value type
+with `align 1`, or `memcpy` into a correctly aligned alloca of that type
+and load it. Do **not** reconstruct aggregates, `[u8; K]`, storage
+values, or `@[physical]` wrappers from an `i<size*8>` integer; that is
+both a representation mismatch and an endianness trap for a future
+big-endian target. The `iN` shortcut is permitted only when the
+projection type's codegen representation *is* that integer (`u32`,
+`i64`, ...). Projection access performs **no conversion**; an
+explicit-endian type such as `be_i32` is an alignment-1 `[u8; 4]`
+physical type whose `.value()`/`.store()` perform the interpretation,
+exactly like `packed_dec`. Do not hide a byte swap in projection
+loading. Fixed-size `memcpy` optimizes away
+readily; do not micro-optimize here. Store is symmetric. Never emit a
+typed load at the projection type with its natural alignment; that is
+exactly the UB the spec rules out.
+
+**Whole-value assignment.** `=` between storage values (including
+storage-typed *projections*) lowers by overlap class, using S3's range
+query on the two places:
+
+```
+known disjoint (or distinct owned roots)  → memcpy(N)
+identical place                           → no-op permitted
+possible overlap                          → memmove(N), or RHS into a
+                                            temporary then memcpy
+```
+
+`r.a = r.b` with `a` and `b` overlapping projections must leave `r.a`
+holding the pre-assignment bytes of `r.b`; an unconditional `memcpy` on
+overlapping ranges is UB and will produce garbage under LLVM. Fixture:
+`behav_storage_assign_partial_overlay.w` (12-byte record, two 8-byte
+`Copy` blocks at 0 and 4, assign, assert bytes). Because storage types
+have no `Drop`, the existing drop-state machinery (see the
+`*-drop-state-debug.md` docs) has nothing to do; add a `debug_assert`
+in the drop lowering that a `Storage` value never reaches it.
+
+**`zeroed` / `from_bytes`.** `memset` / `memcpy` into the destination
+alloca.
+
+**Optimizer.** `MirOpt.w`: storage loads/stores are ordinary memory ops
+on the root's alloca; alias analysis at the MIR level should use the
+same range-intersection query as S3 (share the helper). LLVM will see
+byte GEPs on an `[N x i8]` and can reason about them precisely on its
+own.
+
+**Tests.** `test/codegen/` corpus entries for each lowering shape
+(integer-representation projection → typed `align 1` load; aggregate /
+`[u8; K]` / `@[physical]` projection → `memcpy` to aligned temporary and
+typed load; disjoint whole copy → `memcpy`; overlapping assignment →
+`memmove`/temp; `zeroed`). Run under the
+debug allocator (`docs/debug-allocator.md`) to confirm no hidden
+allocations.
+
+**Done when.** The S3 behavior tests pass through LLVM on all three
+supported targets; stage2 self-host is unaffected (storage types are
+not used by the compiler itself).
+
+### S5. Reflection and polish
+
+**Where.** `ComptimeEval.w` / `ComptimeValue.w` (`T.fields()`
+extension), `Lsp.w` (hover shows offset/range/overlay), `Fmt.w`
+(formatting the new decl form), `Analysis.w` (`analysis_collect_types`
+reports storage layout for the `with analyze` output).
+
+**Reflection.** `T.fields()` for a storage type returns entries with
+`name, type, offset, size, overlay_group`. Add `T.is_storage()`,
+`T.storage_size()`. This is the surface `cobol_import` will build on.
+
+**Portable attribute.** Defer the spelling to the syntax ruling, but
+reserve the check: if the attribute is present, reject native multi-byte
+integers (`i16`..`u128`, `usize`, `isize`, floats) *anywhere* in a
+projection type, recursively through arrays, `@[physical]` wrappers, and
+nested storage types (a nested storage type qualifies iff it is itself
+portable). Implement as a memoized per-type predicate
+`contains_native_endian(ty)` alongside the S1 capability predicates,
+consulted in S2's projection validation when the attribute is present.
+
+**Done when.** `cobol_import`'s author can enumerate a storage layout at
+comptime without further compiler changes.
+
+---
+
+## Part B — Caller-place parameters
+
+### P1. Parameter mode in signatures; call-site spelling
+
+**Where.** `Ast.w` (param node gets a mode field; arg node gets a mode
+prefix), `Parser.w` (accept `inout`/`byref` in both positions), `Sema.w`
+(a `ParamMode: i32` enum `Value=0, Inout=1, Byref=2` beside
+`ReceiverMode`; do not extend `ReceiverMode`), `SemaTypes.w` (signature
+identity includes per-param mode), `Codegen.w` (monomorphization cache
+key includes mode — the `llvm_type_mangle` / mono-cache path). Precisely:
+every signature, type, and monomorphization identity that distinguishes
+parameter *types* must also distinguish parameter *mode* (overload
+resolution, mono cache, bundle interface signature). Link-symbol naming
+policy in `docs/with-abi.md` (semantic symbol names, types carried by the
+source interface) is preserved; do not add mode to external link names
+unless overload implementation already requires type-distinguished link
+names.
+
+**Checks (SemaCheck).** At every call: for each parameter, the argument's
+mode marker must equal the parameter's declared mode; mismatch is an
+error naming the declared mode. The argument expression must be a
+*caller-owned place*: reuse the predicate that already validates
+`mut self` receivers, unchanged. That predicate accepts `let` bindings
+(mutation through an explicitly marked operation is not rebinding), and
+rejects temporaries, rvalues, `&T`/slice views, and `const` items. Do
+not add an "immutable binding" rejection; it would break
+`mut self ≡ inout`. Named arguments carry the mode with the
+expression (`f(target: inout x)`); caller-place parameters may not have
+defaults and may not be omitted, and `implicit` combined with `inout` or
+`byref` is a direct declaration-site error (fixture
+`err_inout_implicit_param.w`), not something left to fail at the
+omission rule. **Evaluation order:** With's
+named-argument sema normalizes the argument list into parameter order.
+That normalization must not reorder side effects or reservation timing.
+Keep a source ordinal on each argument; evaluate (and, for caller
+places, reserve) in source order into temporaries/addresses, then
+marshal in parameter order. Fixture: `f(other: mutate_index(), target:
+inout xs[i])` vs. the reversed source order must select different
+elements. Overload resolution treats mode as part
+of the candidate signature and never coerces a bare expression into a
+place argument. A `byref` parameter's type must satisfy
+`is_bitwise_copyable` (rule B.4.11).
+
+**Declaration contexts (enumerate; do not let parser reuse decide).**
+Accept `inout`/`byref` on free-function and inherent-method non-receiver
+parameters only. Reject with a specific diagnostic on: `extern fn` and
+anything reaching the C ABI surface (`c_import` bindings, `@[export]`
+if it exists), closure parameters, explicit `fn(...)` type syntax, and
+trait method parameters (v1). The trait rejection keeps `ParamMode` out
+of trait metadata, vtable function types, indirect-call lowering, and
+interface matching for this campaign; lifting it is a self-contained
+later stage. Fixtures: `err_inout_extern_fn.w`, `err_inout_c_import.w`,
+`err_inout_closure_param.w`, `err_inout_fn_type.w`,
+`err_inout_trait_method.w`.
+
+**No new overloading.** Mode is in signature identity, but two same-name
+declarations differing only in `T` vs `inout T` must be rejected exactly
+where `T` vs `U` would be. Verify against the current free-function and
+method declaration rules before P1 lands: if With turns out to permit
+signature-only overloading somewhere, the preserved link-name policy is
+insufficient there and needs a separate decision. Fixture:
+`err_inout_mode_only_overload.w`.
+
+**Receiver alignment.** Document in code that `ReceiverMode.Mut` is the
+receiver form of `ParamMode.Inout`; the two share the checking helpers
+introduced in P3.
+
+**Tests.** `err_inout_missing_callsite.w`, `err_inout_spurious_callsite.w`,
+`err_byref_non_bitwise.w`, `err_inout_rvalue_arg.w` (`f(inout make_value())`),
+`err_byref_read_view_arg.w`, `err_byref_const_item.w`,
+`behav_inout_let_binding_ok.w`, `err_inout_param_default.w`,
+`behav_inout_named_arg.w`,
+`behav_inout_basic.w` (mutation visible to caller),
+`behav_byref_same_arg_twice.w`.
+
+**Done when.** Signatures with modes parse, resolve, mangle distinctly,
+and reject mis-spelled call sites. No ABI change yet: temporarily lower
+`inout` and `byref` both as today's `PM_INDIRECT_PLACE` so P1 can land
+green before P2.
+
+### P2. FnAbi alias contract; codegen attributes
+
+**Where.** `FnAbi.w`, `Codegen.w` (`declare_function_from_sig`,
+`apply_noalias_param_attrs_with_offset`), `CodegenDispatch.w`
+(`mir_ref_arg_ptr` and the `push_call_arg` arm for indirect place),
+`docs/with-abi.md`, `WITH_ABI_VERSION`.
+
+**Descriptor.** Add an aliasing field to the per-arg ABI record:
+`PA_EXCLUSIVE = 0, PA_MAY_ALIAS = 1`. `fn_abi_pass_mode` keeps returning
+`PM_INDIRECT_PLACE` wherever it does today. The sibling classifier takes
+the **access contract**, not just `ParamMode`:
+
+```
+fn_abi_alias_contract(receiver_mode, param_mode):
+    ReceiverMode.Mut  or ParamMode.Inout  → PA_EXCLUSIVE
+    ParamMode.Byref                        → PA_MAY_ALIAS
+    ReceiverMode.Read passed by place      → PA_MAY_ALIAS   // NOT Exclusive
+    anything else that is IndirectPlace    → PA_MAY_ALIAS   // default-safe
+```
+
+The default is `MayAlias`. Today's compiler uses `PM_INDIRECT_PLACE` for
+non-`move` read receivers too (`SemaDecl.w`: non-`move` `self` remains
+share-place), and `IndirectPlace` by itself only means "pointer to the
+caller's place." A classifier of "not `byref` → `Exclusive`" would
+retroactively promote every read receiver to `noalias`. Pin with an
+IR-grep that a read-`self` method receives no `noalias` on `self`.
+Keeping pass mode and alias contract as two fields matches the spec's
+"transport vs. guarantee" separation and keeps the ABI diff small.
+
+**Attrs.** `apply_noalias_param_attrs_with_offset` currently applies
+`noalias` to indirect-place params. Two changes:
+
+1. Consult the alias contract and *never* emit `noalias` for
+   `PA_MAY_ALIAS`. This is the single most important line in Part B: if
+   it is missed, LLVM will legally miscompile `legacy(byref r, byref r)`.
+2. **Audit the `Exclusive` case rather than assuming it.** LLVM
+   parameter `noalias` is stronger than With's exclusivity: it promises
+   no access to the pointee during the call through *any* other
+   provenance, including a global the callee names directly. With's
+   rule only excludes other *arguments and live accesses at the call
+   site*. So `fn f(a: inout Account): global_account.x = 1` called as
+   `f(inout global_account)` violates LLVM `noalias` while satisfying
+   the spec. Options: (a) extend the exclusivity check to reject a
+   caller-place argument whose root is a `global var` that the callee
+   (transitively) accesses, using the effect summaries; or (b) emit
+   `noalias` only when the callee's effect summary shows no global-var
+   access, no calls into unknown code, **no raw-pointer parameters or
+   raw-pointer dereferences (including inside `unsafe` blocks), and no
+   other provenance the analysis cannot exclude**. The raw-pointer case
+   is a distinct path: `fn f(a: inout i32, p: *mut i32)` called as
+   `f(inout x, &raw mut x)` writes the pointee through `p` during the
+   call, which the caller-place checker cannot see. `noalias` is an
+   optimization, so a false negative costs nothing and a single false
+   positive is a miscompile; err on omission. (b) is the conservative
+   backend-only fix and is what v1 should do; (a) is a later
+   language-level tightening if the optimization matters. This audit
+   applies to today's `mut self` `noalias` emission as well; it may be a
+   pre-existing latent bug. Check before P2 lands.
+
+The IR gate is therefore: **`byref` never gets `noalias`; `inout` /
+`mut self` get it only when the LLVM contract is established** by (b).
+Pin both halves with codegen corpus greps.
+
+**Bundle-consumed declarations.** The proof in (b) requires the callee's
+effect summary, which needs its body. A declaration consumed from a
+bundle interface (body unavailable) gets **no `noalias` by default**.
+The semantic alias contract (`Exclusive | MayAlias`) round-trips from
+the signature via `ParamMode` and is a language fact; backend
+optimization eligibility is a *separate* fact and must not be
+regenerated from `ParamMode.Inout` alone. If it ever matters, the
+interface can carry a dedicated, fingerprinted backend-proof row
+(`BundleInterfaceEmit.w`), populated only by the producing compiler
+after running (b). Fixture: a `.wo` consumer calling an imported `inout`
+function; IR-grep that the call site and the imported declaration carry
+no `noalias`.
+
+**ABI doc.** Bump `WITH_ABI_VERSION`, add the alias field to the
+descriptor table in `docs/with-abi.md`, regenerate `with-abi.sha256`.
+
+**Tests.** IR-grep corpus tests for both contracts (`byref` absent;
+`inout` present for a pure callee, absent for a callee touching a
+global); behavior test where a `byref` callee writes through one alias
+and reads through the other, compiled at `-O2`, asserting the read sees
+the write; behavior tests for the `global_account` case and the
+`f(inout x, &raw mut x)` raw-pointer case at `-O2`.
+
+**Done when.** `byref` aliasing survives optimization; `inout` and
+`mut self` receive `noalias` exactly when the LLVM contract is
+established.
+
+### P3. Borrow checker: exclusivity, byref class, no-move-out
+
+**Where.** `SemaCheck.w` (the argument-conflict check that today rejects
+arguments retaining access to a `mut self` receiver — generalize it),
+`BorrowCfg.w` if liveness needs a new edge kind.
+
+**Exclusivity (rule B.4.4/5).** At a call, collect the set of places
+each argument designates or retains: `inout` → its place; `byref` → its
+place; `&T` / slice / view args → their origin; `mut self` receiver →
+its place; guards in scope → their places. For each `inout` place,
+require no other collected place overlaps it (S3's query). For each
+`byref` place, require that every overlapping collected place is also
+`byref`. Heterogeneous `byref` overlap (rule B.4.6): if two overlapping
+`byref` places have different static types, require both to be storage
+projections of one root and both `AnyBitPattern`; otherwise error.
+
+**No-move-out (rule B.4.3).** In the callee, an `inout`/`byref`
+parameter's place is marked `NO_CONSUME`. Extend the owned-demand
+resolution (the D22 machinery: `resolve_contextual_join`, owned-anchor
+detection) so a `NO_CONSUME` place can satisfy an owned demand only via
+the `Copy` materialization path. Any consuming use of a non-`Copy`
+value at a `NO_CONSUME` place (passing to an owned param, `return`,
+`let` without copy, `move`) is an error with the clone/assignment
+suggestion. Assignment *to* the place is permitted and runs the old
+value's drop — which for `inout` of a `Drop` type means the callee drops
+the caller's old value in place; that is the intended semantics and
+matches `mut self` field assignment today.
+
+**Tests.** `err_inout_overlap_inout.w`, `err_inout_overlap_ref.w`,
+`err_byref_overlap_inout.w`, `err_byref_hetero_outside_storage.w`,
+`behav_byref_hetero_storage_ok.w`, `err_inout_move_out.w`,
+`err_inout_return_owned.w`, `behav_inout_assign_replace.w`.
+
+**Done when.** Every conflict shape in the spec's rule table has a
+fixture and the receiver conflict check is a special case of the new
+generalized check (no duplicated logic).
+
+### P4. Reservation
+
+**Where.** `SemaCheck.w` argument evaluation; `MirLower.w` argument
+ordering.
+
+**Model.** Introduce a liveness state `RESERVED(place)` created when a
+caller-place argument's designator finishes evaluating and released at
+invocation. While a place is reserved, later argument expressions are
+checked against it with a *weaker* predicate than exclusivity: they may
+read it and may perform completed mutations through it, but may not
+(a) consume the root or any enclosing place, (b) drop or destroy it,
+(c) rebind the root, or (d) invoke an operation classified as
+*relocating* on any enclosing container.
+
+**Invalidation classification.** This is the one new analysis fact,
+and it is *relative to the reserved place*. It is a per-parameter
+effect, `EFF_INVALIDATE_DESCENDANTS`, carried on a receiver or
+caller-place parameter: passing a container through that parameter may
+move, destroy, or shrink storage that lives *inside* the container
+(`Vec.push`, `Vec.insert`, `Vec.remove`, `Vec.pop`, `HashMap.insert`,
+... all set it on `self`). It applies only when the reserved place is a
+descendant of the argument bound to that parameter:
+
+```
+f(inout xs, xs.push(v))       // root xs survives → admissible
+f(inout xs[0], xs.push(v))    // xs[0] is inside xs → reject
+f(inout r.a, r.b.clear())     // r.b is a sibling projection, not an
+                              // enclosing container → admissible
+```
+
+An unconditional "relocates" bit would reject the first case and make
+the implementation stricter than the spec.
+
+The bit is a **per-parameter effect**, `EFF_INVALIDATE_DESCENDANTS`, on
+the existing per-parameter effect summary (the P0 fixpoint / `escape_*`
+/ `write` summaries referenced in `share_place_minimal_design.md`), not
+a method-level property. A `mut self` receiver is one carrier; an
+`inout` parameter is another:
+
+```
+fn grow(v: inout Vec[i32]): v.push(1)
+f(inout xs[0], grow(inout xs))     // reject: grow's param carries the effect
+```
+
+Seed from std annotations on container mutators, propagate through the
+call-graph fixpoint like the other effect bits (an `inout` param that is
+passed on to a parameter carrying the effect acquires it). v1 seeds
+conservatively: any `mut self` method on a growable container sets it
+unless annotated otherwise. The reserved-place check consults the bit on
+the parameter (or receiver) the enclosing container is passed to, and
+only when the reserved place is a descendant of that argument. Fixture:
+`err_inout_reservation_via_inout_callee.w` for the `grow` case.
+
+**Single evaluation — the invariant.**
+
+> A caller-place designator is evaluated exactly once. Reservation
+> preserves the identity selected by that evaluation.
+
+The designator (including any index expressions, e.g. `xs[i]`) is
+evaluated in argument order and its physical address is materialized
+*at that point*. Reservation then proves the address cannot become
+stale before invocation. The compiler must never re-evaluate the
+designator later; in `f(inout xs[i], change_i())`, where `change_i`
+mutates `i` without relocating `xs`, the callee receives the element
+selected by the *original* `i`. (The alternative, holding a symbolic
+`ReservedPlace{root, evaluated index path, origin}` and resolving it to
+an address at `push_call_arg`, is also correct provided the index values
+are the ones captured at designator time; it is more machinery for no
+semantic gain, so v1 materializes immediately.)
+
+**MIR.** `mir_ref_arg_ptr` (the `IndirectPlace` marshal) takes the
+address when the argument is lowered in sequence; confirm it does not
+re-lower the designator at the call. The reservation check runs in Sema
+between designator evaluation and invocation; MIR carries no reserved
+state.
+
+**Tests.** `behav_inout_reservation_len_ok.w`, `behav_inout_reservation_update_ok.w`,
+`behav_inout_reservation_index_evaluated_once.w` (the `xs[i]` /
+`change_i()` case: assert the callee saw the original element),
+`err_inout_reservation_pop.w`, `err_inout_reservation_push.w`,
+`err_inout_reservation_move.w`.
+
+**Done when.** The five spec examples in rule B.4.7 behave as listed.
+
+### P4b. Returned-view provenance across calls
+
+**Where.** `SemaCheck.w` (`set_sig_param_view_origin`,
+`check_returned_view_origins`, the call-site origin substitution that
+already maps a returned view's declared parameter origin onto the actual
+argument's origin).
+
+**What.** A view returned from an `inout`/`byref` parameter is declared,
+in the signature's view-origin summary, as originating from that
+parameter. At the call site the existing substitution maps it onto the
+*actual argument's* origin, so:
+
+```
+fn balance(r: inout Rec) -> &i32: &r.balance
+let p = balance(inout rec)
+rec.balance = 1        // ERROR while p is live
+```
+
+Verify the substitution handles caller-place arguments (it was written
+for `&T` parameters and `self`); the argument is a place, and its origin
+is the place's root plus (for storage projections) range. For `byref`,
+keep escape provenance parameter-specific: `return &a` is summarized as
+originating from `a` only, not from the whole may-alias class. The class
+is consulted for intra-callee conflicts (P6); provenance is not widened
+by it.
+
+**Tests.** `err_inout_returned_view_conflict.w` (the example above),
+`behav_inout_returned_view_ok.w` (view dropped before mutation),
+`behav_byref_returned_view_specific.w` (a view returned from `a` does not
+block mutation through an unrelated caller place that was passed as
+`b`).
+
+### P5. Restrictions: suspend, first-class, closures
+
+**Where.** `MirSuspendCheck.w` (`suspend_body_calls_may_suspend` and the
+per-body `may_suspend` bits), `SemaCheck.w` (function-value formation,
+closure capture analysis).
+
+- After `may_suspend` is computed, any body with a caller-place
+  parameter and a set `may_suspend` bit is an error at the parameter.
+  `async fn` / `gen fn` are rejected at declaration without waiting for
+  the analysis.
+- Taking a function with any caller-place parameter as a value: error at
+  the use site, with the same wording as the existing mutating-method
+  restriction; share the diagnostic.
+- Closure capture of an `inout`/`byref` parameter: error, marked in the
+  message as a v1 restriction.
+
+**Tests.** `err_inout_async_fn.w`, `err_inout_may_suspend_transitive.w`,
+`err_inout_fn_value.w`, `err_inout_closure_capture.w`.
+
+### P6. Intra-callee byref may-alias
+
+**Where.** `SemaCheck.w` view-origin tracking inside a function body.
+
+**Model.** The callee cannot see argument provenance, so grouping is
+by *type*, not by whether the parameter "is a storage projection": at
+function entry, two `byref` parameters may alias iff they have the same
+static type, or both types are admissible `AnyBitPattern` physical types
+(some legal caller could pass overlapping storage projections of those
+types, per spec rule B.4.6). `fn f(a: byref i32, b: byref u32)` groups
+`a` and `b`. Assign each compatible group one *may-alias origin class*. When a view is derived from a `byref` parameter, its
+origin is the class, not the individual parameter. A write through any
+parameter in the class invalidates live views whose origin is the class.
+This reuses the existing origin-mask invalidation; the only new piece is
+that several parameters share a mask bit.
+
+**Feeding the overlap query.** The may-alias class is not only a
+view-origin fact. It must be consulted by S3's general overlap query so
+that every derived-place check (nested call arguments, guards, mutating
+receivers) sees `byref`-rooted places in one class as potentially
+overlapping. The headline fixture:
+
+```
+fn inner(x: inout i32, y: inout i32): ...
+fn outer(a: byref Rec, b: byref Rec):
+    inner(inout a.x, inout b.x)     // ERROR: a and b may alias
+fn owned(a: Rec, b: Rec):
+    inner(inout a.x, inout b.x)     // OK: distinct owned roots
+```
+
+This exercises caller aliasing → `byref` → callee may-alias facts →
+storage projection → attempted `inout` refinement across all three
+layers at once.
+
+**Tests.** `err_byref_intra_callee_view_conflict.w` (the spec's
+`let r = &a; b = 42; r` example), `behav_byref_intra_callee_no_view_ok.w`
+(write through `b` with no live view from `a` is fine),
+`err_byref_nested_inout_refinement.w` and
+`behav_owned_nested_inout_ok.w` (the pair above).
+
+**Done when.** The checker never assumes disjointness for a pair of
+places that the source semantics allow to alias, and the backend never
+attaches an exclusivity promise to a `byref` parameter. (Two `MayAlias`
+parameters need not be pairwise compatible; the invariant is one-
+directional in each layer, not an equivalence.)
+
+---
+
+## Cross-cutting
+
+### Self-host
+
+Neither feature is used by the compiler's own source in this campaign, so
+the seed → stage1 → stage2 chain is unaffected until std adopts them.
+Do not use storage types inside `src/` before the fixpoint check is
+green for two consecutive releases with the feature present.
+
+### Bundle interfaces
+
+`src/compiler/BundleInterfaceEmit.w` currently has struct/union-specific
+emission (`kind_row = "union" | "struct"`) and no storage case. Public
+storage types must round-trip through the bundle interface, so:
+
+- **Emit:** a `storage` row carrying `N`, `align`, and every projection
+  as `(name, type, offset, overlay_group)`. Overlay groups must be
+  preserved, not just offsets, or a consumer re-checking S2's overlap
+  rule would reject a legitimately overlaid layout.
+- **Reconstruct:** `BundleInterfaces.w` rebuilds the `TypeDeclKind.Storage`
+  decl from the row and re-runs S2's validation as a consistency check
+  (declared layout is the contract; recomputation must agree).
+- **Signatures:** parameter mode is already in interface signature
+  identity (P1); the alias contract follows from it and needs no
+  separate row.
+- **Fingerprint:** `BundleFingerprint.w` must include the storage row so
+  a layout change invalidates dependents.
+
+Fixture: an end-to-end `.wo` test where module A exports a storage type
+with an overlay plus one `inout` and one `byref` function, and module B
+consumes all three; assert `sizeof`, an overlay read, and a caller-
+visible mutation across the module boundary.
+
+### `with migrate`
+
+The C migrator (`CiMigrate.w`, `Migrate.w`) should *not* start emitting
+storage types for C unions in this campaign; that is a separate
+decision. Add a `// storage-type candidate` marker in emitted code where
+a C union or explicitly-laid-out struct is encountered, so the census
+tool can count them.
+
+### Documentation
+
+- Spec: new chapter after §4 for Part A; §9.1 gains parameter modes;
+  §21 gains the exclusivity principle, reservation, and byref class;
+  §16.4 gains one sentence pointing storage overlays elsewhere.
+- `docs/with-abi.md`: alias contract field.
+- `docs/with-idiomatic-guide.md`: when to use `inout` vs. returning a
+  value; when `byref` is appropriate (almost never in new code; it
+  records unproven aliasing).
+- `docs/COBOL-migrate.md`: update the mapping table (`REDEFINES` →
+  storage overlay, not anonymous union; `PIC X(n)` → `text[N, Enc]`, not
+  `FixedString`; `CALL BY REFERENCE` → `byref`, refined to `inout`).
+
+### Acceptance
+
+- Every rule in the spec has at least one `compile_errors` or `behavior`
+  fixture, listed in `test/coverage_manifest.txt` under a new
+  `storage-and-places` section.
+- `test/d_acceptance/` gains an end-to-end program: a storage record with
+  overlays, passed `byref` to one function and `inout` to another,
+  compiled at `-O2`, output compared to a golden file.
+- The IR-grep tests for `noalias` presence/absence are red-build gates.
+
+### Estimated shape
+
+S1–S2 and P1 are mostly mechanical and can be parallelized. S3 and P3–P4
+are the real work: they extend the borrow checker with range-overlap
+places, a reserved-place state, and a shared may-alias class. P2 is
+small but is the one change whose omission is a silent miscompile;
+review it separately from everything else.

--- a/docs/storage-types-and-caller-places-spec.md
+++ b/docs/storage-types-and-caller-places-spec.md
@@ -1,0 +1,710 @@
+# Storage Types and Caller-Place Parameters — Specification
+
+Feature proposal. Two coupled additions to the With language:
+
+- **Part A — `storage type`**: an aggregate that owns exactly N bytes and
+  exposes typed, possibly overlapping *projections* onto regions of them.
+- **Part B — `inout` / `byref` parameters**: passing a caller-owned
+  *place* to a function, with exclusive or may-alias semantics, without
+  introducing `&mut T` as a value.
+
+Notation: `bytes[N]` in this document means `[u8; N]`. It is not a new
+type; it is used because "bytes" reads better than "array of u8" in a
+layout context and may become a prelude alias, but nothing here depends
+on it being distinct.
+
+Both are general-purpose language features. The COBOL modernization
+campaign (`docs/COBOL-migrate.md`) is the motivating workload and the
+first serious consumer, but no COBOL concept appears in these rules;
+`std.cobol`, `cobol_import`, and `dec[P,S]` are separate proposals
+layered on top.
+
+Status: proposal. Not spec-normative until accepted and merged into
+`docs/with-specification.md` (targets: a new chapter alongside §4 for
+Part A; §9 and §21 amendments for Part B; ABI doc for the alias contract).
+
+---
+
+## Part A — Storage types
+
+### A.1 Motivation
+
+An ordinary `type` says: *these fields are values that together form an
+object.* A record layout, a wire packet, a database page, a file record,
+or a hardware register block says something different: *these bytes
+exist, and these names are typed views onto regions of them.*
+
+With today can approximate the second with `@[repr(C)]`,
+`@[repr(packed)]`, and `union`, but three things are missing:
+
+1. **Arbitrary overlap at arbitrary offsets.** A union puts every member
+   at offset 0. Real layouts overlay a 6-byte region at offset 10 with a
+   differently typed 4-byte region at offset 12.
+2. **Whole-value copy that is a byte copy.** Struct assignment is
+   field-wise. Copying a record with overlapping views must copy the
+   bytes once, regardless of how they are projected.
+3. **Safe reads of any overlay.** §16.4's union rule (a safe read
+   requires the member to be the last one written) is correct for
+   unions of arbitrary types. It is the wrong rule for layouts whose
+   every projection admits every bit pattern, and weakening it for
+   unions would lose the safety it provides.
+
+`storage type` supplies all three without touching `union`.
+
+### A.2 What it looks like to a mainstream developer
+
+```
+storage type CustomerRecord[128]:
+    customer_id: text[10, ebcdic_037]   at 0
+    balance:     packed_dec[9, 2]       at 10
+    overlay at 16:
+        status_text: text[4, ebcdic_037]
+        status_code: bytes[4]
+    items: [Item; 10]                   at 32
+    // bytes 20..32 and 112..128 are unnamed; they still exist
+```
+
+- The type is exactly 128 bytes. `sizeof(CustomerRecord) == 128`,
+  alignment 1, array stride 128.
+- `record.balance` reads a `packed_dec[9, 2]`; because `packed_dec` is
+  `Copy`, that is a plain value you can bind, copy, or pass.
+  `record.balance = v` writes it. A projection whose type is *not*
+  `Copy` (say a large nested storage record that chose not to
+  `impl Copy`) can be borrowed, passed `inout`/`byref`, or explicitly
+  snapshotted, but `let c = parent.child` is rejected: `BitwiseCopyable`
+  lets the compiler move bytes, `Copy` lets *you* duplicate a value, and
+  the two stay separate. No decoding
+  happens on either side; if the bytes are not a well-formed packed
+  decimal, you still get a `packed_dec[9, 2]` value. Interpreting it is
+  a separate call (`record.balance.value(profile)`, defined by
+  `std.cobol`, not by this feature).
+- `status_text` and `status_code` name the same four bytes. Reading
+  either is always fine.
+- `a = b` between two `CustomerRecord`s copies 128 bytes. Whether `b` is
+  still usable afterwards follows ordinary `Copy`/move rules, exactly as
+  for any other type; storage types are not implicitly `Copy`.
+- Construction is physical: `CustomerRecord.zeroed()` or
+  `CustomerRecord.from_bytes(b)`, then write projections. There is no
+  `CustomerRecord { balance: ..., status_text: ... }` literal, because
+  with overlays it would have no defined meaning.
+
+The mental model: **a storage value is a byte array with names.** Nothing
+inside it is a separately owned thing. That is the whole feature.
+
+### A.3 Syntax
+
+```
+StorageDecl  := 'storage' 'type' Ident '[' IntLit ']' AlignClause? ':' NEWLINE INDENT StorageBody DEDENT
+AlignClause  := 'align' '(' IntLit ')'
+StorageBody       := (Projection | Overlay)+
+Projection        := Ident ':' PhysType 'at' IntLit
+OverlayProjection := Ident ':' PhysType ('at' IntLit)?
+Overlay           := 'overlay' 'at' IntLit ':' NEWLINE INDENT OverlayProjection+ DEDENT
+```
+
+Inside an `overlay at O:` block, a projection without `at` is placed at
+`O`; with `at K` it is placed at `O + K`. Projections in the same
+overlay block are declared to overlap. Projections outside any overlay
+block that overlap each other are a compile error (A.5 rule 3).
+
+Reserved words added: `storage` (contextual, only before `type`),
+`overlay`, `at` (contextual, only inside a storage body). None of these
+are reserved elsewhere; existing identifiers named `at` remain valid.
+
+### A.4 Capabilities
+
+Three compiler-derived properties. User code cannot assert them.
+
+| Capability | Meaning |
+|---|---|
+| `BitwiseCopyable` | The representation may be transported byte-for-byte. |
+| `AnyBitPattern` | Every bit pattern of the type's size is a valid *physical* value. |
+| `Copy` | Ordinary With `Copy`: duplication does not consume the source. |
+
+Every storage type is `BitwiseCopyable` and `AnyBitPattern` by
+construction. It is `Copy` only if declared `impl Copy for T`.
+
+`AnyBitPattern` is a claim about physical validity only. A
+`packed_dec[9, 2]` field holding `0xFF FF FF FF FF` is a valid
+`packed_dec[9, 2]` *value*; it is not a valid decimal *number*. The
+distinction is the point: malformed legacy data is representable in safe
+code without the type system pretending it is well-formed.
+
+### A.5 Rules
+
+1. **Size and alignment.** `storage type T[N]` has exactly `N` bytes and
+   alignment 1 by default. `align(A)` is permitted only when
+   `N % A == 0`. Therefore `sizeof(T) == N` and an array of `T` has
+   stride `N` in every case.
+
+2. **Projection types.** A projection's type must be an exact-size
+   physical value type that is `BitwiseCopyable` and `AnyBitPattern`:
+   fixed-size integers, `bytes[K]`, `[P; K]` arrays of such types, nested
+   storage types, and std-supplied physical field types (`text[K, Enc]`,
+   `packed_dec[P, S]`, `zoned_dec[P, S, Enc]`, `binary_dec[...]`,
+   `be_i32`, `le_u16`, ...). Writing a projection stores a value of that
+   type; reading one as an owned value is permitted only when the
+   projection type is `Copy` (rule 13). No decoding, validation, or
+   conversion occurs in either direction.
+
+3. **Range and overlap.** Every projection's byte range lies within
+   `[0, N)`. Two projections whose ranges intersect must be declared in
+   the same `overlay` block; otherwise intersection is a compile error
+   with both projections and the intersecting range named.
+
+4. **Storage origin.** Every projection carries a compiler-visible
+   *storage origin*: the outermost storage value plus a final byte range.
+   Every subprojection refines that range, whether through a nested
+   storage field, an ordinary field of an admissible physical type, or an
+   array index: `r.address.zip`, `r.header.code`, `r.balance.raw[2]`,
+   and `r.items[1]` all keep origin `r` with a narrowed range. A constant
+   index yields the exact element range; a runtime index keeps the
+   containing array's range. So `inout r.items[0], inout r.items[1]` is
+   provably disjoint, and `inout r.items[i], inout r.items[j]` is not
+   unless index facts prove `i != j`. Two projections of one origin with
+   intersecting ranges are *known to overlap*; with disjoint ranges,
+   *known disjoint*. Part B consumes these facts.
+
+5. **Access lowering.** Projection reads and writes lower to alignment-1
+   loads and stores, byte assembly, or `memcpy`. Unaligned projections
+   have defined semantics on every supported target for by-value access.
+
+6. **Under-aligned places.** Alignment does not itself prohibit
+   by-value access to a projection (owned reads remain subject to rule
+   13; writes are always permitted). Any typed borrowed or place
+   capability that
+   assumes the projection type's natural alignment — `&T`, `inout T`,
+   `byref T`, slices and `prefix(n)` views over `[P; K]`, and `with ...
+   as` place aliases — may be formed only when the compiler can prove
+   that the projected address `addr(origin) + offset` is always a
+   multiple of `alignof(T)`.
+   The proof uses both the origin's guaranteed alignment and the offset;
+   an aligned offset does not compensate for an under-aligned origin, so
+   `x: i32 at 4` in an alignment-1 storage type may not form an `&i32`.
+   *v1 restriction, not fundamental.* It costs nothing for the physical
+   field types, which are all alignment-1.
+
+7. **Endianness.** Native multi-byte integer projections (`i16`, `u32`,
+   ...) use the target's object byte order and do not promise a
+   target-independent representation. Portable layouts use
+   explicit-order physical types. A storage type declared portable
+   (attribute spelling to be settled with syntax) may not contain a
+   native multi-byte integer *anywhere* in its projection types,
+   recursively: `[u32; 4]` or a nested non-portable storage type both
+   violate it. This is an error.
+
+8. **Construction.** v1 construction is physical only: `T.zeroed()` or
+   `T.from_bytes(b: bytes[N])`, followed by explicit projection writes. No fieldwise aggregate
+   initializer. A later feature may define one with explicit write
+   order.
+
+9. **Resource-free.** A storage type and every projection type are
+   resource-free. A storage type may not implement `Drop`, contain owned
+   resources, or attach destruction semantics to its representation.
+   This is what makes rule A.4's "`BitwiseCopyable` by construction"
+   true.
+
+10. **Assignment.** `=` between identical storage types is a bytewise
+    representation transfer with ordinary assignment semantics: the
+    right-hand value is conceptually materialized before the destination
+    is written, so `r.a = r.b` between two overlapping `Copy`
+    projections yields the pre-assignment bytes of `r.b` in `r.a`.
+    Ownership follows ordinary `Copy`/move rules; there is no
+    storage-specific ownership rule. `=` is not
+    defined between different storage types or lengths; such movement
+    is an explicit domain operation supplied by a library
+    (e.g. `dst.cobol_move_from(src, profile)`), which never consumes
+    its source.
+
+11. **Arrays and bounded views.** `[P; K]` is an ordinary projection.
+    `r.items.prefix(n)` yields a runtime-bounded read view over the
+    first `n` elements under ordinary view-origin rules. A projection
+    never reads another field to determine its own extent.
+
+12. **Overlays are not unions.** Overlapping projections are ordinary
+    places. §16.4's last-written rule for `union` is untouched. Reading
+    any overlay member is always defined because every projection type
+    is `AnyBitPattern` (rule 2).
+
+12a. **Recursive storage views (v1).** A storage type may not project
+    itself, directly or through mutual reference (`storage type A[8]:
+    self_view: A at 0`). Although a projection contributes no storage
+    and such a layout is not infinitely sized, v1 rejects it with a
+    specific diagnostic rather than letting ordinary aggregate
+    cycle-checking decide; a later feature may permit it deliberately.
+
+13. **Place capability vs. value; `Copy` governs owned reads.**
+    `BitwiseCopyable` authorizes representation transport;
+    `Copy` authorizes source-visible duplication. An owned read of a
+    projection (`let x = r.field`, passing `r.field` to an owned
+    parameter, returning it) is permitted only when the projection type
+    is `Copy`, and materializes by byte copy. For a non-`Copy` projection
+    type the owned demand is rejected; the projection remains usable as a
+    place (borrow, view, `inout`, `byref`, assignment target) and may be
+    duplicated only by an explicit operation. Small physical field types
+    (`packed_dec`, `text`, integers) will normally be `Copy`; large
+    nested storage records need not be. The projection's *place
+    capability* is not a first-class value and cannot outlive its
+    storage origin. References and other ephemeral views derived from a
+    projection follow §3 and §21's view-origin and escape rules; a
+    read-only view may be returned where those rules permit.
+
+14. **Ownership.** Storage values otherwise participate in ownership
+    like any value: one owner, moved by value, borrowed ephemerally.
+
+### A.6 What it looks like to library authors
+
+Physical field types are ordinary types that satisfy rule 2. A library
+supplies them as exact-size, alignment-1, `AnyBitPattern` values with
+methods for interpretation:
+
+```
+// in std.cobol (sketch; the real one is its own proposal)
+@[physical]
+type packed_dec[P: comptime u8, S: comptime u8] { raw: [u8; (P + 2) / 2] }
+
+impl packed_dec[P, S]:
+    fn value(self, profile: &CobolProfile) -> dec[P, S]: ...
+    fn store(mut self, v: dec[P, S], profile: &CobolProfile): ...
+```
+
+`@[physical]` is a std/compiler-internal attribute that requests exact
+layout (alignment 1, no padding). Every field of a `@[physical]` type
+must itself have alignment 1 in v1 (`[u8; N]`, `u8`, `i8`, other
+`@[physical]` types), so that ordinary field access on a `@[physical]`
+value at an odd address is never under-aligned; a `@[physical] Wrapper
+{ x: u32 }` is rejected. It does *not* assert `BitwiseCopyable` or
+`AnyBitPattern`; the compiler still derives those structurally from the
+fields (A.4). A `@[physical] type Bad { flag: bool }` is rejected as
+a projection type because `bool` is not `AnyBitPattern`, attribute or
+not.
+
+The library owns validity semantics; the language owns bytes. A library
+that wants a different interpretation of the same bytes defines a
+different physical type and lets users overlay it.
+
+Comptime reflection (`T.fields()`, §17.2) reports each projection's
+name, type, offset, range, and overlay membership, which is what
+`cobol_import`-style generators and serializers consume.
+
+### A.7 What it looks like to compiler maintainers
+
+- A new `TypeDeclKind.Storage`, distinct from `Struct`, `Union`, and
+  `Enum`. Layout is declared, not computed: the compiler *checks*
+  offsets rather than assigning them.
+- Projection access is a new place kind carrying `(origin, range)`. The
+  borrow checker's overlap query for two storage places is range
+  intersection on a shared origin.
+- Codegen never emits a typed GEP + load for a projection; it emits an
+  `i8` GEP to the offset and an alignment-1 load/store or `memcpy` of
+  the projection's size.
+- No new runtime support.
+
+### A.8 Interaction with existing features
+
+| Feature | Interaction |
+|---|---|
+| `union` (§16.4) | Unchanged. Storage overlays are a separate kind. |
+| `@[repr(C)]`, `@[repr(packed)]` | Unchanged. Ordinary structs keep computed layout. A `@[repr(C)]` struct is not a valid projection type unless it is also `AnyBitPattern`, which requires every field to be. |
+| `c_import` | A C struct can be re-declared as a storage type by hand; automatic conversion is out of scope for v1. |
+| Ephemeral types (§5, §22) | A storage type cannot be ephemeral and cannot contain ephemerals (rule 2 excludes them). |
+| `with` blocks (§7) | `with record.balance as mut b:` is an ordinary place-scoped access; no special casing. |
+| Generics | v1 storage declarations are concrete: `N` is an integer literal and projection types are concrete. Generic storage types (`N: comptime usize`, generic projection types) are deferred to a later feature; copybook-generated records are concrete regardless. |
+
+### A.9 Diagnostics contract
+
+The compiler must diagnose at least:
+
+- Projection range outside `[0, N)`.
+- Two projections with intersecting ranges outside a shared overlay block.
+- A projection type that is not `BitwiseCopyable + AnyBitPattern`, naming
+  which property fails and, for aggregates, the first offending field.
+- `impl Drop for` a storage type.
+- `align(A)` with `N % A != 0`.
+- Forming any typed borrowed or place capability (`&T`, `inout T`,
+  `byref T`, a slice or `prefix(n)` view, a `with ... as` alias) from an
+  under-aligned projection, with the guaranteed alignment of the origin
+  and the offset shown.
+- An owned read (`let`, owned argument, return) of a projection whose
+  type is not `Copy`, suggesting a borrow, `inout`/`byref`, or an
+  explicit snapshot.
+- A storage type projecting itself, directly or mutually.
+- A fieldwise initializer on a storage type, suggesting `zeroed()` /
+  `from_bytes()`.
+- A native multi-byte integer projection in a portable storage type.
+
+### A.10 Non-goals (v1)
+
+- Fieldwise initializers.
+- Unaligned reference places.
+- Automatic C-struct-to-storage conversion.
+- Volatile or ordered access (storage types are a layout substrate for
+  MMIO, not a sufficient MMIO facility).
+- Any interpretation semantics (decimal, text encoding, dates). Those are
+  library types.
+
+---
+
+## Part B — Caller-place parameters: `inout` and `byref`
+
+### B.1 Motivation
+
+With's receiver model already distinguishes reading (`fn f(self)`),
+mutating in place (`fn f(mut self)`), and consuming (`fn f(move self)`).
+`mut self` passes a pointer to the caller's storage (`PassMode
+IndirectPlace`); the callee mutates it and does not drop it. Free
+function parameters have no equivalent: a plain `T` parameter is owned,
+`&T` is a read view, and there is no way to say "mutate the caller's
+storage" for a non-receiver argument. §1.5 rules out `&mut T` as a
+storable value, and the superseded free-parameter share-place design
+(`docs/share_place_minimal_design.md`) inferred mutation rather than
+declaring it, which D12/D21 rejected.
+
+This feature adds the missing capability *explicitly*: two parameter
+modes that bind a caller-owned place, spelled at both declaration and
+call site, with an aliasing contract that is part of the signature.
+
+### B.2 What it looks like to a mainstream developer
+
+```
+fn deposit(account: inout Account, amount: dec[11, 2]):
+    account.balance = account.balance + amount
+
+fn legacy_post(rec: byref CustomerRecord, ctl: byref CustomerRecord):
+    // rec and ctl may be the same record; writes through one are
+    // visible through the other immediately
+    ...
+
+deposit(inout my_account, 100.00)
+legacy_post(byref r, byref r)          // legal
+deposit(inout r.a, deposit_amount)     // r.a is a storage projection
+```
+
+- `inout T`: the callee has exclusive read/write access to the caller's
+  place for the duration of the call: no other tracked caller access (a
+  `&T`, a view, a guard, another `inout`/`byref` argument) may overlap
+  it. This is `mut self` for any parameter.
+- `byref T`: the callee has read/write access to a place that *may
+  overlap* other `byref` arguments of the same call. Every write is
+  immediately visible through every alias.
+- Neither mode lets the callee take the value. `let owned = account`
+  inside `deposit` is an error unless `Account: Copy`. The caller keeps
+  ownership, always.
+- The call site says which mode is used. `deposit(my_account, ...)`
+  without `inout` is an error, not a silent by-value pass. Mutation
+  through an argument is never hidden inside an ordinary-looking call.
+
+The capability model:
+
+```
+&T          READ
+inout T     READ + WRITE + EXCLUSIVE
+byref T     READ + WRITE + MAY_ALIAS
+T (owned)   READ + WRITE + CONSUME
+```
+
+`inout` is not "owned `T` through a pointer."
+
+### B.3 Syntax
+
+```
+Param       := Ident ':' ParamMode? Type
+ParamMode   := 'inout' | 'byref'
+Arg         := ('inout' | 'byref')? Expr
+```
+
+A call-site `inout`/`byref` marker is required exactly when the
+corresponding parameter is declared with that mode, and forbidden
+otherwise. `inout`/`byref` are reserved words in parameter and argument
+position only.
+
+### B.4 Rules
+
+1. **Place binding.** Both modes bind a place, not a value. Reading the
+   parameter reads the caller's storage at that moment; writing writes
+   it. No copy-in or copy-out.
+
+2. **Call-site spelling is normative; the argument must be a mutable
+   place.** `inout` and `byref` must appear at both declaration and call
+   site, and the argument expression must denote a caller-owned place
+   under the same predicate that governs `mut self` receivers. Because
+   `mut self` is definitionally `inout`, a `let` binding is a valid
+   caller-place argument: `let account = Account.new();
+   update(inout account)` is legal, exactly as `account.deposit(...)`
+   with a `mut self` receiver is legal today. `let` forbids rebinding
+   the name, not mutation through an explicitly marked operation.
+   `f(inout make_value())` (rvalue), `f(inout some_read_view)` (a `&T`
+   or slice view), and `f(byref some_const)` are errors. With named arguments the mode
+   sits with the expression: `f(target: inout x)`. Caller-place
+   parameters have no default value and cannot be omitted in v1, since
+   omission would hide the mutation mode the call site is required to
+   show. A parameter may not be both `implicit` and a caller-place
+   parameter; that combination is a direct error. Named arguments do not
+   change evaluation order: arguments are
+   evaluated, and caller-place designators reserved, in *source* order,
+   then marshalled in parameter order. No ordinary argument expression is
+   implicitly converted to a caller-place argument. Parameter mode is
+   part of semantic signature identity: `fn(T)`, `fn(inout T)`, and
+   `fn(byref T)` are distinct signatures; overload resolution never
+   infers a mode from a bare `f(x)`.
+
+3. **No ownership transfer.** An `inout` or `byref` parameter grants read
+   and write access but not consumption of the caller's value. The
+   parameter, or a non-`Copy` projection from it, may not satisfy an
+   owned demand that would move the value out: passing to a consuming
+   parameter, returning as owned, `let` binding as non-`Copy`, explicit
+   `move`, or any other consumption is rejected. `Copy` values
+   materialize normally; independent owned copies of non-`Copy` values
+   require explicit clone or a domain operation. Replacing the place by
+   assignment is permitted and leaves the caller owning the replacement.
+
+4. **Call-wide exclusivity.** An `inout` place has exclusive access to
+   its storage range for the dynamic extent of the call. *Exclusive*
+   means: no other **language-tracked caller-place or live view
+   capability** may overlap the range. Any such overlapping argument or
+   live access is rejected at the call site: another `inout`, a
+   `byref`, a `&T`, a slice or view, a guard, or a mutating receiver.
+   Exclusivity does **not** assert universal pointer-provenance
+   uniqueness: access through an independently named global, a raw
+   pointer, foreign code, or any other provenance not represented by a
+   live caller-place capability remains governed by its ordinary rules.
+   This is deliberately weaker than LLVM parameter `noalias` (B.5). This is the rule that already rejects
+   arguments retaining conflicting access to a `mut self` receiver,
+   stated for all places.
+
+5. **`byref` exception.** Two `byref` arguments may overlap each other
+   and observe each other's writes. A `byref` still may not overlap an
+   `inout`, a `&T`, or any other non-`byref` live access.
+
+6. **Heterogeneous `byref` overlap.** Overlapping `byref` places of
+   different static types are permitted only when both are projections
+   of a common storage origin (Part A) and both types are
+   `AnyBitPattern`. Otherwise overlapping `byref` arguments must have the
+   same static type. This keeps the feature from becoming safe arbitrary
+   type punning outside the storage system.
+
+7. **Reservation and activation.** A caller-place argument's designator
+   is evaluated in normal argument order. From then until invocation its
+   *place identity is reserved*: later argument evaluation may perform
+   completed reads and other normally sequenced operations, but may not
+   move, destroy, rebind, relocate, or otherwise invalidate the
+   designated place. At invocation the `inout` exclusivity or `byref`
+   may-alias contract becomes *active* for the dynamic extent of the
+   call. Consequences:
+
+   ```
+   mutate(inout xs, xs.len())               // OK: completed read
+   f(inout x, x.compute_and_update())       // OK: place survives
+   f(inout r.a, read(r.b))                  // OK: no retained conflict
+   f(inout xs[last], xs.pop())              // ERROR: may invalidate place
+   f(inout xs[0], xs.push(v))               // ERROR: may relocate
+   f(inout x, move x)                       // ERROR: consumes place
+   ```
+
+   Reservation is about place validity, not value stability.
+
+8. **Overlap facts.** Overlap is decided from ordinary place facts plus
+   Part A's storage-origin facts. Two places rooted in distinct *owned*
+   values are disjoint. Two places rooted in `byref` parameters of the
+   same may-alias class (rule 9) are potentially overlapping regardless
+   of syntactic root, so inside `fn outer(a: byref Rec, b: byref Rec)`,
+   the call `inner(inout a.x, inout b.x)` is rejected: `a` and `b` may
+   denote the same caller record. Two projections of one storage value
+   pass as `inout` only if their ranges are known disjoint. Unprovable
+   overlap is a compile error naming both arguments and the origin.
+
+9. **Intra-callee may-alias.** Within a callee, distinct `byref`
+   parameters whose *types* could legally overlap at some call site
+   (rule 6) are conservatively treated as potentially overlapping: same
+   static type, or two admissible `AnyBitPattern` physical types (since
+   some caller may pass overlapping storage projections). The callee
+   cannot see argument provenance and must assume any legal call. A view derived
+   from one conflicts with a mutation through another while the view is
+   live:
+
+   ```
+   fn f(a: byref i32, b: byref i32) -> &i32:
+       let r = &a
+       b = 42        // ERROR: may mutate r's origin
+       r
+   ```
+
+   This keeps §21's view-liveness analysis and the backend's alias
+   contract in agreement; a checker that assumed disjointness would be
+   unsound at exactly the call sites rule 5 permits.
+
+10. **Semantic contract only.** The `byref` rule that writes are
+    immediately observable through every overlapping place is semantic.
+    Reload-after-store is one conforming lowering; the language does not
+    mandate it, and no LLVM attribute is part of the contract.
+
+11. **`byref` type restriction (v1).** `byref` is restricted to
+    `BitwiseCopyable` types: storage values, storage projections, `Copy`
+    scalars, and std physical field types. Types with `Drop` or owned
+    heap contents may not be passed `byref` until aliased-ownership
+    invariants are separately ruled. `inout` has no such restriction.
+
+12. **Escape and returned-view provenance.** The mutable place
+    capability of either mode cannot be captured by an escaping closure,
+    stored, or returned. Read-only ephemeral views derived from the
+    parameter follow §3/§21, and a view returned from a caller-place
+    parameter acquires the origin of the *actual argument* at the call
+    site:
+
+    ```
+    fn balance(r: inout Rec) -> &i32:
+        &r.balance
+    let p = balance(inout rec)
+    rec.balance = 1        // ERROR while p is live
+    ```
+
+    For `byref`, escape provenance stays parameter-specific: `return &a`
+    originates from `a`'s argument, not from every compatible `byref`
+    parameter. The may-alias class (rule 9) governs intra-callee
+    conflict checking only. Capture by
+    a proven non-escaping closure is not unsound; *v1 rejects it for
+    implementation simplicity*, and that restriction is explicitly not
+    fundamental.
+
+13. **First-class callables (v1).** A function with any `inout` or
+    `byref` parameter cannot be taken as a first-class value, mirroring
+    the existing restriction on mutating methods. A later feature may
+    add `fn(inout T) -> R` / `fn(byref T) -> R` as callable types with
+    the mode part of identity; a mode can never be erased to `fn(T)`.
+
+14. **Suspension (v1).** `inout` and `byref` parameters are prohibited on
+    functions that may suspend (`async fn`, `gen fn`, and any function
+    the `may_suspend` analysis marks). A caller-place capability
+    surviving a suspension point is a semantic question deferred to a
+    later feature.
+
+15. **Receivers unchanged.** `mut self` is definitionally an `inout`
+    receiver. Existing receiver rules (D12/D21) are unaffected.
+
+16. **Declaration contexts.** Where caller-place modes may appear:
+
+    | Context | v1 |
+    |---|---|
+    | free functions | yes |
+    | inherent method parameters (non-receiver) | yes |
+    | `mut self` receiver | already equivalent to `inout` |
+    | `extern fn`, `c_import`, any foreign-ABI declaration | **no** — the modes carry With-specific promises (caller ownership, non-escape, reservation, alias contract) a foreign callee cannot be assumed to keep; foreign mutation stays on the C-pointer surface, and a safe With wrapper adds `inout`/`byref` where the contract can be established |
+    | closure parameters | no — the callable would need a caller-place function type (rule 13) |
+    | explicit `fn(...)` type syntax | no (rule 13) |
+    | trait method parameters | **no in v1** — supporting them requires `ParamMode` through trait metadata, vtable function types, indirect calls, and interface matching; deferred as a unit |
+
+17. **No new overloading.** Parameter mode participates in signature
+    identity and candidate matching but does not by itself introduce
+    same-name overloading where the language does not already permit
+    it. Two declarations that differ only in `T` versus `inout T` are
+    rejected wherever two declarations differing only in `T` versus `U`
+    would be.
+
+### B.5 ABI
+
+Both modes lower through the existing indirect-place path, which gains an
+alias contract:
+
+```
+PassMode::IndirectPlace { aliasing: Exclusive | MayAlias }
+
+mut self / inout            →  IndirectPlace + Exclusive
+byref                       →  IndirectPlace + MayAlias
+existing read `self` (non-move, by-place)  →  IndirectPlace + MayAlias
+```
+
+The alias contract derives from the *access mode*, not from the pass
+mode: `IndirectPlace` only says "pointer to the caller's place." Today's
+compiler passes non-`move` read receivers by place as well; those carry
+no exclusivity promise and must not acquire one when the field is
+introduced. (A future `SharedRead` contract may distinguish them from
+`byref`; v1 uses `MayAlias` for both.)
+
+The language promises exclusivity for `Exclusive` places; the backend may
+exploit that with whatever optimization metadata is sound for the target
+and lowering. Note that LLVM parameter `noalias` is *stronger* than
+With's exclusivity: it forbids any access to the pointee during the call
+through unrelated provenance, including a global the callee names
+directly. Exclusivity as specified here does not by itself exclude
+`fn f(a: inout Account): global_account.x = 1` called as
+`f(inout global_account)`, so the backend must either prove the stronger
+contract or omit the attribute. `MayAlias` places carry no disjointness
+assumption and never receive it. This is
+an ABI descriptor change (`docs/with-abi.md`, `WITH_ABI_VERSION` bump).
+
+### B.6 What it looks like to library authors
+
+- APIs that today take `mut self` and return nothing can offer a free
+  function form: `fn swap(a: inout T, b: inout T)`.
+- Serialization and record libraries take `byref` storage values so a
+  caller can pass overlapping projections without the library needing to
+  know.
+- Nothing about `inout` leaks into type signatures beyond the mode word;
+  there is no `&mut` type to thread through generics.
+
+### B.7 What it looks like to compiler maintainers
+
+- `ReceiverMode` (`Sema.w`) gains no variants; a parallel `ParamMode`
+  (`Value | Inout | Byref`) is added to parameters. Mode participates in
+  signature identity and mangling.
+- The per-argument ABI descriptor (`FnAbi.w`) gains an alias contract
+  derived from access mode; `PM_INDIRECT_PLACE` itself remains purely
+  the transport mode and implies nothing about aliasing.
+- `apply_noalias_param_attrs` (`Codegen.w`) must skip `MayAlias`
+  parameters.
+- The borrow checker gains: a "reserved place" liveness state between
+  designator evaluation and invocation; range-overlap queries on storage
+  origins; a per-function may-alias class for compatible `byref`
+  parameters.
+- `MirSuspendCheck.w` gains a rule: caller-place parameters on a
+  may-suspend body are an error.
+
+### B.8 Diagnostics contract
+
+- Missing or extraneous call-site `inout`/`byref`, with the parameter's
+  declared mode shown.
+- Consumption of an `inout`/`byref` parameter, suggesting `.clone()` or
+  assignment-replacement as applicable.
+- Overlapping `inout` with any other live access; overlapping `byref`
+  with a non-`byref`; heterogeneous `byref` overlap outside a storage
+  origin. Each names both accesses and the origin.
+- Reservation violation: which later argument may invalidate which
+  reserved place, and why (consume / relocate / destroy).
+- Intra-callee `byref` conflict: the live view, its source parameter,
+  and the mutating parameter.
+- `byref` on a non-`BitwiseCopyable` type.
+- Caller-place parameter on a may-suspend function; taking a caller-place
+  function as a value; capturing a caller-place in a closure.
+- Caller-place mode in a disallowed declaration context (`extern fn`,
+  `c_import`, closure parameter, `fn(...)` type, trait method), naming
+  the context.
+- `implicit` combined with a caller-place mode; a default value on a
+  caller-place parameter; omission of a caller-place argument.
+- Two same-name declarations differing only in parameter mode, where
+  the language does not permit signature-only overloading.
+
+### B.9 Non-goals (v1)
+
+- Place-typed callable values.
+- Caller places across suspension.
+- `byref` for `Drop`/heap-owning types.
+- Non-escaping closure capture of caller places.
+- Inferred modes of any kind; this feature is explicit by design.
+
+---
+
+## Rationale summary
+
+Both parts follow one principle: **represent the physical thing first,
+and let abstraction be earned by proof.** A storage type is bytes with
+names; interpretation is a library operation. A caller place is the
+caller's storage; consumption is a different capability. `byref` records
+that aliasing has not been disproven; `inout` records that it has. The
+migrator, the borrow checker, and the backend all read the same facts.
+
+Ada gets close to Part A with representation clauses but treats the
+record as fields; C/C++ get the bytes with unions and give up safety; C#
+needs explicit layout plus `unsafe`. No mainstream language has Part B's
+two-mode split with the mode in the signature; Swift's `inout` is
+exclusive-only, Fortran's aliasing is undefined, and C's `restrict` is
+unchecked.


### PR DESCRIPTION
Records the selected stdlib engines, adds the storage-type/caller-place and Perl-compatible regex documents, and adds the planning documents under `docs/plans/`.

Preserves the newer main integration update in the handoff alongside the detailed September 9 investigation, marked as historical. Changes are confined to `docs/`; the local deletions under `plans/` are excluded.

Tests and CI skipped at Eric's explicit request for this docs-only change.
